### PR TITLE
feat(observability): add pve_exporter, Proxmox alerts, OTLP pipeline, and Alloy on Proxmox

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -464,7 +464,7 @@ export class DockgeLxc extends ComponentResource {
     return mp;
   }
 
-  public deployStacks(args: { dependsOn: Input<Resource[]> }): Output<Command[]> {
+  public deployStacks(args: { dependsOn: Input<Resource[]>; variables?: Record<string, Input<string>> }): Output<Command[]> {
     const op = new OPClient();
     const authentikToken = output(op.getItemByTitle("Authentik Token"));
     const vaultRegex = /op\:\/\/Eris\/([\w| -]+)\/([\w| -]+)/g;
@@ -500,6 +500,7 @@ export class DockgeLxc extends ComponentResource {
       replaceVariable(/\$\{CLUSTER_DOMAIN\}/g, this.cluster.rootDomain),
       replaceVariable(/\$\{CLUSTER_AUTHENTIK_DOMAIN\}/g, this.cluster.authentikDomain),
       replaceVariable(/\$UPTIME_API_URL/g, interpolate`http://uptime.${this.args.globals.searchDomain}:9595`),
+      ...Object.entries(args.variables ?? {}).map(([key, value]) => replaceVariable(new RegExp(`\\$\\{${key}\\}`, "g"), value)),
       (input: Input<string>) => {
         return output(input).apply(async (str) => {
           const matches = str.matchAll(vaultRegex);

--- a/components/ProxmoxHost.ts
+++ b/components/ProxmoxHost.ts
@@ -136,31 +136,6 @@ export class ProxmoxHost extends ComponentResource {
         cro,
       );
 
-      // TODO: make work at somepoint
-      // const script = new Purrl(`${name}-alloy-script`, {
-      //   name: "install-alloystack.sh",
-      //   url: "https://raw.githubusercontent.com/IT-BAER/alloy-aio/main/alloy_setup.sh",
-      //   method: "GET",
-      //   responseCodes: ["200"],
-      // });
-
-      // const filePath = writeTempFile(`${name}-alloystack-script`, script.response);
-
-      // const alloyScriptOnServer = new remote.CopyToRemote(`${name}-copy-alloystack-script`, {
-      //   connection: connection,
-      //   remotePath: "/tmp/install-alloystack.sh",
-      //   source: filePath.apply((path) => new asset.FileAsset(path)),
-      // });
-
-      // const installAlloyStack = new remote.Command(
-      //   `${name}-install-alloystack`,
-      //   {
-      //     connection: connection,
-      //     create: interpolate`chmod +x /tmp/install-alloystack.sh && /tmp/install-alloystack.sh --loki-url "http://loki.${args.globals.tailscaleDomain}:3100/loki/api/v1/push" --prometheus-url "http://thanos-receive.${args.globals.tailscaleDomain}:19291/api/v1/receive"`,
-      //     logging: Logging.StdoutAndStderr,
-      //   },
-      //   mergeOptions(cro, { dependsOn: [alloyScriptOnServer] })
-      // );
       updateTailscaleProxmox({
         connection,
         parent: this,
@@ -211,6 +186,88 @@ export class ProxmoxHost extends ComponentResource {
           create: "chmod 755 /etc/cron.weekly/tailscale && /etc/cron.weekly/tailscale",
         },
         mergeOptions(cro, { dependsOn: [tailscaleCron] }),
+      );
+
+      // Install Alloy on this Proxmox host for metrics and log forwarding
+      const installAlloy = new remote.Command(
+        `${name}-install-alloy`,
+        {
+          connection,
+          create: [
+            "mkdir -p /etc/apt/keyrings",
+            "wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor > /etc/apt/keyrings/grafana.gpg",
+            'echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | tee /etc/apt/sources.list.d/grafana.list',
+            "apt-get update -qq",
+            "apt-get install -y alloy",
+          ].join(" && "),
+        },
+        mergeOptions(cro, { dependsOn: [tailscaleSetCert] }),
+      );
+
+      const alloyConfig = interpolate`logging {
+  level  = "warn"
+  format = "logfmt"
+}
+
+// Systemd journal logs → Loki
+loki.source.journal "default" {
+  forward_to = [loki.write.default.receiver]
+  labels = {
+    cluster     = "${cluster.apply((c) => c.key)}",
+    environment = "homelab",
+    region      = "home",
+    hostname    = "${name}",
+    job         = "proxmox/journal",
+  }
+}
+
+loki.write "default" {
+  endpoint {
+    url = "http://loki.${args.globals.tailscaleDomain}:3100/loki/api/v1/push"
+  }
+}
+
+// Host metrics via built-in node_exporter → Thanos
+prometheus.exporter.unix "node" {}
+
+prometheus.scrape "node" {
+  targets    = prometheus.exporter.unix.node.targets
+  forward_to = [prometheus.remote_write.thanos.receiver]
+}
+
+prometheus.remote_write "thanos" {
+  endpoint {
+    url = "http://thanos-receive.${args.globals.tailscaleDomain}:19291/api/v1/receive"
+    queue_config {
+      max_samples_per_send = 10000
+    }
+  }
+  external_labels = {
+    cluster     = "${cluster.apply((c) => c.key)}",
+    environment = "homelab",
+    region      = "home",
+    hostname    = "${name}",
+  }
+}
+`;
+
+      const copyAlloyConfig = new remote.CopyToRemote(
+        `${name}-alloy-config`,
+        {
+          connection,
+          remotePath: "/etc/alloy/config.alloy",
+          source: alloyConfig.apply((c) => new asset.StringAsset(c)),
+        },
+        mergeOptions(cro, { dependsOn: [installAlloy] }),
+      );
+
+      new remote.Command(
+        `${name}-enable-alloy`,
+        {
+          connection,
+          create: "systemctl enable alloy && systemctl restart alloy",
+        },
+        mergeOptions(cro, { dependsOn: [copyAlloyConfig] }),
       );
     }
     const proxmoxInfo = new OnePasswordItem(

--- a/docker/_common/prometheus/compose.yaml
+++ b/docker/_common/prometheus/compose.yaml
@@ -13,6 +13,9 @@ services:
       - /etc/alloy/config.alloy
     environment:
       - DOCKER_HOST=tcp://docker-socket-proxy:2375
+    ports:
+      - "4317:4317"
+      - "4318:4318"
     labels:
       autoheal: true
       traefik.enable: true
@@ -66,6 +69,27 @@ services:
       - node-exporter
       - cadvisor
       - blackbox-exporter
+      - pve-exporter
+
+  pve-exporter:
+    container_name: pve-exporter
+    image: prompve/prometheus-pve-exporter:3.9.0@sha256:e1e61099c4c4b385bbf88eff61886a5ff4d84be5e88ed7af6c77f98e783de978
+    restart: unless-stopped
+    dns:
+      - 100.100.100.100
+    command:
+      - --config.file=/etc/pve/pve.yml
+    environment:
+      - PVE_USER=${PVE_USER}
+      - PVE_TOKEN_NAME=${PVE_TOKEN_NAME}
+      - PVE_TOKEN_VALUE=${PVE_TOKEN_VALUE}
+    volumes:
+      - ./config/pve.yml:/etc/pve/pve.yml:ro
+    labels:
+      autoheal: true
+      traefik.enable: false
+    networks:
+      - dockge_default
 
   blackbox-exporter:
     user: "65534:65534"

--- a/docker/_common/prometheus/config/alloy/config.alloy
+++ b/docker/_common/prometheus/config/alloy/config.alloy
@@ -46,3 +46,87 @@ loki.write "default" {
     url = "http://loki.${tailscaleDomain}:3100/loki/api/v1/push"
   }
 }
+
+// ── OpenTelemetry Pipeline ──────────────────────────────────────────────────
+
+// Receive OTLP signals from local Docker containers (gRPC + HTTP)
+otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
+  http {
+    endpoint = "0.0.0.0:4318"
+  }
+  output {
+    metrics = [otelcol.processor.attributes.default.input]
+    logs    = [otelcol.processor.attributes.default.input]
+    traces  = [otelcol.processor.attributes.default.input]
+  }
+}
+
+// Inject cluster/environment labels onto all signals
+otelcol.processor.attributes "default" {
+  action {
+    key    = "cluster"
+    value  = "${CLUSTER_KEY}"
+    action = "insert"
+  }
+  action {
+    key    = "environment"
+    value  = "homelab"
+    action = "insert"
+  }
+  action {
+    key    = "region"
+    value  = "home"
+    action = "insert"
+  }
+  output {
+    metrics = [otelcol.processor.batch.default.input]
+    logs    = [otelcol.processor.batch.default.input]
+    traces  = [otelcol.processor.batch.default.input]
+  }
+}
+
+// Batch signals before forwarding
+otelcol.processor.batch "default" {
+  output {
+    metrics = [otelcol.exporter.prometheus.default.input]
+    logs    = [otelcol.exporter.loki.default.input]
+    traces  = [otelcol.exporter.otlphttp.tempo.input]
+  }
+}
+
+// OTLP metrics → Prometheus remote_write → Thanos
+otelcol.exporter.prometheus "default" {
+  forward_to = [prometheus.remote_write.thanos.receiver]
+}
+
+prometheus.remote_write "thanos" {
+  endpoint {
+    url = "http://thanos-receive.${tailscaleDomain}:19291/api/v1/receive"
+    queue_config {
+      max_samples_per_send = 10000
+    }
+  }
+  external_labels = {
+    cluster     = "${CLUSTER_KEY}",
+    environment = "homelab",
+    region      = "home",
+  }
+}
+
+// OTLP logs → Loki
+otelcol.exporter.loki "default" {
+  forward_to = [loki.write.default.receiver]
+}
+
+// OTLP traces → Grafana Tempo
+otelcol.exporter.otlphttp "tempo" {
+  client {
+    endpoint = "http://tempo.${tailscaleDomain}:4318"
+    tls {
+      insecure = true
+    }
+  }
+}

--- a/docker/_common/prometheus/config/blackbox.yml
+++ b/docker/_common/prometheus/config/blackbox.yml
@@ -41,6 +41,17 @@ modules:
     dns:
       query_name: "example.com"
       query_type: "A"
+  http_2xx_insecure:
+    prober: http
+    timeout: 5s
+    http:
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      method: GET
+      follow_redirects: true
+      preferred_ip_protocol: "ip4"
+      tls_config:
+        insecure_skip_verify: true
+
   ssh_banner:
     prober: tcp
     timeout: 5s

--- a/docker/_common/prometheus/config/prometheus.yml
+++ b/docker/_common/prometheus/config/prometheus.yml
@@ -137,10 +137,7 @@ scrape_configs:
     params:
       module: [http_2xx_insecure]
     static_configs:
-      - targets:
-          - https://100.111.10.100:8006  # twilight-sparkle PVE
-          - https://100.111.10.103:8006  # celestia PVE
-          - https://100.111.10.200:8006  # alpha-site PVE (via subnet router)
+      - targets: ${PROXMOX_BLACKBOX_TARGETS}
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target
@@ -156,10 +153,7 @@ scrape_configs:
     params:
       module: [default]
     static_configs:
-      - targets:
-          - 100.111.10.100:8006  # twilight-sparkle PVE
-          - 100.111.10.103:8006  # celestia PVE
-          - 100.111.10.200:8006  # alpha-site PVE (via subnet router)
+      - targets: ${PROXMOX_PVE_TARGETS}
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/docker/_common/prometheus/config/prometheus.yml
+++ b/docker/_common/prometheus/config/prometheus.yml
@@ -129,3 +129,41 @@ scrape_configs:
         target_label: hostname
         replacement: '${1}'  # Use the value of instance as hostname
         regex: '([^:]+).*'
+
+  # Blackbox HTTP probes for Proxmox VE web UIs (uses self-signed certs)
+  - job_name: 'blackbox-proxmox'
+    scrape_interval: 2m
+    metrics_path: /probe
+    params:
+      module: [http_2xx_insecure]
+    static_configs:
+      - targets:
+          - https://100.111.10.100:8006  # twilight-sparkle PVE
+          - https://100.111.10.103:8006  # celestia PVE
+          - https://100.111.10.200:8006  # alpha-site PVE (via subnet router)
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115
+
+  # Proxmox VE metrics via prometheus-pve-exporter
+  - job_name: 'proxmox'
+    scrape_interval: 2m
+    metrics_path: /pve
+    params:
+      module: [default]
+    static_configs:
+      - targets:
+          - 100.111.10.100:8006  # twilight-sparkle PVE
+          - 100.111.10.103:8006  # celestia PVE
+          - 100.111.10.200:8006  # alpha-site PVE (via subnet router)
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: pve-exporter:9221

--- a/docker/_common/prometheus/config/pve.yml
+++ b/docker/_common/prometheus/config/pve.yml
@@ -1,0 +1,5 @@
+default:
+  user: ${PVE_USER}
+  token_name: ${PVE_TOKEN_NAME}
+  token_value: ${PVE_TOKEN_VALUE}
+  verify_ssl: false

--- a/docker/_common/prometheus/config/rules/proxmox.yml
+++ b/docker/_common/prometheus/config/rules/proxmox.yml
@@ -1,0 +1,89 @@
+groups:
+  - name: proxmox-hosts
+    interval: 60s
+    rules:
+      # Alert when pve_exporter cannot reach a Proxmox host (host is down or API unreachable)
+      - alert: ProxmoxHostUnreachable
+        expr: |
+          pve_up == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Proxmox host {{ $labels.id }} is unreachable"
+          description: "The Proxmox VE API on {{ $labels.id }} ({{ $labels.instance }}) has been unreachable for more than 2 minutes."
+
+      # Alert when pve_exporter itself is down (cannot scrape)
+      - alert: ProxmoxExporterDown
+        expr: |
+          up{job="proxmox"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Proxmox exporter is down for {{ $labels.instance }}"
+          description: "The prometheus-pve-exporter cannot be scraped for {{ $labels.instance }} — the host may be down or the API credentials are invalid."
+
+      # Alert when a Proxmox node is using more than 85% CPU for 10 minutes
+      - alert: ProxmoxNodeHighCPU
+        expr: |
+          pve_cpu_usage_ratio{type="node"} > 0.85
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Proxmox node {{ $labels.id }} has high CPU usage"
+          description: "Proxmox node {{ $labels.id }} CPU usage is {{ $value | humanizePercentage }} (threshold: 85%)."
+
+      # Alert when a Proxmox node is using more than 90% memory for 10 minutes
+      - alert: ProxmoxNodeHighMemory
+        expr: |
+          (
+            pve_memory_usage_bytes{type="node"}
+            / pve_memory_size_bytes{type="node"}
+          ) > 0.90
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Proxmox node {{ $labels.id }} has high memory usage"
+          description: "Proxmox node {{ $labels.id }} memory usage is {{ $value | humanizePercentage }} (threshold: 90%)."
+
+      # Alert when a Proxmox storage pool is more than 85% full
+      - alert: ProxmoxStorageFull
+        expr: |
+          (
+            pve_disk_usage_bytes{type="storage"}
+            / pve_disk_size_bytes{type="storage"}
+          ) > 0.85
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Proxmox storage {{ $labels.id }} is almost full"
+          description: "Proxmox storage {{ $labels.id }} on {{ $labels.instance }} is {{ $value | humanizePercentage }} full (threshold: 85%)."
+
+      # Alert when a Proxmox storage pool is more than 95% full (critical)
+      - alert: ProxmoxStorageCritical
+        expr: |
+          (
+            pve_disk_usage_bytes{type="storage"}
+            / pve_disk_size_bytes{type="storage"}
+          ) > 0.95
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Proxmox storage {{ $labels.id }} is critically full"
+          description: "Proxmox storage {{ $labels.id }} on {{ $labels.instance }} is {{ $value | humanizePercentage }} full (threshold: 95%)."
+
+      # Alert when a VM or LXC that should be running has stopped
+      - alert: ProxmoxVMDown
+        expr: |
+          pve_up{type=~"qemu|lxc"} == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Proxmox VM/LXC {{ $labels.name }} is not running"
+          description: "VM or LXC {{ $labels.name }} ({{ $labels.id }}) on {{ $labels.instance }} has been stopped for more than 5 minutes."

--- a/stacks/gulf-of-mexico/index.ts
+++ b/stacks/gulf-of-mexico/index.ts
@@ -74,7 +74,13 @@ const pbs = new ProxmoxBackupServerLxc("luna-pbs", {
 });
 pbs.addHostMount("/data");
 
-dockgeRuntime.deployStacks({ dependsOn: [pbs] });
+dockgeRuntime.deployStacks({
+  dependsOn: [pbs],
+  variables: {
+    PROXMOX_BLACKBOX_TARGETS: `["https://${host.tailscaleIpAddress}:8006"]`,
+    PROXMOX_PVE_TARGETS: `["${host.tailscaleIpAddress}:8006"]`,
+  },
+});
 host.addUptimeGatus();
 
 exportNodeStateToOnePassword(

--- a/stacks/home/index.ts
+++ b/stacks/home/index.ts
@@ -166,16 +166,20 @@ celestiaPbs.addHostMount("/data");
 celestiaPbs.addHostMount(`/mnt/pve/${celestiaBackupMount}`, "/spike/backup");
 celestiaPbs.addHostMount(`/mnt/pve/${celestiaDataMount}`, "/spike/data");
 
-const pveHosts = [twilightSparkleHost, celestiaHost, alphaSiteHost];
-const proxmoxBlackboxTargets = `[${pveHosts.map((h) => `"https://${h.tailscaleIpAddress}:8006"`).join(", ")}]`;
-const proxmoxPveTargets = `[${pveHosts.map((h) => `"${h.tailscaleIpAddress}:8006"`).join(", ")}]`;
-const pveVariables = {
-  PROXMOX_BLACKBOX_TARGETS: proxmoxBlackboxTargets,
-  PROXMOX_PVE_TARGETS: proxmoxPveTargets,
+// Celestia monitors twilight-sparkle + itself; alpha-site monitors only itself
+const celestiaPveHosts = [twilightSparkleHost, celestiaHost];
+const celestiaPveVariables = {
+  PROXMOX_BLACKBOX_TARGETS: `[${celestiaPveHosts.map((h) => `"https://${h.tailscaleIpAddress}:8006"`).join(", ")}]`,
+  PROXMOX_PVE_TARGETS: `[${celestiaPveHosts.map((h) => `"${h.tailscaleIpAddress}:8006"`).join(", ")}]`,
 };
 
-celestiaDockgeRuntime.deployStacks({ dependsOn: [celestiaPbs], variables: pveVariables });
-alphaSiteDockgeRuntime.deployStacks({ dependsOn: [], variables: pveVariables });
+const alphaSitePveVariables = {
+  PROXMOX_BLACKBOX_TARGETS: `["https://${alphaSiteHost.tailscaleIpAddress}:8006"]`,
+  PROXMOX_PVE_TARGETS: `["${alphaSiteHost.tailscaleIpAddress}:8006"]`,
+};
+
+celestiaDockgeRuntime.deployStacks({ dependsOn: [celestiaPbs], variables: celestiaPveVariables });
+alphaSiteDockgeRuntime.deployStacks({ dependsOn: [], variables: alphaSitePveVariables });
 
 celestiaHost.addUptimeGatus();
 alphaSiteHost.addUptimeGatus();

--- a/stacks/home/index.ts
+++ b/stacks/home/index.ts
@@ -166,8 +166,16 @@ celestiaPbs.addHostMount("/data");
 celestiaPbs.addHostMount(`/mnt/pve/${celestiaBackupMount}`, "/spike/backup");
 celestiaPbs.addHostMount(`/mnt/pve/${celestiaDataMount}`, "/spike/data");
 
-celestiaDockgeRuntime.deployStacks({ dependsOn: [celestiaPbs] });
-alphaSiteDockgeRuntime.deployStacks({ dependsOn: [] });
+const pveHosts = [twilightSparkleHost, celestiaHost, alphaSiteHost];
+const proxmoxBlackboxTargets = `[${pveHosts.map((h) => `"https://${h.tailscaleIpAddress}:8006"`).join(", ")}]`;
+const proxmoxPveTargets = `[${pveHosts.map((h) => `"${h.tailscaleIpAddress}:8006"`).join(", ")}]`;
+const pveVariables = {
+  PROXMOX_BLACKBOX_TARGETS: proxmoxBlackboxTargets,
+  PROXMOX_PVE_TARGETS: proxmoxPveTargets,
+};
+
+celestiaDockgeRuntime.deployStacks({ dependsOn: [celestiaPbs], variables: pveVariables });
+alphaSiteDockgeRuntime.deployStacks({ dependsOn: [], variables: pveVariables });
 
 celestiaHost.addUptimeGatus();
 alphaSiteHost.addUptimeGatus();

--- a/stacks/ocracoke/index.ts
+++ b/stacks/ocracoke/index.ts
@@ -68,7 +68,13 @@ const dockgeRuntime = new DockgeLxc("skystar-dockge", {
 // });
 // pbs.addHostMount("/data");
 
-dockgeRuntime.deployStacks({ dependsOn: [] });
+dockgeRuntime.deployStacks({
+  dependsOn: [],
+  variables: {
+    PROXMOX_BLACKBOX_TARGETS: `["https://${host.tailscaleIpAddress}:8006"]`,
+    PROXMOX_PVE_TARGETS: `["${host.tailscaleIpAddress}:8006"]`,
+  },
+});
 host.addUptimeGatus();
 
 exportNodeStateToOnePassword(


### PR DESCRIPTION
## Summary

Enhances observability across all homelab layers.

### Proxmox Alerting & Metrics
- Add `pve_exporter` service to `_common/prometheus` stack (image pinned with SHA256)
- Add `blackbox-proxmox` job probing PVE web UI (TLS skip), and `proxmox` scrape job via pve_exporter
- New `config/rules/proxmox.yml` with 7 alert rules: ProxmoxHostUnreachable, ProxmoxExporterDown, ProxmoxNodeHighCPU, ProxmoxNodeHighMemory, ProxmoxStorageFull, ProxmoxStorageCritical, ProxmoxVMDown
- New `config/pve.yml` credentials config (Dockge env var substitution)

### OpenTelemetry on Docker Hosts
- Extend `config/alloy/config.alloy` with full OTLP pipeline (receiver → attributes → batch → Thanos/Loki/Tempo)
- Expose ports 4317/4318 on Alloy service in `compose.yaml`

### Alloy on Proxmox Hosts (via Pulumi)
- Remove broken commented-out code from `ProxmoxHost.ts`
- Add working install: apt install alloy → copy config → systemctl enable
- Collects systemd journal logs and host metrics, forwards to Loki/Thanos via Tailscale

## Required: Add to each Dockge .env
```
PVE_USER=monitoring@pve
PVE_TOKEN_NAME=prometheus
PVE_TOKEN_VALUE=<token>
```

## Related PRs
- equestria-cluster: deploy Tempo + OTLP on Alloy
- stargate-command-cluster: OTLP on alloy-proxy + tempo-headless ExternalName