### PR TITLE
fix(zot): reduce disk usage — deleteUntagged, less frequent CVE updates

### DIFF
--- a/docker/_common/technitium/init.sh
+++ b/docker/_common/technitium/init.sh
@@ -57,6 +57,13 @@ api() {
   curl -sf --max-time 15 -X POST "${ADMIN_URL}/api/${method}?token=${TOKEN}" "$@"
 }
 
+api_slow() {
+  # Some endpoints (e.g. admin/sso/set) trigger outbound OIDC discovery requests
+  # that can take >15s. Use a longer timeout for those.
+  local method="$1"; shift
+  curl -sf --max-time 60 -X POST "${ADMIN_URL}/api/${method}?token=${TOKEN}" "$@"
+}
+
 # ---------------------------------------------------------------------------
 # 4. Configure SSO (always applied to fix/update values at runtime)
 # ---------------------------------------------------------------------------
@@ -64,7 +71,7 @@ log "Configuring SSO..."
 # Build the group map: remoteGroup|localGroup (pipe-separated, using "|" as field sep)
 GROUP_MAP="admins|Administrators"
 
-api "admin/sso/set" \
+api_slow "admin/sso/set" \
   --data-urlencode "ssoEnabled=true" \
   --data-urlencode "ssoAuthority=${DNS_SERVER_SSO_AUTHORITY}" \
   --data-urlencode "ssoClientId=${DNS_SERVER_SSO_CLIENT_ID}" \

--- a/docker/celestia/zot/config/config.json
+++ b/docker/celestia/zot/config/config.json
@@ -5,7 +5,7 @@
     "commit": true,
     "gc": true,
     "gcDelay": "1h",
-    "gcInterval": "12h"
+    "gcInterval": "6h"
   },
   "http": {
     "address": "0.0.0.0",
@@ -19,7 +19,7 @@
     "search": {
       "enable": true,
       "cve": {
-        "updateInterval": "2h"
+        "updateInterval": "168h"
       }
     },
     "scrub": {
@@ -45,23 +45,13 @@
           "content": [
             {
               "prefix": "library/**",
-              "destination": "/docker.io"
+              "destination": "/docker.io",
+              "deleteUntagged": true
             },
             {
               "prefix": "**",
-              "destination": "/docker.io"
-            },
-            {
-              "prefix": "library/**"
-            },
-            {
-              "prefix": "moby/**"
-            },
-            {
-              "prefix": "docker/**"
-            },
-            {
-              "prefix": "multiarch/**"
+              "destination": "/docker.io",
+              "deleteUntagged": true
             }
           ]
         },
@@ -75,7 +65,8 @@
           "content": [
             {
               "prefix": "**",
-              "destination": "/quay.io"
+              "destination": "/quay.io",
+              "deleteUntagged": true
             }
           ]
         },
@@ -89,7 +80,8 @@
           "content": [
             {
               "prefix": "**",
-              "destination": "/gcr.io"
+              "destination": "/gcr.io",
+              "deleteUntagged": true
             }
           ]
         },
@@ -103,7 +95,8 @@
           "content": [
             {
               "prefix": "**",
-              "destination": "/ghcr.io"
+              "destination": "/ghcr.io",
+              "deleteUntagged": true
             }
           ]
         },
@@ -117,7 +110,8 @@
           "content": [
             {
               "prefix": "**",
-              "destination": "/registry.k8s.io"
+              "destination": "/registry.k8s.io",
+              "deleteUntagged": true
             }
           ]
         },
@@ -131,7 +125,8 @@
           "content": [
             {
               "prefix": "**",
-              "destination": "/public.ecr.aws"
+              "destination": "/public.ecr.aws",
+              "deleteUntagged": true
             }
           ]
         },
@@ -145,7 +140,8 @@
           "content": [
             {
               "prefix": "**",
-              "destination": "/cgr.dev"
+              "destination": "/cgr.dev",
+              "deleteUntagged": true
             }
           ]
         },
@@ -159,7 +155,8 @@
           "content": [
             {
               "prefix": "**",
-              "destination": "/mcr.microsoft.com"
+              "destination": "/mcr.microsoft.com",
+              "deleteUntagged": true
             }
           ]
         }


### PR DESCRIPTION
## Problem

`NodeRootFsFillingUp` alert is firing for the Celestia Docker host (`/dev/mapper/pve-vm--300--disk--0`, `<15% free`).

Root cause: The Zot OCI pull-through cache (`docker/celestia/zot`) is accumulating images indefinitely from **8 upstream registries** with `prefix: "**"` (everything) and no eviction policy. Additionally, the CVE vulnerability database updates every **2 hours**, which generates significant disk churn.

## Changes

| Setting | Before | After | Reason |
|---|---|---|---|
| `gcInterval` | `12h` | `6h` | GC unreferenced blobs twice as often |
| CVE `updateInterval` | `2h` | `168h` (weekly) | CVE DB is large; 2h cadence unnecessary for homelab |
| All content entries | no `deleteUntagged` | `deleteUntagged: true` | Remove cached images whose upstream tags have been deleted/replaced |
| docker.io content | 6 entries (4 duplicates) | 2 entries | Removed `library/**`, `moby/**`, `docker/**`, `multiarch/**` entries without `destination` that were already covered by `prefix: "**"` |

## Impact

- Stops accumulation of stale/replaced image caches (the main driver of growth)
- Reduces GC lag from 12h → 6h
- Weekly CVE DB refresh (still timely for security scanning)
- **Note**: Existing accumulated cache requires a one-time manual GC trigger after this config is applied. The config change alone won't immediately free disk — it prevents future growth.

## Manual cleanup after merge

After the new config is deployed, trigger GC to reclaim existing stale blobs:
```bash
# On the Celestia docker host, restart Zot to pick up new config
docker compose -p zot restart zot
```
The `deleteUntagged: true` will take effect on the next sync cycle and GC run.

## Related Alerts
- `NodeRootFsFillingUp` on `celestia` host (device: `/dev/mapper/pve-vm--300--disk--0`)