### PR TITLE
docker/celestia/pdm: fix compose for OIDC and persistence

### DIFF
--- a/docker/celestia/pdm/compose.yaml
+++ b/docker/celestia/pdm/compose.yaml
@@ -9,20 +9,22 @@ services:
       - apparmor=unconfined
     cap_add:
       - ALL
+    environment:
+      PASSWORD: "op://Eris/pdm-root/password"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup
+      - /opt/stacks-data/pdm:/etc/proxmox-datacenter-manager
     labels:
       # Enable Traefik
       traefik.enable: true
 
+      # PDM has native OIDC support — no forward-auth middleware needed
       traefik.http.routers.pdm.rule: Host(`pdm.${searchDomain}`)
-      traefik.http.routers.pdm.middlewares: authentik-outpost@docker
       traefik.http.routers.pdm.entrypoints: websecure
       traefik.http.routers.pdm.service: pdm
       traefik.http.routers.pdm.tls.certresolver: le
 
       traefik.http.routers.pdm-tailscale.rule: Host(`pdm.${tailscaleDomain}`)
-      traefik.http.routers.pdm-tailscale.middlewares: authentik-outpost@docker
       traefik.http.routers.pdm-tailscale.entrypoints: tailscale
       traefik.http.routers.pdm-tailscale.service: pdm
 


### PR DESCRIPTION
## Summary

Fixes PDM (Proxmox Datacenter Manager) deployment on Celestia.

### Changes

- **Remove `.ignore`** — was blocking Pulumi from managing this stack entirely
- **Remove `authentik-outpost@docker` middleware** — PDM has native OIDC; forward-auth intercepts `/oidc-callback` and breaks login
- **Add persistent volume** `/opt/stacks-data/pdm:/etc/proxmox-datacenter-manager` — preserves OIDC realm config and remote registrations across restarts
- **Add `PASSWORD` env var** → `op://Eris/pdm-root/password` — required for initial root access (container locks root if unset)

### What Pulumi does after merge
1. Creates DNS `pdm.driscoll.tech`
2. Creates Authentik OAuth2 app
3. Stores `celestia-pdm-oidc-credentials` in 1Password (client_id, client_secret, issuer)
4. Registers Tailscale serve endpoint + Gatus check

### One-time post-deploy: configure OIDC realm in PDM
After Pulumi runs, POST to `/api2/json/config/access/openid` using credentials from `celestia-pdm-oidc-credentials` in 1Password.

> **Prerequisite**: Create `pdm-root` item in the Eris 1Password vault with a `password` field before deploying.