### PR TITLE
fix: vaultRegex hyphen support + Alpha Site 502 fixes

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -504,7 +504,7 @@ export class DockgeLxc extends ComponentResource {
   public deployStacks(args: { dependsOn: Input<Resource[]> }): Output<Command[]> {
     const op = new OPClient();
     const authentikToken = output(op.getItemByTitle("Authentik Token"));
-    const vaultRegex = /op\:\/\/Eris\/([\w| ]+)\/([\w| ]+)/g;
+    const vaultRegex = /op\:\/\/Eris\/([\w| -]+)\/([\w| -]+)/g;
 
     // update hostname on machine
     const createDockerNetwork = new remote.Command(

--- a/docker/alpha-site/uptime/compose.yaml
+++ b/docker/alpha-site/uptime/compose.yaml
@@ -20,15 +20,13 @@ services:
       traefik.http.routers.uptime-tailscale.entrypoints: tailscale
       traefik.http.routers.uptime-tailscale.service: uptime
 
-      traefik.http.services.uptime.loadbalancer.server.port: 9595
+      traefik.http.services.uptime.loadbalancer.server.port: 8080
     volumes:
       - /opt/stacks-data/${APP}/config/:/config/
       - /opt/stacks-data/${APP}/data/:/data/
       - /opt/stacks/config/default.yaml:/config/default.yaml
     networks:
       - dockge_default
-    ports:
-      - 9595:9595
 x-dockge:
   urls:
     - https://uptime.${searchDomain}

--- a/docker/alpha-site/zot/compose.yaml
+++ b/docker/alpha-site/zot/compose.yaml
@@ -24,8 +24,7 @@ services:
     environment:
       TZ: ${TIMEZONE}
     volumes:
-      - ./config:/etc/zot/config
-      # - ./config/credentials.json:/etc/credentials/credentials.json
+      - ./config/config.json:/etc/zot/config.json
       - ./data:/var/lib/registry
     networks:
       - dockge_default


### PR DESCRIPTION
## Summary

Three bug fixes from connectivity troubleshooting session.

### 1. `components/DockgeLxc.ts` — vaultRegex hyphen support
The `vaultRegex` character class `[\w| ]+` did not match hyphens, so `op://` refs with hyphenated item names (e.g. `celestia-technitium-oidc-credentials`) passed through literally → crash loops.
**Fix:** `[\w| ]+` → `[\w| -]+`

### 2. `docker/alpha-site/uptime/compose.yaml` — Gatus port mismatch
Traefik label said port `9595` but Gatus listens on **8080**. Fixed label and removed broken port mapping.

### 3. `docker/alpha-site/zot/compose.yaml` — Zot config not loaded
Volume mounted `./config` (directory) to `/etc/zot/config` but Zot reads `/etc/zot/config.json` (file). Zot fell back to defaults (port 5000) instead of configured port 6785.
**Fix:** Mount file directly: `./config/config.json:/etc/zot/config.json`

## After merging
Run `pulumi up` on the **home** stack to push resolved technitium `.env` files and Skystar `.env-token`.