### PR TITLE
fix(prometheus): increase DockerContainerDown max_over_time window from 10m to 1h

### DIFF
--- a/docker/_common/prometheus/config/rules/alerts.yml
+++ b/docker/_common/prometheus/config/rules/alerts.yml
@@ -3,14 +3,18 @@ groups:
     interval: 30s
     rules:
       # Alert when a Docker container has stopped running (not seen for 5 minutes).
-      # Uses max_over_time with a 10m window to avoid the Prometheus staleness issue:
+      # Uses max_over_time to avoid the Prometheus staleness issue:
       # plain `time() - container_last_seen > 300` can never fire because the metric
       # becomes stale at exactly T+300s (the default lookback-delta), so the condition
       # and metric availability are mutually exclusive.
+      # Window must be significantly larger than the detection threshold (300s):
+      # with [10m], max_over_time loses the last value at T+600 and the alert
+      # auto-resolves ~5 min after firing, even if the container is still down.
+      # Using [1h] keeps the alert active for ~55 min before expiring.
       - alert: DockerContainerDown
         expr: |
           (
-            time() - max_over_time(container_last_seen{name!="", name!~".*POD.*"}[10m])
+            time() - max_over_time(container_last_seen{name!="", name!~".*POD.*"}[1h])
           ) > 300
         for: 0m
         labels:


### PR DESCRIPTION
## Problem

The `DockerContainerDown` alert was silently self-resolving ~5 minutes after firing, even when the container was still down.

### Root Cause

The `max_over_time` lookback window `[10m]` is too small relative to the 300s (5 min) detection threshold:

| Time | Event |
|------|-------|
| T | Container stops; last `container_last_seen` value ≈ T |
| T+15s | cAdvisor drops the container; Prometheus writes stale marker |
| T+300 | `time() - max_over_time([10m]) > 300` becomes TRUE → alert fires |
| T+600 | `max_over_time([10m])` range `(T, T+600]` no longer includes the last real value at T → **returns no data** |
| T+600 | Alert condition is absent → Prometheus resolves the alert → alertmanager sends false "recovered" |

**Result:** Each container-down event produces only a ~5-minute alert window, then silently resolves — no re-alert while the container stays down.

## Fix

Change `[10m]` → `[1h]`. With a 1-hour window, `max_over_time` continues to find the last real value until T+3600, keeping the alert firing for ~55 minutes after it first triggers.