### PR TITLE
fix: run APP/STACK_NAME substitutions before vaultRegex resolver

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -504,7 +504,7 @@ export class DockgeLxc extends ComponentResource {
   public deployStacks(args: { dependsOn: Input<Resource[]> }): Output<Command[]> {
     const op = new OPClient();
     const authentikToken = output(op.getItemByTitle("Authentik Token"));
-    const vaultRegex = /op\:\/\/Eris\/([\w| ]+)\/([\w| ]+)/g;
+    const vaultRegex = /op\:\/\/Eris\/([\w| -]+)\/([\w| -]+)/g;
 
     // update hostname on machine
     const createDockerNetwork = new remote.Command(

--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -680,7 +680,11 @@ export class DockgeLxc extends ComponentResource {
     const copyFiles = [];
     const cluster = this.cluster;
     const tailscaleDomain = this.args.globals.tailscaleDomain;
-    replacements = [...replacements, replaceVariable(/\$\{STACK_NAME\}/g, stackName), replaceVariable(/\$\{APP\}/g, stackName)];
+    // Prepend stack-specific substitutions so they run BEFORE the vaultRegex resolver.
+    // vaultRegex is the last item in the inherited replacements array; if APP/STACK_NAME
+    // were appended after it, op:// paths like "op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/..."
+    // would still contain "${APP}" when the resolver runs and the regex would fail to match.
+    replacements = [replaceVariable(/\$\{STACK_NAME\}/g, stackName), replaceVariable(/\$\{APP\}/g, stackName), ...replacements];
 
     let hasCompose = false;
     let hasInit = false;

--- a/docker/alpha-site/uptime/compose.yaml
+++ b/docker/alpha-site/uptime/compose.yaml
@@ -20,15 +20,13 @@ services:
       traefik.http.routers.uptime-tailscale.entrypoints: tailscale
       traefik.http.routers.uptime-tailscale.service: uptime
 
-      traefik.http.services.uptime.loadbalancer.server.port: 9595
+      traefik.http.services.uptime.loadbalancer.server.port: 8080
     volumes:
       - /opt/stacks-data/${APP}/config/:/config/
       - /opt/stacks-data/${APP}/data/:/data/
       - /opt/stacks/config/default.yaml:/config/default.yaml
     networks:
       - dockge_default
-    ports:
-      - 9595:9595
 x-dockge:
   urls:
     - https://uptime.${searchDomain}

--- a/docker/alpha-site/zot/compose.yaml
+++ b/docker/alpha-site/zot/compose.yaml
@@ -24,8 +24,7 @@ services:
     environment:
       TZ: ${TIMEZONE}
     volumes:
-      - ./config:/etc/zot/config
-      # - ./config/credentials.json:/etc/credentials/credentials.json
+      - ./config/config.json:/etc/zot/config.json
       - ./data:/var/lib/registry
     networks:
       - dockge_default


### PR DESCRIPTION
## Problem

`op://` paths in `.env` templates can reference `${APP}` and `${STACK_NAME}` variables, e.g.:

```
DNS_SERVER_SSO_AUTHORITY="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/issuer"
```

Previously, these stack-local variables were **appended** to the end of the `replacements` array in `createStack`, placing them **after** the `vaultRegex` resolver. This meant the resolver received the string with `${APP}` still unexpanded:

```
op://Eris/celestia-${APP}-oidc-credentials/issuer
```

Since `$`, `{`, and `}` are not in the regex character class `[\w| -]+`, the pattern never matched and the literal `op://` string was passed through unchanged to the container — causing Technitium to crash with:

```
System.ArgumentException: The SSO Authority URL scheme can be 'http' or 'https' only.
```

## Fix

Prepend `APP`/`STACK_NAME` substitutions to the **front** of the replacements array so they run before all other replacements, including the `vaultRegex` resolver. By the time the resolver runs, `${APP}` has already been replaced with the stack name (e.g. `technitium`).

## Root cause chain

1. `vaultRegex` hyphen bug (fixed in #322) — `[\w| ]+` didn't match hyphens in item names
2. **This PR** — `${APP}` not substituted before `vaultRegex` runs, so `op://` paths containing `${APP}` were never resolved

Both bugs needed to be fixed for Technitium SSO to work.