### PR TITLE
fix: correct PBS/PVE OIDC authentication configuration bugs

### DIFF
--- a/components/ProxmoxBackupServerLxc.ts
+++ b/components/ProxmoxBackupServerLxc.ts
@@ -268,17 +268,17 @@ if proxmox-backup-manager openid list 2>/dev/null | grep -q "\\"$REALM_ID\\""; t
   proxmox-backup-manager openid update "$REALM_ID" \\
     --issuer-url "$ISSUER_URL" \\
     --client-id "$CLIENT_ID" \\
-    --client-secret "$CLIENT_SECRET" \\
+    --client-key "$CLIENT_SECRET" \\
     --username-claim email \\
     --scopes "openid,email,profile"
 else
-  proxmox-backup-manager openid register "$REALM_ID" \\
+  proxmox-backup-manager openid create "$REALM_ID" \\
     --issuer-url "$ISSUER_URL" \\
     --client-id "$CLIENT_ID" \\
-    --client-secret "$CLIENT_SECRET" \\
+    --client-key "$CLIENT_SECRET" \\
     --username-claim email \\
     --scopes "openid,email,profile" \\
-    --autocreate-users true
+    --autocreate true
 fi
 echo "PBS OIDC configured for realm: $REALM_ID"
 `;
@@ -329,17 +329,17 @@ if proxmox-backup-manager openid list 2>/dev/null | grep -q "\\"$REALM_ID\\""; t
   proxmox-backup-manager openid update "$REALM_ID" \\
     --issuer-url "$ISSUER_URL" \\
     --client-id "$CLIENT_ID" \\
-    --client-secret "$CLIENT_SECRET" \\
+    --client-key "$CLIENT_SECRET" \\
     --username-claim email \\
     --scopes "openid,email,profile"
 else
-  proxmox-backup-manager openid register "$REALM_ID" \\
+  proxmox-backup-manager openid create "$REALM_ID" \\
     --issuer-url "$ISSUER_URL" \\
     --client-id "$CLIENT_ID" \\
-    --client-secret "$CLIENT_SECRET" \\
+    --client-key "$CLIENT_SECRET" \\
     --username-claim email \\
     --scopes "openid,email,profile" \\
-    --autocreate-users true
+    --autocreate true
 fi
 echo "PBS TSIDP realm configured"
 `;

--- a/components/ProxmoxHost.ts
+++ b/components/ProxmoxHost.ts
@@ -253,6 +253,9 @@ export class ProxmoxHost extends ComponentResource {
       // Register Proxmox VE as a native Authentik OAuth2 OIDC application.
       // This replaces the previous forward-proxy registration.
       const pveRedirectUri = interpolate`https://${this.tailscaleHostname}:8006/`;
+      // PVE sends whatever URL the user accessed it from as redirect_uri (no override possible).
+      // Include both the Tailscale direct URL and the external Traefik-proxied URL.
+      const pveExternalUri = `https://pve.${clusterDefinition.rootDomain}`;
       const oidcApp = this.applicationManager.createApplication({
         metadata: { name: `pve-${clusterDefinition.key}`, namespace: clusterDefinition.key },
         spec: {
@@ -264,7 +267,10 @@ export class ProxmoxHost extends ComponentResource {
           authentik: {
             oauth2: {
               clientType: "confidential",
-              allowedRedirectUris: [{ matching_mode: "strict", url: pveRedirectUri }],
+              allowedRedirectUris: [
+                { matching_mode: "strict", url: pveRedirectUri },
+                { matching_mode: "strict", url: pveExternalUri },
+              ],
               includeClaimsInIdToken: true,
               propertyMappings: ["proxmox_groups", "openid", "email", "profile"],
             },
@@ -298,7 +304,7 @@ export class ProxmoxHost extends ComponentResource {
             client_name: `Proxmox VE (${clusterDefinition.title})`,
             client_id: tsidpClientId,
             client_secret: tsidpClientSecret.result,
-            redirect_uris: [pveRedirectUri],
+            redirect_uris: [pveRedirectUri, pveExternalUri],
           }),
           headers: { "Content-Type": "application/json" },
         },

--- a/stacks/gulf-of-mexico/index.ts
+++ b/stacks/gulf-of-mexico/index.ts
@@ -39,7 +39,7 @@ const host = new ProxmoxHost("luna", {
   proxmox: mainProxmoxCredentials,
   remote: true,
   cluster: cluster,
-  tailscaleArgs: { acceptRoutes: false },
+  tailscaleArgs: { acceptDns: true, acceptRoutes: false },
   tailscaleSubnetRoutes: [Tailscale.subnets.home],
   vmIdRange: vmRange,
 });


### PR DESCRIPTION
## Summary

Diagnosis and fixes for three reported authentication failures on PBS and PVE.

---

## Bug 1: PBS OIDC never configured (affects both celestia-pbs and luna-pbs)

The shell scripts in `ProxmoxBackupServerLxc.ts` used `proxmox-backup-manager openid register` which **does not exist**. The command failed silently (no `set -e`), printed a success message, and left PBS with no OIDC realms at all.

Additional bugs in the same scripts:
- `--client-secret` → correct flag is `--client-key`
- `--autocreate-users true` → correct flag is `--autocreate true`

All three bugs applied to both the Authentik realm script and the TSIDP realm script.

**Fix:** Replace `openid register` with `openid create`, and correct the flag names throughout.

---

## Bug 2: PVE Authentik redirect_uri mismatch

Error: `The request fails due to a missing, invalid, or mismatching redirection URI`

PVE has **no `--redirect-url` override parameter** (confirmed via `pvesh usage`). It sends whatever URL the user used to access the login page as `redirect_uri`. When accessed via the external Traefik hostname (`https://pve.luna.driscoll.tech`), PVE sends that URL — but Authentik only had the internal Tailscale URL with port 8006 as an allowed redirect URI.

**Fix:** Add `https://pve.<rootDomain>` to Authentik's `allowedRedirectUris` alongside the existing Tailscale direct URL. Also add it to the TSIDP DCR `redirect_uris`.

---

## Bug 3: Luna TSIDP "Name or service not known" DNS failure

Error: `OpenID redirect failed. Request failed: ureq request failed - io: failed to lookup address information: Name or service not known`

Luna's `ProxmoxHost` had `tailscaleArgs: { acceptRoutes: false }` with **no `acceptDns`**. Tailscale DNS was disabled on the bare PVE host, so `idp.opossum-yo.ts.net` (a Tailscale MagicDNS name) returned NXDOMAIN.

**Fix:** Add `acceptDns: true` to luna's `ProxmoxHost` tailscaleArgs.

---

## Additional note: luna using celestia's OIDC credentials

Live inspection showed luna's `authentik` and `tsidp` PVE realms are configured with celestia's `client-id`/`issuer-url`. After `pulumi up` on the `gulf-of-mexico` stack with these fixes, the `configure-pve-oidc` remote.Command will be re-triggered (its triggers include `oidcClientId`, `oidcClientSecret`, `oidcIssuerUrl`) and will overwrite luna's realm config with the correct luna-specific Authentik application credentials.

---

## Files changed

| File | Change |
|---|---|
| `components/ProxmoxBackupServerLxc.ts` | `openid register` → `create`, `--client-secret` → `--client-key`, `--autocreate-users` → `--autocreate` |
| `components/ProxmoxHost.ts` | Add external Traefik URL to Authentik `allowedRedirectUris` and TSIDP `redirect_uris` |
| `stacks/gulf-of-mexico/index.ts` | Add `acceptDns: true` to luna ProxmoxHost tailscaleArgs |

## Deployment

After merging, run:
1. `cd stacks/home && pulumi up` — reconfigures celestia PBS with correct `openid create`
2. `cd stacks/gulf-of-mexico && pulumi up` — reconfigures luna PBS, fixes luna PVE realm credentials, enables DNS on luna Tailscale