### PR TITLE
perf(alpha-site): switch Prometheus to agent mode, enable Traefik gzip compression

### DIFF
--- a/docker/_common/prometheus/compose.yaml
+++ b/docker/_common/prometheus/compose.yaml
@@ -38,9 +38,8 @@ services:
       - 100.100.100.100
     command:
       - --config.file=/etc/prometheus/prometheus.yml
-      - --storage.tsdb.path=/prometheus
-      - --storage.tsdb.retention.time=2d
-      - --storage.tsdb.retention.size=20GB
+      - --enable-feature=agent
+      - --storage.agent.path=/prometheus
       - --web.enable-lifecycle
     labels:
       autoheal: true

--- a/docker/_common/traefik/config.yaml
+++ b/docker/_common/traefik/config.yaml
@@ -27,6 +27,9 @@ accessLog:
 entryPoints:
   web:
     address: ":80"
+    http:
+      middlewares:
+        - compress@file
     transport:
       respondingTimeouts:
         readTimeout: "0s"
@@ -35,11 +38,16 @@ entryPoints:
     http:
       tls:
         certResolver: le
+      middlewares:
+        - compress@file
     transport:
       respondingTimeouts:
         readTimeout: "0s"
   tailscale:
     address: ":8443"
+    http:
+      middlewares:
+        - compress@file
     transport:
       respondingTimeouts:
         readTimeout: "0s"

--- a/docker/_common/traefik/dynamic/compression.yaml
+++ b/docker/_common/traefik/dynamic/compression.yaml
@@ -1,0 +1,5 @@
+http:
+  middlewares:
+    compress:
+      compress:
+        minResponseBodyBytes: 1024


### PR DESCRIPTION
## Problem

Alpha-site (Raspberry Pi 4) was experiencing severe HTTP slowness — large JS/CSS bundles (1–2MB) taking 20–160 seconds to serve. Root cause: **SD card I/O saturation**.

Two contributing factors:
1. **Prometheus TSDB writes** — full 2-day local retention means constant disk writes, even though all data is already remote-written to Thanos on Equestria
2. **Uncompressed static assets** — Traefik was serving raw 1–2MB JS files, maxing out SD card read throughput for every page load

Evidence from Loki logs (yesterday's incident, ~14:43–15:30 UTC):
- Prometheus JS bundle (1.9MB): **161 seconds**
- Registry JS bundle (1.4MB): 115 seconds  
- AdGuard login JS (686KB): 98 seconds
- Proxmox web UI: **30s → 504 Gateway Timeout**
- Prometheus TSDB stopped persisting entirely for ~24 hours (I/O-starved WAL flush)

## Changes

### Option A: Prometheus Agent Mode (`docker/_common/prometheus/compose.yaml`)

Switches all Docker-cluster Prometheus instances from full TSDB to `--enable-feature=agent` mode. Agent mode:
- **Eliminates local TSDB writes** (only keeps a small WAL buffer, ~50–200MB)
- Scrapes and remote-writes to Thanos exactly as before — no data loss
- Still exposes its own metrics and `/targets` status page

All clusters already remote-write to `thanos-receive` on Equestria, so local retention was purely redundant disk I/O.

### Option C: Traefik Compression (`docker/_common/traefik/`)

- New `dynamic/compression.yaml` — defines a `compress` middleware (min 1KB, supports zstd/br/gzip in priority order)
- `config.yaml` — applies `compress@file` as a default middleware on `web`, `websecure`, and `tailscale` entrypoints

Expected impact: 1.9MB JS → ~380KB (80% reduction). Even at SD card speeds this turns a 160s load into ~32s, and under normal conditions into sub-second.

WebSocket connections are unaffected — Traefik's compress middleware skips requests with an `Upgrade` header.

## Deployment notes

- **Prometheus**: On first restart in agent mode, the old TSDB data directory (`./data/prometheus/`) can be cleared — it won't be read. The agent WAL will be written there instead.
- **Traefik**: `dynamic/compression.yaml` needs to be present at `/opt/stacks-data/traefik/dynamic/compression.yaml` on each host before or at restart.