### PR TITLE
fix(renovate): override 1password-cli to use AgileBits custom datasource

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,6 +24,18 @@
   "docker-compose": {
     pinDigests: true,
   },
+  customDatasources: {
+    "1password-cli": {
+      defaultRegistryUrlTemplate: "https://app-updates.agilebits.com/product_history/CLI2",
+      format: "html",
+      // Renovate html format extracts all <a href> values as {version: href}.
+      // Filter to darwin_arm64 downloads (one per release), extract version string.
+      // Beta URLs contain "beta" in path; mark those isStable: false.
+      transformTemplates: [
+        '{"releases": releases[$contains(version, "/op_darwin_arm64_v") and $contains(version, ".zip")].{"version": $replace(version, /^.*\\/op_darwin_arm64_(v[0-9.]+(?:-[a-zA-Z0-9.]+)?)\\.zip$/, "$1"), "isStable": $not($contains(version, "beta"))}, "sourceUrl": "https://app-updates.agilebits.com/product_history/CLI2", "homepage": "https://1password.com/downloads/command-line/"}',
+      ],
+    },
+  },
   packageRules: [
     {
       description: "Auto-merge GitHub Actions",
@@ -103,6 +115,12 @@
     {
       matchDatasources: ["github-releases"],
       addLabels: ["renovate/github-release"],
+    },
+    {
+      description: "Override 1password-cli datasource: aqua type:http uses AgileBits CDN, no GitHub releases exist",
+      matchManagers: ["mise"],
+      matchDepNames: ["1password-cli"],
+      overrideDatasource: "custom.1password-cli",
     },
   ],
   customManagers: [


### PR DESCRIPTION
## Problem

Renovate Dashboard issue #11 reports:
> `Renovate failed to look up the following dependencies: Failed to look up github-tags package 1password/cli: no-result.`

### Root cause chain

1. `.mise.toml` declares `1password-cli = "2.34.0"`
2. Renovate's mise manager → resolves to `aqua:1password/cli` backend
3. Renovate calls `createAquaToolConfig("1password/cli", ...)` which **hardcodes `datasource: "github-tags"`** for all aqua packages
4. GitHub lookup for `1password/cli` → 404 — no such public repo exists
5. 1Password CLI is distributed exclusively via **AgileBits CDN**: `https://cache.agilebits.com/dist/1P/op2/pkg/`

## Fix

### `customDatasources["1password-cli"]`

Adds a custom datasource that scrapes the [AgileBits product history page](https://app-updates.agilebits.com/product_history/CLI2) using Renovate's `html` format. The page contains `<a href>` links like:
```
https://cache.agilebits.com/dist/1P/op2/pkg/v2.34.0/op_darwin_arm64_v2.34.0.zip
```

A JSONata `transformTemplates` expression:
- Filters to `darwin_arm64` download links (one canonical link per release)
- Extracts the version string (e.g. `v2.34.0`)
- Sets `isStable: false` for any URL containing `beta`

### `packageRules` override

Adds a rule to override the datasource for `1password-cli` in the `mise` manager to use `custom.1password-cli` instead of the broken `github-tags` lookup.

Fixes #11