### PR TITLE
fix(technitium): correct cluster join logic in init.sh

### DIFF
--- a/docker/_common/technitium/init.sh
+++ b/docker/_common/technitium/init.sh
@@ -108,9 +108,9 @@ log "Forwarders configured."
 # ---------------------------------------------------------------------------
 # 6. Cluster init or join (idempotent — skipped if already in cluster)
 # ---------------------------------------------------------------------------
-cluster_status=$(api "admin/cluster/get" || echo '{"status":"error"}')
+cluster_status=$(api "admin/cluster/state" || echo '{"status":"error"}')
 in_cluster=$(echo "$cluster_status" | python3 -c \
-  "import sys,json; d=json.load(sys.stdin); print('true' if d.get('response',{}).get('enabled') else 'false')" 2>/dev/null || echo "false")
+  "import sys,json; d=json.load(sys.stdin); print('true' if d.get('response',{}).get('clusterInitialized') else 'false')" 2>/dev/null || echo "false")
 
 if [ "$in_cluster" = "true" ]; then
   log "Already in cluster — skipping cluster init/join."
@@ -126,6 +126,7 @@ else
   api "admin/cluster/initJoin" \
     --data-urlencode "primaryNodeUrl=${DNS_CLUSTER_PRIMARY_URL}/" \
     --data-urlencode "primaryNodeIpAddress=${DNS_CLUSTER_PRIMARY_IP}" \
+    --data-urlencode "ignoreCertificateErrors=true" \
     --data-urlencode "primaryNodeUsername=admin" \
     --data-urlencode "primaryNodePassword=${DNS_SERVER_ADMIN_PASSWORD}" \
     --data-urlencode "secondaryNodeIpAddresses=${DNS_CLUSTER_NODE_IP}" \


### PR DESCRIPTION
## Problem

Secondary Technitium DNS nodes on Luna and Skystar were failing to join the cluster due to three bugs in `init.sh`.

## Root Causes

### Bug 1 & 2: Cluster status check always returned "not in cluster"

The script called `admin/cluster/get` (non-existent endpoint → always errors) and checked `response.enabled` (non-existent field). This meant `in_cluster` was **always `false`**, causing every `init.sh` run to attempt a re-join.

| | Was | Now |
|---|---|---|
| Endpoint | `admin/cluster/get` | `admin/cluster/state` |
| Field | `response.enabled` | `response.clusterInitialized` |

### Bug 3: TLS certificate validation failure on join

`initJoin` was missing `ignoreCertificateErrors=true`. The primary Technitium web service uses a self-signed cert (`DNS_SERVER_WEB_SERVICE_USE_SELF_SIGNED_CERT: "true"`), so the join handshake failed with a certificate error.

## Changes

- `docker/_common/technitium/init.sh` — fix cluster state endpoint, field name, and add `ignoreCertificateErrors=true` to `initJoin`

## Verification

Primary `https://technitium.celestia.driscoll.tech` confirmed reachable and API-healthy.