### PR TITLE
fix(technitium): increase SSO set timeout from 15s to 60s

### DIFF
--- a/docker/_common/technitium/init.sh
+++ b/docker/_common/technitium/init.sh
@@ -57,6 +57,13 @@ api() {
   curl -sf --max-time 15 -X POST "${ADMIN_URL}/api/${method}?token=${TOKEN}" "$@"
 }
 
+api_slow() {
+  # Some endpoints (e.g. admin/sso/set) trigger outbound OIDC discovery requests
+  # that can take >15s. Use a longer timeout for those.
+  local method="$1"; shift
+  curl -sf --max-time 60 -X POST "${ADMIN_URL}/api/${method}?token=${TOKEN}" "$@"
+}
+
 # ---------------------------------------------------------------------------
 # 4. Configure SSO (always applied to fix/update values at runtime)
 # ---------------------------------------------------------------------------
@@ -64,7 +71,7 @@ log "Configuring SSO..."
 # Build the group map: remoteGroup|localGroup (pipe-separated, using "|" as field sep)
 GROUP_MAP="admins|Administrators"
 
-api "admin/sso/set" \
+api_slow "admin/sso/set" \
   --data-urlencode "ssoEnabled=true" \
   --data-urlencode "ssoAuthority=${DNS_SERVER_SSO_AUTHORITY}" \
   --data-urlencode "ssoClientId=${DNS_SERVER_SSO_CLIENT_ID}" \


### PR DESCRIPTION
## Problem

The `gulf-of-mexico` and `ocracoke` Pulumi stacks are firing `PulumiStackFailed` alerts with 26+ consecutive failures. Both fail at the same point in `init.sh`:

```
[18:57:55] Configuring SSO...
[18:58:10] ERROR: SSO configuration failed   # exactly 15 seconds later
```

The `admin/sso/set` Technitium API endpoint makes an outbound OIDC discovery request to validate the authority URL. When Authentik is slow to respond, this call takes >15 seconds and triggers the `--max-time 15` timeout.

## Fix

Introduce `api_slow()` with a 60-second timeout specifically for the SSO set call, keeping the 15s default for all other fast API calls.

## Testing

Once merged, the next Pulumi stack run for `gulf-of-mexico` and `ocracoke` should complete successfully without the SSO timeout.

## Related Alerts

- `PulumiStackFailed` for `gulf-of-mexico` stack
- `PulumiStackFailed` for `ocracoke` stack