### PR TITLE
fix: enable Dockge Prometheus alerting by removing agent mode

### DIFF
--- a/docker/_common/prometheus/compose.yaml
+++ b/docker/_common/prometheus/compose.yaml
@@ -41,8 +41,8 @@ services:
       - 100.100.100.100
     command:
       - --config.file=/etc/prometheus/prometheus.yml
-      - --enable-feature=agent
-      - --storage.agent.path=/prometheus
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=7d
       - --web.enable-lifecycle
     labels:
       autoheal: true

--- a/docker/_common/prometheus/compose.yaml
+++ b/docker/_common/prometheus/compose.yaml
@@ -42,7 +42,7 @@ services:
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus
-      - --storage.tsdb.retention.time=7d
+      - --storage.tsdb.retention.time=4h
       - --web.enable-lifecycle
     labels:
       autoheal: true


### PR DESCRIPTION
Prometheus agent mode (`--enable-feature=agent`) disables rule evaluation and alerting entirely. The Watchdog alert rule was defined in `watchdog.yml` but was never evaluated, so no alert was ever sent to Alertmanager -- leaving Dockge clusters silent while Kubernetes clusters reported normally.

**Changes:**
- Removed `--enable-feature=agent` and `--storage.agent.path`
- Switched to standard TSDB mode with `--storage.tsdb.path=/prometheus`
- Set local retention to `4h` -- just enough to buffer through a short Thanos outage; all data is forwarded via `remote_write` anyway

This applies to all Dockge clusters (celestia, luna, skystar, alpha-site) since the compose file lives in `docker/_common/prometheus/`. Redeploying the prometheus stack on each cluster will bring Watchdog alerts back online.