### PR TITLE
fix: restore compress@file middleware and rollback backrest to v1.12.1

### DIFF
--- a/docker/_common/backrest/compose.yaml
+++ b/docker/_common/backrest/compose.yaml
@@ -1,6 +1,6 @@
 services:
   backrest:
-    image: garethgeorge/backrest:v1.13.0@sha256:9c9966b5c285ec791a6b06cb4545fa0247424d05442e12f9558b4322d9f8a15f
+    image: garethgeorge/backrest:v1.12.1@sha256:f4d34bd6fa985d13bdb6c01c5d8727e07708899afa9567d800808357d77b9fb0
     container_name: backrest
     hostname: backrest
     tmpfs: /tmp

--- a/docker/_common/traefik/compose.yaml
+++ b/docker/_common/traefik/compose.yaml
@@ -42,6 +42,7 @@ services:
       - ./letsencrypt:/letsencrypt
       - ./config.yaml:/config/config.yaml
       - /opt/stacks-data/${APP}/dynamic:/config/dynamic
+      - ./dynamic/middlewares.yaml:/config/dynamic/middlewares.yaml
     networks:
       - dockge_default
   error-pages:

--- a/docker/_common/traefik/config.yaml
+++ b/docker/_common/traefik/config.yaml
@@ -90,23 +90,6 @@ providers:
     directory: /config/dynamic/
     watch: true
 
-http:
-  middlewares:
-    compress:
-      compress:
-        minResponseBodyBytes: 1024
-    errors:
-      errors:
-        status:
-          - "401-599"
-        query: /{status}.html
-        service: error-pages
-  services:
-    error-pages:
-      loadBalancer:
-        servers:
-          - url: "http://error-pages:8080"
-
 # Certificate resolvers configuration
 certificatesResolvers:
   le:

--- a/docker/_common/traefik/dynamic/middlewares.yaml
+++ b/docker/_common/traefik/dynamic/middlewares.yaml
@@ -1,0 +1,16 @@
+http:
+  middlewares:
+    compress:
+      compress:
+        minResponseBodyBytes: 1024
+    errors:
+      errors:
+        status:
+          - "401-599"
+        query: /{status}.html
+        service: error-pages@file
+  services:
+    error-pages:
+      loadBalancer:
+        servers:
+          - url: "http://error-pages:8080"


### PR DESCRIPTION
## Problem

Two services were broken after the previous PR (#355) and the user's middleware commits:

### 1. Universal 404s — `compress@file` middleware not resolving

The user moved the `compress` middleware definition from `dynamic/compression.yaml` (file provider) into the `http.middlewares` block of `config.yaml` (static config). However, **Traefik's static config ignores the `http` section** — middlewares must be in a file watched by the file provider. The entrypoints still referenced `compress@file`, which the file provider couldn't find, so Traefik dropped all routes → 404 on every service across all clusters.

Same issue affected the new `errors` middleware and `error-pages` service the user added.

### 2. Backrest crash-loop — v1.13.0 migration bug

`backrest` v1.13.0 introduced a breaking config migration (v2→v6) that fails when repos have **both** `auto_initialize: true` **and** a `guid` field. The migration errors out on startup without writing to disk.

## Fix

### Traefik
- Created `docker/_common/traefik/dynamic/middlewares.yaml` — contains the `compress`, `errors` middlewares and `error-pages` service definition in proper file provider format
- Added volume mount `./dynamic/middlewares.yaml:/config/dynamic/middlewares.yaml` so Traefik's watched directory includes this file
- Removed the dead `http.middlewares` block from `config.yaml` (it was silently ignored there)

### backrest  
- Rolled back `docker/_common/backrest/compose.yaml` image from `v1.13.0` → `v1.12.1`
- Long-term fix: manually edit `/opt/stacks-data/backrest/config/config.json` on Celestia and Luna to remove `auto_initialize: true` from repos that already have a `guid`, then upgrade

## Why this works

`./dynamic/middlewares.yaml:/config/dynamic/middlewares.yaml` is a **file-level bind mount** layered on top of the existing directory mount (`/opt/stacks-data/${APP}/dynamic:/config/dynamic`). Docker resolves both mounts simultaneously — the directory provides Pulumi-managed files, the file mount adds `middlewares.yaml` on top. Traefik's file provider watches the directory and picks up all files including the mounted one.

## Affected clusters
All three clusters (Celestia, Luna, Skystar) share `docker/_common/` — all three benefit from this fix.