### PR TITLE
fix: remove padEnd(1024) from writeTempFile and add chown for sftp keys

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -329,7 +329,7 @@ export class DockgeLxc extends ComponentResource {
         {
           connection: this.remoteConnection,
           triggers: keyWrites.map((k) => k.id),
-          create: interpolate`chmod 700 ${sftpKeysDir} ${jobsKeysDir} ${backrestSshDir} && chmod 600 ${sftpKeysDir}/host_key ${sftpKeysDir}/authorized_keys ${jobsKeysDir}/id_ed25519 ${jobsKeysDir}/id_ed25519.pub ${jobsKeysDir}/known_hosts ${jobsKeysDir}/server_host_key.pub ${backrestSshDir}/id_ed25519 ${backrestSshDir}/id_ed25519.pub ${backrestSshDir}/known_hosts || true`,
+          create: interpolate`chmod 700 ${sftpKeysDir} ${jobsKeysDir} ${backrestSshDir} && chmod 600 ${sftpKeysDir}/host_key ${sftpKeysDir}/authorized_keys ${jobsKeysDir}/id_ed25519 ${jobsKeysDir}/id_ed25519.pub ${jobsKeysDir}/known_hosts ${jobsKeysDir}/server_host_key.pub ${backrestSshDir}/id_ed25519 ${backrestSshDir}/id_ed25519.pub ${backrestSshDir}/known_hosts && chown -R 65534:65534 ${sftpKeysDir} || true`,
         },
         mergeOptions(cro, { dependsOn: keyWrites }),
       ),

--- a/components/helpers.ts
+++ b/components/helpers.ts
@@ -72,7 +72,7 @@ export function writeTempFile(fileName: Input<string>, content: Input<string>) {
       try {
         await rm(filePath, { force: true });
       } catch (_) {}
-      return writeFile(filePath, content.padEnd(1024), {});
+      return writeFile(filePath, content, {});
     })
     .apply(() => filePath);
 }


### PR DESCRIPTION
## Problem

`writeTempFile` in `components/helpers.ts` was padding all file content with spaces to exactly 1024 bytes via `content.padEnd(1024)`. For SSH `authorized_keys` files this caused `rclone serve sftp` to log **"Loaded 0 authorized keys"** and refuse all connections.

### Root cause analysis

1. **`padEnd(1024)` bug**: The SSH public key (`81 bytes`) + newline was padded to 1024 bytes with trailing spaces. `golang.org/x/crypto/ssh`'s `ParseAuthorizedKey` returns an error when it encounters the 943 trailing spaces (no newline), causing rclone to treat it as 0 valid keys.

2. **Why padEnd was added**: Commit `ea81be3` ("try padding") replaced a `truncate -s 0` pre-write command with `padEnd`. Investigation of `pulumi-command`'s source shows `sftp.Create()` opens remote files with `O_WRONLY|O_CREAT|O_TRUNC` — it **already truncates** before writing. There was never a stale-bytes issue. The workaround was unnecessary and harmful.

3. **Ownership bug**: `DockgeLxc.ts` ran `chmod 600/700` on key files but never `chown`. Pulumi writes via SSH as root → files remain `root:root`. The rclone-sftp container runs as `nobody` (uid 65534) and cannot read root-owned `700` directories or `600` files.

## Fix

- `components/helpers.ts`: Remove `content.padEnd(1024)` — write content as-is
- `components/DockgeLxc.ts`: Add `chown -R 65534:65534 ${sftpKeysDir}` after `chmod` so the container can read its key files

## Verification

Both celestia and luna rclone-sftp containers were manually recovered during triage (clean authorized_keys written, ownership fixed). They are currently healthy:
- `Loaded 1 authorized keys`  
- `SFTP server listening on [::]:2022` ✅

This PR prevents regression when Pulumi next runs against these hosts.