### PR TITLE
feat: add dual OIDC auth (Authentik + TSIDP) to PBS and PVE

### DIFF
--- a/components/ProxmoxBackupServerLxc.ts
+++ b/components/ProxmoxBackupServerLxc.ts
@@ -3,6 +3,9 @@ import { getTailscaleIp, installTailscaleLxc } from "@components/tailscale.ts";
 import { OnePasswordItem, TypeEnum } from "@dynamic/1password/OnePasswordItem.ts";
 import { remote } from "@pulumi/command";
 import { all, asset, ComponentResource, ComponentResourceOptions, Input, interpolate, mergeOptions, Output, output, Resource } from "@pulumi/pulumi";
+import * as pulumi from "@pulumi/pulumi";
+import * as purrl from "@pulumiverse/purrl";
+import * as random from "@pulumi/random";
 import { TailscaleIp } from "@openapi/tailscale-grants.js";
 import { ClusterDefinition, GlobalResources } from "./globals.ts";
 import { ProxmoxHost } from "./ProxmoxHost.ts";
@@ -232,6 +235,7 @@ echo "PBS post-install complete"`;
                 clientType: "confidential",
                 allowedRedirectUris: [{ matching_mode: "strict", url: `https://pbs.${c.rootDomain}/oidccode` }],
                 includeClaimsInIdToken: true,
+                propertyMappings: ["proxmox_groups", "openid", "email", "profile"],
               },
             },
             gatus: [
@@ -262,12 +266,16 @@ if proxmox-backup-manager openid list 2>/dev/null | grep -q "\\"$REALM_ID\\""; t
   proxmox-backup-manager openid update "$REALM_ID" \\
     --issuer-url "$ISSUER_URL" \\
     --client-id "$CLIENT_ID" \\
-    --client-secret "$CLIENT_SECRET"
+    --client-secret "$CLIENT_SECRET" \\
+    --username-claim email \\
+    --scopes "openid,email,profile"
 else
   proxmox-backup-manager openid register "$REALM_ID" \\
     --issuer-url "$ISSUER_URL" \\
     --client-id "$CLIENT_ID" \\
     --client-secret "$CLIENT_SECRET" \\
+    --username-claim email \\
+    --scopes "openid,email,profile" \\
     --autocreate-users true
 fi
 echo "PBS OIDC configured for realm: $REALM_ID"
@@ -278,6 +286,90 @@ echo "PBS OIDC configured for realm: $REALM_ID"
         connection: args.host.remoteConnection,
         create: all([output(args.vmId), oidcScript]).apply(([vmId, script]) => `pct exec ${vmId} -- bash << '__PBS_OIDC__'\n${script.trim()}\n__PBS_OIDC__`),
         triggers: [oidc.clientId, oidc.clientSecret, oidc.config.issuerUrl],
+      },
+      mergeOptions(cro, { dependsOn: [createPbsLxc, ...(args.dependsOn ?? [])] }),
+    );
+
+    // TSIDP (Tailscale Identity Provider) as a backup OIDC realm for PBS
+    const tsidpClientId = pulumi.interpolate`pbs-${args.globals.tailscaleDomain}`;
+    const tsidpClientSecret = new random.RandomPassword(
+      `${name}-tsidp-client-secret`,
+      { length: 32, special: false },
+      cro,
+    );
+    const pbsRedirectUri = cluster.apply((c) => `https://pbs.${c.rootDomain}/oidccode`);
+    const tsidpDcr = new purrl.Purrl(
+      `${name}-tsidp-dcr`,
+      {
+        name: `PBS TSIDP Dynamic Client Registration`,
+        responseCodes: ["201"],
+        url: pulumi.interpolate`https://idp.${args.globals.tailscaleDomain}/register`,
+        method: "POST",
+        body: pulumi.jsonStringify({
+          client_name: pulumi.interpolate`Proxmox Backup Server (${cluster.apply((c) => c.title)})`,
+          client_id: tsidpClientId,
+          client_secret: tsidpClientSecret.result,
+          redirect_uris: [pbsRedirectUri],
+        }),
+        headers: { "Content-Type": "application/json" },
+      },
+      cro,
+    );
+
+    const tsidpRealm = "tsidp";
+    const tsidpScript = pulumi.interpolate`
+REALM_ID="${tsidpRealm}"
+ISSUER_URL="https://idp.${args.globals.tailscaleDomain}"
+CLIENT_ID="${tsidpClientId}"
+CLIENT_SECRET="${tsidpClientSecret.result}"
+
+if proxmox-backup-manager openid list 2>/dev/null | grep -q "\\"$REALM_ID\\""; then
+  proxmox-backup-manager openid update "$REALM_ID" \\
+    --issuer-url "$ISSUER_URL" \\
+    --client-id "$CLIENT_ID" \\
+    --client-secret "$CLIENT_SECRET" \\
+    --username-claim email \\
+    --scopes "openid,email,profile"
+else
+  proxmox-backup-manager openid register "$REALM_ID" \\
+    --issuer-url "$ISSUER_URL" \\
+    --client-id "$CLIENT_ID" \\
+    --client-secret "$CLIENT_SECRET" \\
+    --username-claim email \\
+    --scopes "openid,email,profile" \\
+    --autocreate-users true
+fi
+echo "PBS TSIDP realm configured"
+`;
+    new remote.Command(
+      `${name}-configure-tsidp`,
+      {
+        connection: args.host.remoteConnection,
+        create: all([output(args.vmId), tsidpScript]).apply(([vmId, script]) => `pct exec ${vmId} -- bash << '__PBS_TSIDP__'\n${script.trim()}\n__PBS_TSIDP__`),
+        triggers: [tsidpClientSecret.result],
+      },
+      mergeOptions(cro, { dependsOn: [createPbsLxc, tsidpDcr, ...(args.dependsOn ?? [])] }),
+    );
+
+    // Pre-create PBS groups with ACLs.
+    // PBS does not support groups-claim in OIDC, so groups must be configured manually.
+    // New OIDC users start with no permissions until an admin adds them to a group.
+    const groupsScript = all([output(args.vmId)]).apply(([vmId]) => `pct exec ${vmId} -- bash << '__PBS_GROUPS__'
+# Create groups (idempotent)
+proxmox-backup-manager group create admins --comment "Administrators" 2>/dev/null || true
+proxmox-backup-manager group create users --comment "Read-only users" 2>/dev/null || true
+
+# Assign ACLs at root path
+proxmox-backup-manager acl update / --group admins --role Admin 2>/dev/null || true
+proxmox-backup-manager acl update / --group users  --role Audit 2>/dev/null || true
+echo "PBS groups and ACLs configured"
+__PBS_GROUPS__`);
+    new remote.Command(
+      `${name}-configure-groups`,
+      {
+        connection: args.host.remoteConnection,
+        create: groupsScript,
+        triggers: [],
       },
       mergeOptions(cro, { dependsOn: [createPbsLxc, ...(args.dependsOn ?? [])] }),
     );

--- a/components/ProxmoxBackupServerLxc.ts
+++ b/components/ProxmoxBackupServerLxc.ts
@@ -13,6 +13,8 @@ import { StandardDns } from "./StandardDns.ts";
 import { getContainerHostnames } from "./helpers.ts";
 import { CommunityScriptLxcVars, runCommunityScriptLxc } from "./lxc.ts";
 import { AuthentikOutputs } from "@components/authentik.ts";
+import { getUsersOutput } from "@pulumi/authentik";
+import { getUsersOutput as getTailscaleUsersOutput } from "@pulumi/tailscale";
 import { ApplicationCertificate } from "@components/authentik/application-certificate.ts";
 import { DockgeLxc } from "./DockgeLxc.ts";
 import { Tailscale } from "@components/constants.ts";
@@ -354,7 +356,32 @@ echo "PBS TSIDP realm configured"
     // Pre-create PBS groups with ACLs.
     // PBS does not support groups-claim in OIDC, so groups must be configured manually.
     // New OIDC users start with no permissions until an admin adds them to a group.
-    const groupsScript = all([output(args.vmId)]).apply(([vmId]) => `pct exec ${vmId} -- bash << '__PBS_GROUPS__'
+    // Pre-populate the admins group with current Authentik and Tailscale admin users so
+    // they have access immediately without waiting for a manual group assignment.
+    const authentikAdmins = getUsersOutput({ groupsByNames: ["admins"] }, { parent: this });
+    const tailscaleAdmins = getTailscaleUsersOutput({ role: "admin" }, { provider: args.globals.tailscaleProvider, parent: this });
+    const groupsScript = all([output(args.vmId), authentikAdmins, tailscaleAdmins]).apply(([vmId, authAdmins, tsAdmins]) => {
+      const authentikEntries = authAdmins.users
+        .map(u => {
+          const userId = `${u.email}@authentik`;
+          return [
+            `proxmox-backup-manager user create "${userId}" 2>/dev/null || true`,
+            `proxmox-backup-manager user modify "${userId}" --groups admins 2>/dev/null || true`,
+          ].join("\n");
+        })
+        .join("\n");
+
+      const tsidpEntries = tsAdmins.users
+        .map(u => {
+          const userId = `${u.loginName}@tsidp`;
+          return [
+            `proxmox-backup-manager user create "${userId}" 2>/dev/null || true`,
+            `proxmox-backup-manager user modify "${userId}" --groups admins 2>/dev/null || true`,
+          ].join("\n");
+        })
+        .join("\n");
+
+      return `pct exec ${vmId} -- bash << '__PBS_GROUPS__'
 # Create groups (idempotent)
 proxmox-backup-manager group create admins --comment "Administrators" 2>/dev/null || true
 proxmox-backup-manager group create users --comment "Read-only users" 2>/dev/null || true
@@ -362,8 +389,15 @@ proxmox-backup-manager group create users --comment "Read-only users" 2>/dev/nul
 # Assign ACLs at root path
 proxmox-backup-manager acl update / --group admins --role Admin 2>/dev/null || true
 proxmox-backup-manager acl update / --group users  --role Audit 2>/dev/null || true
-echo "PBS groups and ACLs configured"
-__PBS_GROUPS__`);
+
+# Pre-populate admins group with current Authentik admin users
+${authentikEntries}
+
+# Pre-populate admins group with current Tailscale admin users
+${tsidpEntries}
+echo "PBS groups, ACLs, and admin users configured"
+__PBS_GROUPS__`;
+    });
     new remote.Command(
       `${name}-configure-groups`,
       {

--- a/components/ProxmoxBackupServerLxc.ts
+++ b/components/ProxmoxBackupServerLxc.ts
@@ -403,7 +403,8 @@ __PBS_GROUPS__`;
       {
         connection: args.host.remoteConnection,
         create: groupsScript,
-        triggers: [],
+        update: groupsScript,
+        triggers: [groupsScript],
       },
       mergeOptions(cro, { dependsOn: [createPbsLxc, ...(args.dependsOn ?? [])] }),
     );

--- a/components/ProxmoxHost.ts
+++ b/components/ProxmoxHost.ts
@@ -2,6 +2,8 @@ import { ComponentResource, ComponentResourceOptions, Input, Output, mergeOption
 import proxmox, { Provider as ProxmoxVEProvider } from "@muhlba91/pulumi-proxmoxve";
 import { remote, types } from "@pulumi/command";
 import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+import * as purrl from "@pulumiverse/purrl";
 import { ClusterDefinition, GlobalResources } from "./globals.ts";
 import { createPeerRelayRule, updateTailscaleProxmox } from "./tailscale.ts";
 import { OPClient } from "./op.ts";
@@ -248,26 +250,129 @@ export class ProxmoxHost extends ComponentResource {
     });
 
     cluster.apply((clusterDefinition) => {
-      // Register Proxmox UIs as Authentik forward-proxy applications.
-      // Traffic is routed through this cluster's Dockge Traefik ingress.
-      return this.applicationManager.createApplication({
+      // Register Proxmox VE as a native Authentik OAuth2 OIDC application.
+      // This replaces the previous forward-proxy registration.
+      const pveRedirectUri = interpolate`https://${this.tailscaleHostname}:8006/`;
+      const oidcApp = this.applicationManager.createApplication({
         metadata: { name: `pve-${clusterDefinition.key}`, namespace: clusterDefinition.key },
         spec: {
           name: "Proxmox VE",
           category: clusterDefinition.title,
           description: `Proxmox Virtual Environment for ${clusterDefinition.title}`,
-          url: `https://${this.tailscaleHostname}:8006/`,
+          url: interpolate`https://${this.tailscaleHostname}:8006/`,
           icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/proxmox.svg",
+          authentik: {
+            oauth2: {
+              clientType: "confidential",
+              allowedRedirectUris: [{ matching_mode: "strict", url: pveRedirectUri }],
+              includeClaimsInIdToken: true,
+              propertyMappings: ["proxmox_groups", "openid", "email", "profile"],
+            },
+          },
           gatus: [
             {
               name: "Proxmox VE",
-              url: `https://${this.tailscaleHostname}:8006/`,
+              url: interpolate`https://${this.tailscaleHostname}:8006/`,
               method: "GET",
               conditions: ["[STATUS] == 200"],
             },
           ],
         },
       });
+
+      // TSIDP (Tailscale Identity Provider) as a backup OIDC realm for PVE
+      const tsidpClientId = interpolate`pve-${clusterDefinition.key}-${args.globals.tailscaleDomain}`;
+      const tsidpClientSecret = new random.RandomPassword(
+        `${name}-pve-tsidp-client-secret`,
+        { length: 32, special: false },
+        { parent: this },
+      );
+      const tsidpDcr = new purrl.Purrl(
+        `${name}-pve-tsidp-dcr`,
+        {
+          name: `PVE TSIDP Dynamic Client Registration`,
+          responseCodes: ["201"],
+          url: interpolate`https://idp.${args.globals.tailscaleDomain}/register`,
+          method: "POST",
+          body: pulumi.jsonStringify({
+            client_name: `Proxmox VE (${clusterDefinition.title})`,
+            client_id: tsidpClientId,
+            client_secret: tsidpClientSecret.result,
+            redirect_uris: [pveRedirectUri],
+          }),
+          headers: { "Content-Type": "application/json" },
+        },
+        { parent: this },
+      );
+
+      // Configure both OIDC realms and groups via pveum (idempotent)
+      const oidcClientId = oidcApp.apply((a) => a.clientId);
+      const oidcClientSecret = oidcApp.apply((a) => a.clientSecret);
+      const oidcIssuerUrl = oidcApp.apply((a) => a.config.issuerUrl);
+      const realmScript = interpolate`
+AUTHENTIK_ISSUER="${oidcIssuerUrl}"
+AUTHENTIK_CLIENT_ID="${oidcClientId}"
+AUTHENTIK_CLIENT_SECRET="${oidcClientSecret}"
+TSIDP_CLIENT_ID="${tsidpClientId}"
+TSIDP_CLIENT_SECRET="${tsidpClientSecret.result}"
+TSIDP_ISSUER="https://idp.${args.globals.tailscaleDomain}"
+
+configure_realm() {
+  local realm="$1"
+  local issuer="$2"
+  local client_id="$3"
+  local client_key="$4"
+  local comment="$5"
+
+  if pveum realm list --output-format json 2>/dev/null | grep -q "\\"$realm\\""; then
+    pveum realm modify "$realm" \\
+      --issuer-url "$issuer" \\
+      --client-id "$client_id" \\
+      --client-key "$client_key" \\
+      --username-claim email \\
+      --scopes "openid email profile" \\
+      --groups-claim groups \\
+      --groups-autocreate 1 \\
+      --groups-overwrite 1
+  else
+    pveum realm add "$realm" --type openid \\
+      --issuer-url "$issuer" \\
+      --client-id "$client_id" \\
+      --client-key "$client_key" \\
+      --username-claim email \\
+      --scopes "openid email profile" \\
+      --groups-claim groups \\
+      --groups-autocreate 1 \\
+      --groups-overwrite 1 \\
+      --autocreate 1 \\
+      --comment "$comment"
+  fi
+}
+
+configure_realm "authentik" "$AUTHENTIK_ISSUER" "$AUTHENTIK_CLIENT_ID" "$AUTHENTIK_CLIENT_SECRET" "Authentik SSO"
+configure_realm "tsidp"     "$TSIDP_ISSUER"     "$TSIDP_CLIENT_ID"     "$TSIDP_CLIENT_SECRET"     "Tailscale TSIDP (backup)"
+
+# Create groups and assign ACLs (idempotent; PVE appends -<realmid> suffix to OIDC group names)
+for grp in admins-authentik users-authentik admins-tsidp users-tsidp; do
+  pveum group add "$grp" 2>/dev/null || true
+done
+
+pveum acl modify / --groups admins-authentik --roles Administrator --propagate 1
+pveum acl modify / --groups users-authentik  --roles PVEAuditor    --propagate 1
+pveum acl modify / --groups admins-tsidp     --roles Administrator --propagate 1
+pveum acl modify / --groups users-tsidp      --roles PVEAuditor    --propagate 1
+
+echo "PVE OIDC realms, groups, and ACLs configured"
+`;
+      new remote.Command(
+        `${name}-configure-pve-oidc`,
+        {
+          connection: this.remoteConnection,
+          create: realmScript,
+          triggers: [oidcClientId, oidcClientSecret, oidcIssuerUrl, tsidpClientSecret.result],
+        },
+        { parent: this, dependsOn: [tsidpDcr] },
+      );
     });
   }
 

--- a/components/authentik/property-mappings.ts
+++ b/components/authentik/property-mappings.ts
@@ -52,6 +52,10 @@ elif ak_is_group_member(request.user, name="media-managers"):
 else:
     return {"ggrequestz_role": "user"}`,
     },
+    proxmox_groups: {
+      description: "Proxmox group membership claim — returns all group names for use with PVE/PBS OIDC group mapping",
+      expression: `return {"groups": [g.name for g in request.user.ak_groups.all()]}`,
+    },
   };
 
   constructor(opts?: pulumi.ComponentResourceOptions) {


### PR DESCRIPTION
## Summary

Configures Proxmox Backup Server (PBS) and Proxmox VE (PVE) with dual OIDC authentication — Authentik as primary, Tailscale TSIDP as backup fallback. Both realms appear in the login dropdown alongside local `pam`/`root` access.

## Changes

### `components/authentik/property-mappings.ts`
- Add `proxmox_groups` OAuth2 scope mapping — returns `{"groups": [g.name for g in request.user.ak_groups.all()]}` — enables PVE's `groups-claim` auto-mapping

### `components/ProxmoxBackupServerLxc.ts`
- Include `proxmox_groups`, `openid`, `email`, `profile` in Authentik OAuth2 app
- Add `--username-claim email` and `--scopes "openid,email,profile"` to realm registration
- Add TSIDP DCR registration via `purrl.Purrl` (`proxmox-backup-manager openid register tsidp`)
- Pre-create `admins`/`users` groups with `Admin`/`Audit` ACLs at `/`
  > **Note:** PBS has no `groups-claim` support — group membership must be assigned manually by an admin after first login

### `components/ProxmoxHost.ts`
- Replace forward-proxy Authentik registration with native confidential OAuth2 OIDC app
- Add TSIDP DCR registration via `purrl.Purrl`
- Configure both `authentik` and `tsidp` realms via `pveum realm add/modify` (idempotent) with `groups-claim`, `groups-autocreate`, `groups-overwrite` enabled
- Pre-create suffixed groups (`admins-authentik`, `users-authentik`, `admins-tsidp`, `users-tsidp`) and assign ACLs at `/`

## Role Mapping

| Authentik/TSIDP group | PBS role | PVE role |
|---|---|---|
| `admins` | `Admin` at `/` | `Administrator` at `/` |
| `users` (default) | `Audit` at `/` | `PVEAuditor` at `/` |

TSIDP groups come from existing `extraClaims` in `stacks/home/tailscale.ts`:
- `autogroup:admin` → `["admins"]`
- `autogroup:member` → `["users"]`