### PR TITLE
fix(pbs): fix Traefik external service routing for Proxmox Backup Server

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -45,7 +45,11 @@ export interface DockgeLxcArgs {
 export interface ExternalServiceOpts {
   name: Input<string>;
   hostname: Input<string>;
+  /** Backend hostname used in the Traefik service URL. Defaults to `hostname` when omitted. */
+  backendHostname?: Input<string>;
   port: Input<number>;
+  /** URL scheme for the backend. Defaults to `http`. Use `https` for services with TLS backends (e.g. PBS). */
+  scheme?: string;
   middleware?: string[];
   certResolver?: string;
 }
@@ -430,6 +434,8 @@ export class DockgeLxc extends ComponentResource {
   public registerExternalService(opts: ExternalServiceOpts, dependsOn?: Resource[]) {
     return output(opts).apply((opts) => {
       const middlewareYaml = opts.middleware?.length ? `      middlewares:\n${opts.middleware.map((m) => `        - ${m}`).join("\n")}\n` : "";
+      const scheme = opts.scheme ?? "http";
+      const backendHost = opts.backendHostname ?? opts.hostname;
 
       const content = interpolate`http:
   routers:
@@ -447,11 +453,7 @@ ${middlewareYaml}  services:
     dynamic-${opts.name}:
       loadBalancer:
         servers:
-          - url: http://${opts.hostname}:${opts.port}
-    dynamic-${opts.name}-tailscale:
-      loadBalancer:
-        servers:
-          - url: http://${this.args.host.tailscaleHostname}:${opts.port}
+          - url: ${scheme}://${backendHost}:${opts.port}
 `;
 
       const dns = new StandardDns(`${opts.name}-service`, { hostname: opts.hostname, ipAddress: this.tailscaleIpAddress, type: "A" }, this.args.globals, {

--- a/components/ProxmoxBackupServerLxc.ts
+++ b/components/ProxmoxBackupServerLxc.ts
@@ -205,7 +205,7 @@ echo "PBS post-install complete"`;
     this.resources.push(deviceInfo.apply((z) => z.resource));
 
     const externalHostname = externalUrl.apply((u) => new URL(u).hostname);
-    const { dns } = args.dockge.registerExternalService({ name, hostname: externalHostname, port: 8007 }, []);
+    const { dns } = args.dockge.registerExternalService({ name, hostname: externalHostname, backendHostname: this.tailscaleHostname, port: 8007, scheme: "https" }, []);
     this.dns = dns;
 
     const oidc = all([cluster])


### PR DESCRIPTION
## Problem

`https://pbs.celestia.driscoll.tech/` returns 502 Bad Gateway because `registerExternalService` was generating an incorrect Traefik backend URL for PBS.

**Root cause 1 — Wrong backend host:**  
`opts.hostname` was `pbs.celestia.driscoll.tech` — the public DNS name that resolves to **Dockge's Tailscale IP** (not PBS's). Traefik was looping back to itself.

**Root cause 2 — Wrong scheme:**  
The backend URL used `http://` but PBS only speaks HTTPS on port 8007.

**Root cause 3 — Dead code:**  
A second `dynamic-{name}-tailscale` service entry was generated but never referenced by any router.

## Fix

- Added `backendHostname?: Input<string>` to `ExternalServiceOpts` — allows callers to override the backend host while keeping the public-facing `hostname` for DNS/routing rules.
- Added `scheme?: string` (defaults to `"http"`) — allows callers to specify `"https"` for TLS backends.
- Removed the unreferenced duplicate `dynamic-{name}-tailscale` service definition.
- Updated `ProxmoxBackupServerLxc.ts` to pass `backendHostname: this.tailscaleHostname` and `scheme: "https"`, so Traefik proxies to `https://pbs-celestia.<tailnet>:8007`.

## Deployment

After merging, run `pulumi up` in `stacks/home`. This will:
1. Create `/opt/stacks/traefik/dynamic/` on the Dockge LXC (was missing)
2. Write `celestia-pbs.yaml` with the correct backend: `https://pbs-celestia.<tailnet>:8007`

Note: `serversTransport.insecureSkipVerify: true` is already set globally in the Traefik static config, so PBS's self-signed cert is accepted.