### PR TITLE
fix(DockgeLxc): wait for all applications before creating Authentik outpost

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -551,11 +551,17 @@ export class DockgeLxc extends ComponentResource {
       .apply((z) => z.filter((z) => z !== null).map((z) => z!))
       .apply((z) => {
         z.forEach((s) => log.info(`Loaded docker stack ${s.name} from ${s.path}`));
-        return output(z.filter((z) => !!z.compose).map((z) => z.compose!));
-      })
-      .apply(async (stacks) => {
-        await this.createOutpost(stacks);
-        return stacks;
+        const composes = output(z.filter((z) => !!z.compose).map((z) => z.compose!));
+
+        // Wait for ALL applications to be registered before creating the outpost.
+        // proxyProviders is populated inside async .apply() callbacks in createApplication(),
+        // so creating the outpost before those callbacks complete sends an empty providers
+        // list which Authentik rejects with 400 Bad Request.
+        all(z.map((s) => s.waitForApplications)).apply(async () => {
+          await this.createOutpost(composes);
+        });
+
+        return composes;
       });
   }
 
@@ -640,7 +646,7 @@ export class DockgeLxc extends ComponentResource {
     path: string,
     replacements: ((input: Output<string>) => Output<string>)[],
     dependsOn: Input<Resource[]>,
-  ): Output<{ name: string; path: string; compose?: remote.Command }> {
+  ): Output<{ name: string; path: string; compose?: remote.Command; waitForApplications: Output<Resource[]> }> {
     const copyFiles = [];
     const cluster = this.cluster;
     const tailscaleDomain = this.args.globals.tailscaleDomain;
@@ -800,9 +806,9 @@ export class DockgeLxc extends ComponentResource {
         },
       );
 
-      return output({ name: stackName, path, compose });
+      return output({ name: stackName, path, compose, waitForApplications });
     }
-    return output({ name: stackName, path });
+    return output({ name: stackName, path, waitForApplications });
   }
 }
 


### PR DESCRIPTION
## Problem

The `home-operations` Pulumi stack has been failing with **369 errors** in the equestria cluster. The Authentik API returns `400 Bad Request` when updating the alpha-site outpost:

```
{"providers":["This list may not be empty."]}
```

## Root Cause — Race Condition

`AuthentikApplicationManager.proxyProviders` is a plain mutable JS array (`pulumi.Output<number>[] = []`). Items are pushed to it inside **async `.apply()` callbacks** in `createApplication()` — these callbacks depend on file reads and 1Password lookups (async operations).

Previously, `createOutpost()` was chained after `output([...compose commands...]).apply(...)`. Compose command **objects** (not their IDs) resolve immediately during synchronous program evaluation — before the async file reads and 1Password lookups complete. So `createOutpost` captured an empty `proxyProviders` array and sent `protocolProviders: []` to Authentik.

The bug was latent until a recent commit changed the outpost's `config` JSON (formatting/fields), triggering an outpost update. That update sent the empty providers list, causing Authentik to reject every attempt.

## Fix

Return `waitForApplications` (an `Output` that resolves after all `createApplication()` callbacks complete) from `createStack()`. In `deployStacks()`, chain `createOutpost()` inside `all(waitForApplications).apply(...)` instead of after the compose commands.

This guarantees every `proxyProviders.push()` has been called before the outpost resource is registered.

```
Before: compose objects resolve (immediate) → createOutpost (proxyProviders=[])
After:  all app callbacks complete → createOutpost (proxyProviders=[588,564,566,563,834])
```