### PR TITLE
fix(DockgeLxc): correct registerExternalService routing bugs

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -397,7 +397,7 @@ export class DockgeLxc extends ComponentResource {
       {
         name: interpolate`pve-${cluster.key}`,
         hostname: interpolate`pve.${cluster.rootDomain}`,
-        backend: interpolate`https://${args.host.internalIpAddress}:8006`,
+        backend: interpolate`https://${args.host.tailscaleHostname}:8006`,
       },
       [],
     );

--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -397,7 +397,7 @@ export class DockgeLxc extends ComponentResource {
       {
         name: interpolate`pve-${cluster.key}`,
         hostname: interpolate`pve.${cluster.rootDomain}`,
-        backend: interpolate`https://pve.${cluster.rootDomain}:8006`,
+        backend: interpolate`https://${args.host.internalIpAddress}:8006`,
       },
       [],
     );
@@ -432,11 +432,11 @@ export class DockgeLxc extends ComponentResource {
   }
 
   public registerExternalService(opts: ExternalServiceOpts, dependsOn?: Resource[]) {
-    return output(opts).apply((opts) => {
+    return all([output(opts), this.args.globals.tailscaleDomain]).apply(([opts, tailscaleDomain]) => {
       const content = output({
         http: {
           routers: {
-            [`host-${opts.name}:`]: {
+            [`host-${opts.name}`]: {
               rule: `Host(\`${opts.hostname}\`)`,
               entryPoints: ["websecure"],
               service: `host-${opts.name}`,
@@ -445,15 +445,15 @@ export class DockgeLxc extends ComponentResource {
                 certResolver: opts.certResolver ?? "le",
               },
             },
-            [`host-${opts.name}-tailscale:`]: {
-              rule: `Host(\`${opts.name}.${this.args.globals.tailscaleDomain}\`)`,
+            [`host-${opts.name}-tailscale`]: {
+              rule: `Host(\`${opts.name}.${tailscaleDomain}\`)`,
               entryPoints: ["tailscale"],
               service: `host-${opts.name}`,
               ...(opts.middleware?.length ? { middlewares: opts.middleware.map((m) => `- ${m}`).join("\n") } : {}),
             },
           },
           services: {
-            [`host-${opts.name}:`]: {
+            [`host-${opts.name}`]: {
               loadBalancer: {
                 servers: [{ url: opts.backend }],
               },

--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -432,7 +432,7 @@ export class DockgeLxc extends ComponentResource {
   }
 
   public registerExternalService(opts: ExternalServiceOpts, dependsOn?: Resource[]) {
-    return all([output(opts), this.args.globals.tailscaleDomain]).apply(([opts, tailscaleDomain]) => {
+    return output(opts).apply((opts) => {
       const content = output({
         http: {
           routers: {
@@ -446,7 +446,7 @@ export class DockgeLxc extends ComponentResource {
               },
             },
             [`host-${opts.name}-tailscale`]: {
-              rule: `Host(\`${opts.name}.${tailscaleDomain}\`)`,
+              rule: interpolate`Host(\`${opts.name}.${this.args.globals.tailscaleDomain}\`)`,
               entryPoints: ["tailscale"],
               service: `host-${opts.name}`,
               ...(opts.middleware?.length ? { middlewares: opts.middleware.map((m) => `- ${m}`).join("\n") } : {}),


### PR DESCRIPTION
## Problem

Three bugs in `registerExternalService` caused Traefik dynamic-config routes for external services (currently only PVE) to silently fail with **HTTP 404**.

### Bug 1 — Circular backend URL

`pve.as.driscoll.tech` resolves to the Dockge/Traefik LXC IP (`10.10.10.9`), not the Proxmox VE host (`10.10.10.200`). Traefik was forwarding to itself on port 8006 (which isn't listening).

```ts
// Before: loops back to Traefik LXC
backend: interpolate`https://pve.${cluster.rootDomain}:8006`

// After: points directly at the Proxmox host
backend: interpolate`https://${args.host.internalIpAddress}:8006`
```

### Bug 2 — Trailing colon in YAML keys → router/service name mismatch

Router keys were `host-<name>:` (with trailing colon) but the router's `service:` field referenced `host-<name>` (no colon). Traefik couldn't resolve the service → 404 on every request.

```yaml
# Before: key has colon, reference does not — mismatch
routers:
  "host-pve-alpha-site:":
    service: host-pve-alpha-site   # no colon → Traefik can't find it
services:
  "host-pve-alpha-site:":

# After: consistent names, no trailing colon
routers:
  "host-pve-alpha-site":
    service: host-pve-alpha-site
services:
  "host-pve-alpha-site":
```

### Bug 3 — `Output<string>` in template literal

`this.args.globals.tailscaleDomain` is `Output<string>`. Using it directly in a plain template literal inside `.apply()` calls `.toString()`, emitting Pulumi's warning message verbatim into the generated YAML — breaking the Tailscale router rule entirely.

Fix: `all([output(opts), this.args.globals.tailscaleDomain]).apply(([opts, tailscaleDomain]) => ...)` resolves both values before the YAML is built.

## Observed state on dockge-as before this fix

```yaml
# /opt/stacks-data/traefik/dynamic/pve-alpha-site.yaml
http:
  routers:
    "host-pve-alpha-site:":
      service: host-pve-alpha-site          # mismatch → 404
    "host-pve-alpha-site-tailscale:":
      rule: >-
        Host(`pve-alpha-site.Calling [toString] on an [Output<T>] ...`)  # broken
  services:
    "host-pve-alpha-site:":
      loadBalancer:
        servers:
          - url: https://pve.as.driscoll.tech:8006  # loops back to Traefik
```

## After fix

`pulumi up` on the `home` stack will regenerate the dynamic config with correct names, a valid Tailscale rule, and the backend pointing directly to the Proxmox host IP. `https://pve.as.driscoll.tech/` will proxy through to the PVE web UI.