### PR TITLE
feat(backups): add Backrest plan for /opt/stacks-data

### DIFF
--- a/stacks/backups/index.ts
+++ b/stacks/backups/index.ts
@@ -43,6 +43,12 @@ backupPlanManager.createBackrestPlan("pgdump", {
   repository: "pgdump",
 });
 
+backupPlanManager.createBackrestPlan("stacks-data", {
+  title: "Docker Stacks Data",
+  path: "/opt/stacks-data/",
+  repository: "stacks-data",
+});
+
 backupPlanManager.createMinioBucketBackupJob({
   title: "Home Operations",
   bucket: "home-operations",


### PR DESCRIPTION
## Summary

Adds a Backrest backup plan for `/opt/stacks-data/` on the Dockge LXC.

### What this does

- Registers a new Backrest **repository** (`stacks-data`) with URI `/backup/stacks-data/` on the source Dockge LXC
- Registers a new Backrest **plan** that backs up `/opt/stacks-data/` daily (max once per day, CLOCK_LAST_RUN_TIME)
- Creates a **Backup job** copying `/opt/stacks-data/` → `/data/backup/stacks-data/` (PBS local) at 15:00 daily
- Creates a **Replicate job** copying from source PBS over SFTP → destination PBS at 03:00 daily
- Default retention: 7 daily, 4 weekly, 3 monthly, keep last 10

### Retention / schedule

Uses the standard defaults from `createBackrestPlan` — no custom overrides needed for stacks data.