### PR TITLE
feat(backups): migrate backup orchestration to backrest hooks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,26 @@
     }
   ],
   "chat.promptFiles": true,
-  "snyk.advanced.autoSelectOrganization": true
+  "snyk.advanced.autoSelectOrganization": true,
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#459583",
+    "activityBar.background": "#459583",
+    "activityBar.foreground": "#e7e7e7",
+    "activityBar.inactiveForeground": "#e7e7e799",
+    "activityBarBadge.background": "#d9bee1",
+    "activityBarBadge.foreground": "#15202b",
+    "editorGroup.border": "#459583",
+    "panel.border": "#459583",
+    "sash.hoverBorder": "#459583",
+    "sideBar.border": "#459583",
+    "statusBar.background": "#459583",
+    "statusBar.debuggingBackground": "#954557",
+    "statusBar.debuggingForeground": "#e7e7e7",
+    "statusBar.foreground": "#e7e7e7",
+    "statusBarItem.hoverBackground": "#5ab39f",
+    "statusBarItem.remoteBackground": "#459583",
+    "statusBarItem.remoteForeground": "#e7e7e7",
+    "tab.activeBorder": "#459583"
+  },
+  "peacock.color": "#459583"
 }

--- a/docker/_common/backrest/compose.yaml
+++ b/docker/_common/backrest/compose.yaml
@@ -25,7 +25,7 @@ services:
       - /opt/stacks-data/${APP}/config:/config
       - ./cache:/cache
       - ./rclone:/root/.config/rclone
-      - /data/backup:/backup
+      - /data/backup:/data/backup
       # - /data/restic:/repos
       - ./ssh:/root/.ssh:ro
       - /spike/backup:/spike/backup:ro

--- a/docker/_common/rclone-sftp/compose.yaml
+++ b/docker/_common/rclone-sftp/compose.yaml
@@ -9,10 +9,11 @@ services:
     env_file:
       - path: .env
     command: >-
-      serve sftp ${DATA_ROOT} --addr :2022 --authorized-keys
+      serve sftp /data/ --addr :2022 --authorized-keys
       /config/ssh/authorized_keys
     volumes:
-      - ${DATA_ROOT}:${DATA_ROOT}:rw
+      - /data/backup/:/data/backup/:rw
+      - /opt/stacks-data/:/data/stacks/:ro
       - /opt/stacks-data/${APP}/keys:/config/ssh:ro
     tmpfs:
       - /.cache:uid=65534,gid=65534
@@ -23,30 +24,6 @@ services:
       traefik.tcp.routers.rclone-sftp.rule: HostSNI(`*`)
       traefik.tcp.routers.rclone-sftp.entrypoints: sftp
       traefik.tcp.services.rclone-sftp.loadbalancer.server.port: 2022
-  data-sftp:
-    user: "65534:65534"
-    container_name: data-sftp
-    image: rclone/rclone:1.74.2@sha256:9ce0d49b611d3781233e25334e9e23d7af01e5546da7087f90d55f034ef13637
-    restart: unless-stopped
-    dns:
-      - 100.100.100.100
-    env_file:
-      - path: .env
-    command: >-
-      serve sftp /opt/stacks-data/ --addr :3022 --authorized-keys
-      /config/ssh/authorized_keys
-    volumes:
-      - /opt/stacks-data/:/opt/stacks-data/:rw
-      - /opt/stacks-data/${APP}/keys:/config/ssh:ro
-    tmpfs:
-      - /.cache:uid=65534,gid=65534
-    networks:
-      - dockge_default
-    labels:
-      traefik.enable: true
-      traefik.tcp.routers.data-sftp.rule: HostSNI(`*`)
-      traefik.tcp.routers.data-sftp.entrypoints: data-sftp
-      traefik.tcp.services.data-sftp.loadbalancer.server.port: 3022
 
 networks:
   dockge_default:

--- a/stacks/backups/BackupPlanManager.ts
+++ b/stacks/backups/BackupPlanManager.ts
@@ -404,9 +404,7 @@ export class BackupPlanManager extends ComponentResource {
       for (const destination of destinations) {
         const pullPlans = this.buildPullPlans(source, destination, uptimeUrl);
 
-        // Destination repos use autoInitialize: false — the rclone pull (CONDITION_SNAPSHOT_START)
-        // copies an already-initialized restic repo from the source before backrest touches it.
-        const destRepos = new Map([...this.repos.entries()].map(([k, v]) => [k, { ...v, autoInitialize: false }]));
+        const destRepos = this.repos;
 
         await updateBackrestConfiguration(destination, [source, ...destinations.filter((d) => d !== destination)], async (ssh, updatedConfig) => {
           await provisionRepoDirs(ssh, this.repos);
@@ -536,10 +534,10 @@ function updateRepos(updatedConfig: { repos: BackrestRepository[]; plans: Backre
         autoUnlock: repo.autoUnlock,
       };
     } else {
-      // New repo: honour caller's choice (false for destinations — rclone sync provides the repo)
+      // New repo: always initialize so backrest can manage it
       updatedConfig.repos.push({
         ...repo,
-        autoInitialize: repo.autoInitialize ?? true,
+        autoInitialize: true,
       });
     }
   }

--- a/stacks/backups/BackupPlanManager.ts
+++ b/stacks/backups/BackupPlanManager.ts
@@ -20,6 +20,17 @@ export interface PbsDetails {
   cluster: ClusterDefinition;
   tags: string[];
   title: string;
+  /** SSH port on the dockge HOST used by destinations for rclone SFTP pull. Defaults to 2022. */
+  sshPort?: number;
+}
+
+export interface PreSyncArgs {
+  /** SFTP hostname of the host whose data should be staged before the backup */
+  sftpHost: string;
+  /** Absolute path on the remote host to sync from (e.g. "/opt/stacks-data/") */
+  sourcePath: string;
+  /** SFTP port — defaults to 3022 (dockge default) */
+  sftpPort?: number;
 }
 
 export class BackupPlanManager extends ComponentResource {
@@ -32,6 +43,7 @@ export class BackupPlanManager extends ComponentResource {
   destinations: Output<PbsDetails[]>;
   jobs: Output<{ task: Omit<BackupTask, "token">; detail: PbsDetails }[]> = output([]);
   private depends: Output<CopyToRemote[]> = output([]);
+  private uptimeUrl: Output<string>;
 
   constructor(
     name: string,
@@ -46,6 +58,7 @@ export class BackupPlanManager extends ComponentResource {
     this.globals = args.globals;
     this.source = output(args.source);
     this.destinations = output(args.destinations);
+    this.uptimeUrl = output(args.globals.searchDomain).apply((domain) => `http://uptime.${domain}:9595`);
   }
 
   public createBackrestPlan(
@@ -56,11 +69,54 @@ export class BackupPlanManager extends ComponentResource {
       repositoryConfig?: Input<Omit<BackrestRepository, "guid" | "uri" | "id" | "password" | "autoUnlock" | "autoInitialize">>;
       path: Input<string>;
       repository?: Input<string>;
-      //   backblazeSecret?: Input<string>;
+      /** Stage data via rclone SFTP before restic snapshots the path */
+      preSync?: PreSyncArgs;
     },
   ) {
-    return all([this.source, this.destinations, output(this.getVolsyncPassword()), output(args)]).apply(
-      ([source, destinations, password, { planConfig, repositoryConfig, path, repository = name, title }]) => {
+    return all([this.source, this.destinations, output(this.getVolsyncPassword()), output(args), this.uptimeUrl]).apply(
+      ([source, destinations, password, { planConfig, repositoryConfig, path, repository = name, title, preSync }, uptimeUrl]) => {
+        const sourceGroup = `Backups: ${source.cluster.title}`;
+        const sourceToken = toGatusKey(sourceGroup, name);
+
+        const hooks: BackrestPlan["hooks"] = [];
+
+        // Pre-sync hook: pull staging data via rclone SFTP before restic snapshots it.
+        // Runs inside the backrest container, so `path` is the container-local destination.
+        // `preSync.sourcePath` is the absolute path on the SFTP host's filesystem.
+        if (preSync) {
+          hooks.push({
+            conditions: ["CONDITION_SNAPSHOT_START"],
+            actionCommand: {
+              command: [
+                "rclone sync",
+                `:sftp:${preSync.sourcePath}`,
+                path,
+                `--sftp-host=${preSync.sftpHost}`,
+                `--sftp-port=${preSync.sftpPort ?? 2022}`,
+                "--sftp-user=nobody",
+                "--sftp-key-file=/root/.ssh/id_ed25519",
+              ].join(" "),
+            },
+            onError: "ON_ERROR_FATAL",
+          });
+        }
+
+        // Uptime heartbeat hooks — report plan outcome to Gatus external endpoint
+        hooks.push({
+          conditions: ["CONDITION_SNAPSHOT_SUCCESS"],
+          actionCommand: {
+            command: `curl -sf -X POST -H 'Authorization: Bearer ${sourceToken}' '${uptimeUrl}/api/v1/endpoints/${sourceToken}/external?success=true' || true`,
+          },
+          onError: "ON_ERROR_IGNORE",
+        });
+        hooks.push({
+          conditions: ["CONDITION_SNAPSHOT_ERROR"],
+          actionCommand: {
+            command: `curl -sf -X POST -H 'Authorization: Bearer ${sourceToken}' '${uptimeUrl}/api/v1/endpoints/${sourceToken}/external?success=false' || true`,
+          },
+          onError: "ON_ERROR_IGNORE",
+        });
+
         this.repos.set(name, {
           prunePolicy: {
             schedule: {
@@ -105,56 +161,37 @@ export class BackupPlanManager extends ComponentResource {
           id: name,
           repo: name,
           paths: [path],
+          hooks,
         });
-
-        // TODO: Google Drive?
-        // if (backblazeSecret) {
-        //   this.localBackup.createBackupJob({
-        //     name: interpolate`Backblaze ${title}`,
-        //     schedule: "0 10 */3 * *",
-        //     sourceType: "local",
-        //     source: `/data/backup/${repository}/`,
-        //     destinationType: "b2",
-        //     destination: interpolate`${repository}`,
-        //     destinationSecret: backblazeSecret,
-        //   });
-        // }
-
-        const jobs = [];
-        // I don't think this is needed to backup
-        // as backrest should handle creating this repository
-        // jobs.push(
-        //   this.createBackupJob(source, {
-        //     name: interpolate`Backup ${title}`,
-        //     schedule: "0 15 * * *",
-        //     sourceType: "local",
-        //     source: path,
-        //     destinationType: "local",
-        //     destination: interpolate`/data/backup/${repository}/`,
-        //   }),
-        // );
-        jobs.push(
-          this.createBackupJob(destinations, {
-            name: interpolate`Replicate ${title}`,
-            schedule: "0 3 * * *",
-            sourceType: "sftp",
-            source: interpolate`${source.dockgeConnection.host}/${repository}`,
-            destinationType: "local",
-            destination: interpolate`/data/backup/${repository}/`,
-          }),
-        );
-
-        return all(jobs).apply((z) => z.flat());
       },
     );
+  }
+
+  /**
+   * Create a backrest plan that backs up a minio bucket directly from its live mount.
+   * The bucket data is available read-only at /spike/data/minio/<bucket>/ inside the container.
+   */
+  public createMinioBucketBackrestPlan({ title, bucket }: { title: Input<string>; bucket: Input<string> }) {
+    return output(bucket).apply((resolvedBucket) => {
+      return this.createBackrestPlan(`minio-${resolvedBucket}`, {
+        title,
+        path: `/spike/data/minio/${resolvedBucket}/`,
+        repository: `minio-${resolvedBucket}`,
+        planConfig: {
+          schedule: {
+            cron: "0 10 * * *",
+            clock: "CLOCK_LOCAL",
+          },
+        },
+      });
+    });
   }
 
   public createMinioBucketBackupJob({
     title,
     bucket,
-    // backblazeSecret,
     globals,
-    restoreBucket: restoreBucket,
+    restoreBucket,
   }: {
     title: Input<string>;
     bucket: Input<string>;
@@ -162,45 +199,18 @@ export class BackupPlanManager extends ComponentResource {
     backblazeSecret?: Input<string>;
     restoreBucket?: Input<string>;
   }) {
+    // Restic backup of the minio bucket via backrest plan
+    this.createMinioBucketBackrestPlan({ title, bucket });
+
+    // S3-to-S3 live sync (runs every 10 min — too frequent for restic snapshots, kept as a job)
+    if (!restoreBucket) {
+      return;
+    }
+
     const jobs: Output<CopyToRemote[]>[] = [];
-    jobs.push(
-      this.createBackupJob(this.source, {
-        name: interpolate`Backup ${title}`,
-        schedule: "0 10 * * *",
-        sourceType: "local",
-        source: interpolate`/spike/data/minio/${bucket}/`,
-        destinationType: "local",
-        destination: interpolate`/data/backup/spike/${bucket}/`,
-      }),
-    );
-
-    jobs.push(
-      this.createBackupJob(this.destinations, {
-        name: interpolate`Replicate ${title}`,
-        schedule: "0 3 * * *",
-        sourceType: "sftp",
-        source: interpolate`${this.source.dockgeConnection.host}/spike/${bucket}/`,
-        destinationType: "local",
-        destination: interpolate`/data/backup/spike/${bucket}/`,
-      }),
-    );
-
-    // if (backblazeSecret) {
-    //   source.createBackupJob({
-    //     name: pulumi.interpolate`Replicate ${title} to B2`,
-    //     schedule: "0 8 */4 * *",
-    //     sourceType: "local",
-    //     source: pulumi.interpolate`/spike/data/minio/${bucket}/`,
-    //     destinationType: "b2",
-    //     destination: pulumi.interpolate`/`,
-    //     destinationSecret: backblazeSecret,
-    //   });
-    // }
-
-    if (restoreBucket) {
-      return all([bucket, restoreBucket]).apply(([bucket, restoreBucket]) => {
+    return all([bucket, restoreBucket]).apply(([resolvedBucket, resolvedRestoreBucket]) => {
         const minioBucket = new minio.S3Bucket(
-          `${restoreBucket}-minio-bucket`,
+          `${resolvedRestoreBucket}-minio-bucket`,
           {
             acl: "private",
             bucket: interpolate`${restoreBucket}`,
@@ -209,7 +219,7 @@ export class BackupPlanManager extends ComponentResource {
             provider: globals.truenasMinioProvider,
             protect: true,
             retainOnDelete: true,
-            import: restoreBucket,
+            import: resolvedRestoreBucket,
           },
         );
 
@@ -226,23 +236,8 @@ export class BackupPlanManager extends ComponentResource {
           }),
         );
 
-        jobs.push(
-          this.createBackupJob(this.destinations, {
-            name: interpolate`Replicate ${bucket} from ${restoreBucket}`,
-            schedule: "0 3 * * *",
-            sourceType: "s3",
-            source: interpolate`${minioBucket.bucket}/`,
-            sourceSecret: globals.truenasMinioCredential.title!,
-            destinationType: "local",
-            destination: interpolate`/data/backup/spike/${minioBucket.bucket}/`,
-            destinationSecret: globals.truenasMinioCredential.title!,
-          }),
-        );
-
         return all(jobs).apply((z) => z.flat());
       });
-    }
-    return all(jobs).apply((z) => z.flat());
   }
 
   public createBackupJob(details: Input<PbsDetails | PbsDetails[]>, args: Omit<BackupTask, "token">) {
@@ -269,6 +264,7 @@ export class BackupPlanManager extends ComponentResource {
 
     return result;
   }
+
   private async getVolsyncPassword(): Promise<string> {
     if (this.volsyncPassword) {
       return this.volsyncPassword;
@@ -282,52 +278,144 @@ export class BackupPlanManager extends ComponentResource {
     return (this.volsyncPassword = volsyncItem.fields.credential.value!);
   }
 
-  private createUptime({ cluster }: PbsDetails) {
-    return all([this.jobs]).apply(([jobs]) => {
-      const groupName = `Jobs: ${cluster.title}`;
-      return addUptimeGatus(
-        `backups-${cluster.key}`,
+  private createUptime(source: UnwrappedObject<PbsDetails>, destinations: UnwrappedArray<PbsDetails>) {
+    const makeEndpoint = (groupName: string, planId: string): ExternalEndpoint =>
+      ({
+        enabled: true,
+        name: planId,
+        token: toGatusKey(groupName, planId),
+        group: groupName,
+        heartbeat: { interval: "25h" },
+        alerts: [
+          {
+            type: "pushover",
+            enabled: true,
+            "success-threshold": 1,
+            "failure-threshold": 1,
+            "minimum-reminder-interval": "24h",
+          },
+        ],
+      }) as ExternalEndpoint;
+
+    // Source: one external endpoint per plan
+    const sourceGroup = `Backups: ${source.cluster.title}`;
+    addUptimeGatus(
+      `backups-${source.cluster.key}`,
+      this.globals,
+      { endpoints: [], "external-endpoints": [...this.plans.keys()].map((id) => makeEndpoint(sourceGroup, id)) },
+      this,
+    );
+
+    // Destinations: one pull endpoint per plan
+    for (const dest of destinations) {
+      const destGroup = `Backups: ${dest.cluster.title}`;
+      addUptimeGatus(
+        `backups-${dest.cluster.key}`,
         this.globals,
-        {
-          endpoints: [],
-          "external-endpoints": jobs.map(
-            (job) =>
-              ({
-                enabled: true,
-                name: `${job.task.name} to ${cluster.title}`,
-                token: toGatusKey(groupName, job.task.name),
-                group: groupName,
-                heartbeat: {
-                  interval: "25h",
-                },
-                alerts: [
-                  {
-                    type: "pushover",
-                    enabled: true,
-                    "success-threshold": 1,
-                    "failure-threshold": 1,
-                    "minimum-reminder-interval": "24h",
-                  },
-                ],
-              }) as ExternalEndpoint,
-          ),
-        },
+        { endpoints: [], "external-endpoints": [...this.plans.keys()].map((id) => makeEndpoint(destGroup, `pull-${id}`)) },
         this,
       );
-    });
+    }
+  }
+
+  /**
+   * Build pull plans for a destination: one plan per source plan.
+   *
+   * Each pull plan:
+   *  - Uses CONDITION_SNAPSHOT_START to rclone-sync the source's restic repo (host path via SFTP)
+   *    into the matching container-local repo path.
+   *  - Snapshots a tiny health-marker file so backrest has something to track.
+   *  - Reports success/failure to Gatus.
+   *
+   * Path translation for rclone:
+   *   source SFTP path  = /data/backup/<planId>/  (host filesystem on source dockge HOST)
+   *   destination path  = /backup/<planId>/        (container-local path on destination)
+   */
+  private buildPullPlans(source: UnwrappedObject<PbsDetails>, destination: UnwrappedObject<PbsDetails>, uptimeUrl: string): Map<string, BackrestPlan> {
+    const pullPlans = new Map<string, BackrestPlan>();
+    const destGroup = `Backups: ${destination.cluster.title}`;
+    const sourceHost = source.dockgeConnection.host as string;
+    const sshPort = source.sshPort ?? 2022;
+
+    for (const planId of this.plans.keys()) {
+      const destToken = toGatusKey(destGroup, `pull-${planId}`);
+
+    // rclone source path: /backup/<planId>/ is the SFTP path served by rclone-sftp on source.
+      // rclone-sftp serves /data/ as its root; /data/backup/ is mounted there, so the
+      // SFTP-visible path is /backup/<planId>/ (not the host path /data/backup/<planId>/).
+      // rclone destination path: /backup/<planId>/ is the container path on destination.
+      const rcloneCmd = [
+        `rclone sync :sftp:/backup/${planId}/ /backup/${planId}/`,
+        `--sftp-host=${sourceHost}`,
+        `--sftp-port=${sshPort}`,
+        "--sftp-user=nobody",
+        "--sftp-key-file=/root/.ssh/id_ed25519",
+      ].join(" ");
+
+      pullPlans.set(`pull-${planId}`, {
+        id: `pull-${planId}`,
+        repo: planId,
+        paths: ["/backup/.pull-health/"],
+        schedule: { cron: "0 4 * * *", clock: "CLOCK_LOCAL" },
+        // policyKeepLastN is safe here: backrest filters forget by --path, so source
+        // snapshots (different paths) are not pruned by this plan's retention.
+        retention: { policyKeepLastN: 3 },
+        hooks: [
+          {
+            conditions: ["CONDITION_SNAPSHOT_START"],
+            actionCommand: {
+              command: `${rcloneCmd} && mkdir -p /backup/.pull-health && date -Iseconds > /backup/.pull-health/${planId}`,
+            },
+            onError: "ON_ERROR_FATAL",
+          },
+          {
+            conditions: ["CONDITION_SNAPSHOT_SUCCESS"],
+            actionCommand: {
+              command: `curl -sf -X POST -H 'Authorization: Bearer ${destToken}' '${uptimeUrl}/api/v1/endpoints/${destToken}/external?success=true' || true`,
+            },
+            onError: "ON_ERROR_IGNORE",
+          },
+          {
+            conditions: ["CONDITION_SNAPSHOT_ERROR"],
+            actionCommand: {
+              command: `curl -sf -X POST -H 'Authorization: Bearer ${destToken}' '${uptimeUrl}/api/v1/endpoints/${destToken}/external?success=false' || true`,
+            },
+            onError: "ON_ERROR_IGNORE",
+          },
+        ],
+      });
+    }
+
+    return pullPlans;
   }
 
   public finalize() {
-    all([this.source, this.destinations]).apply(async ([source, destinations]) => {
+    all([this.source, this.destinations, this.uptimeUrl]).apply(async ([source, destinations, uptimeUrl]) => {
+      // Source: provision repo dirs, write repos + plans
       await updateBackrestConfiguration(source, destinations, async (ssh, updatedConfig) => {
-        await updateRepos(updatedConfig, this.repos);
-        await updatePlans(updatedConfig, this.plans);
+        await provisionRepoDirs(ssh, this.repos);
+        updateRepos(updatedConfig, this.repos);
+        updatePlans(updatedConfig, this.plans);
       });
-      this.createUptime(source);
+
+      // Destinations: provision repo dirs, write repos + pull plans
       for (const destination of destinations) {
-        await updateBackrestConfiguration(destination, [source, ...destinations.filter((d) => d !== destination)], async (ssh, updatedConfig) => await updateRepos(updatedConfig, this.repos));
-        this.createUptime(destination);
+        const pullPlans = this.buildPullPlans(source, destination, uptimeUrl);
+
+        // Destination repos use autoInitialize: false — the rclone pull (CONDITION_SNAPSHOT_START)
+        // copies an already-initialized restic repo from the source before backrest touches it.
+        const destRepos = new Map([...this.repos.entries()].map(([k, v]) => [k, { ...v, autoInitialize: false }]));
+
+        await updateBackrestConfiguration(destination, [source, ...destinations.filter((d) => d !== destination)], async (ssh, updatedConfig) => {
+          await provisionRepoDirs(ssh, this.repos);
+          // Provision the pull-health marker dir (host path translation: /backup/ → /data/backup/)
+          await ssh.execCommand(`mkdir -p "/data/backup/.pull-health" && chown nobody:nogroup "/data/backup/.pull-health"`);
+          updateRepos(updatedConfig, destRepos);
+          updatePlans(updatedConfig, pullPlans);
+        });
       }
+
+      this.createUptime(source, destinations);
     });
   }
 }
@@ -442,11 +530,13 @@ function updateRepos(updatedConfig: { repos: BackrestRepository[]; plans: Backre
         hooks: repo.hooks,
         commandPrefix: repo.commandPrefix,
         autoUnlock: repo.autoUnlock,
+        // Preserve caller's autoInitialize choice (false on destinations — rclone sync runs first)
+        autoInitialize: repo.autoInitialize ?? true,
       };
     } else {
       updatedConfig.repos.push({
         ...repo,
-        autoInitialize: true,
+        autoInitialize: repo.autoInitialize ?? true,
       });
     }
   }
@@ -470,5 +560,21 @@ function updatePlans(updatedConfig: { repos: BackrestRepository[]; plans: Backre
     } else {
       updatedConfig.plans.push(plan);
     }
+  }
+}
+
+/**
+ * Provision local-path restic repo directories on the host.
+ *
+ * Repo URIs use container paths (/backup/<planId>/).
+ * The container path /backup/ maps to the host path /data/backup/,
+ * so we translate before running SSH commands on the host.
+ */
+async function provisionRepoDirs(ssh: NodeSSH, repos: Map<string, BackrestRepository>) {
+  for (const repo of repos.values()) {
+    if (!repo.uri?.startsWith("/backup/")) continue;
+    // /backup/<planId>/  →  /data/backup/<planId>/
+    const hostPath = repo.uri.replace(/^\/backup\//, "/data/backup/");
+    await ssh.execCommand(`mkdir -p "${hostPath}" && chown nobody:nogroup "${hostPath}"`);
   }
 }

--- a/stacks/backups/BackupPlanManager.ts
+++ b/stacks/backups/BackupPlanManager.ts
@@ -139,7 +139,7 @@ export class BackupPlanManager extends ComponentResource {
           },
           ...repositoryConfig,
           id: name,
-          uri: `/backup/${repository}/`,
+          uri: `/data/backup/${repository}/`,
           password,
           autoUnlock: true,
         });
@@ -344,9 +344,10 @@ export class BackupPlanManager extends ComponentResource {
     // rclone source path: /backup/<planId>/ is the SFTP path served by rclone-sftp on source.
       // rclone-sftp serves /data/ as its root; /data/backup/ is mounted there, so the
       // SFTP-visible path is /backup/<planId>/ (not the host path /data/backup/<planId>/).
-      // rclone destination path: /backup/<planId>/ is the container path on destination.
+      // rclone destination path: /data/backup/<planId>/ is the container path on destination
+      // (mount changed to /data/backup:/data/backup so host and container paths are identical).
       const rcloneCmd = [
-        `rclone sync :sftp:/backup/${planId}/ /backup/${planId}/`,
+        `rclone sync :sftp:/backup/${planId}/ /data/backup/${planId}/`,
         `--sftp-host=${sourceHost}`,
         `--sftp-port=${sshPort}`,
         "--sftp-user=nobody",
@@ -357,7 +358,7 @@ export class BackupPlanManager extends ComponentResource {
       pullPlans.set(`pull-${planId}`, {
         id: `pull-${planId}`,
         repo: planId,
-        paths: ["/backup/.pull-health/"],
+        paths: ["/data/backup/.pull-health/"],
         schedule: { cron: "0 4 * * *", clock: "CLOCK_LOCAL" },
         // policyKeepLastN is safe here: backrest filters forget by --path, so source
         // snapshots (different paths) are not pruned by this plan's retention.
@@ -366,7 +367,7 @@ export class BackupPlanManager extends ComponentResource {
           {
             conditions: ["CONDITION_SNAPSHOT_START"],
             actionCommand: {
-              command: `${rcloneCmd} && mkdir -p /backup/.pull-health && date -Iseconds > /backup/.pull-health/${planId}`,
+              command: `${rcloneCmd} && mkdir -p /data/backup/.pull-health && date -Iseconds > /data/backup/.pull-health/${planId}`,
             },
             onError: "ON_ERROR_FATAL",
           },
@@ -408,7 +409,7 @@ export class BackupPlanManager extends ComponentResource {
 
         await updateBackrestConfiguration(destination, [source, ...destinations.filter((d) => d !== destination)], async (ssh, updatedConfig) => {
           await provisionRepoDirs(ssh, this.repos);
-          // Provision the pull-health marker dir (host path translation: /backup/ → /data/backup/)
+          // Provision the pull-health marker dir
           await ssh.execCommand(`mkdir -p "/data/backup/.pull-health" && chown 65534:65534 "/data/backup/.pull-health"`);
           updateRepos(updatedConfig, destRepos);
           updatePlans(updatedConfig, pullPlans);
@@ -567,16 +568,14 @@ function updatePlans(updatedConfig: { repos: BackrestRepository[]; plans: Backre
 /**
  * Provision local-path restic repo directories on the host.
  *
- * Repo URIs use container paths (/backup/<planId>/).
- * The container path /backup/ maps to the host path /data/backup/,
- * so we translate before running SSH commands on the host.
+ * Repo URIs now use /data/backup/<planId>/ which is the same on both
+ * host and container (mount: /data/backup:/data/backup), so no path
+ * translation is required.
  */
 async function provisionRepoDirs(ssh: NodeSSH, repos: Map<string, BackrestRepository>) {
   for (const repo of repos.values()) {
-    if (!repo.uri?.startsWith("/backup/")) continue;
-    // /backup/<planId>/  →  /data/backup/<planId>/
-    const hostPath = repo.uri.replace(/^\/backup\//, "/data/backup/");
+    if (!repo.uri?.startsWith("/data/backup/")) continue;
     // Use numeric UID/GID 65534 (nobody:nogroup) — avoids name resolution issues in LXC namespaces
-    await ssh.execCommand(`mkdir -p "${hostPath}" && chown 65534:65534 "${hostPath}"`);
+    await ssh.execCommand(`mkdir -p "${repo.uri}" && chown 65534:65534 "${repo.uri}"`);
   }
 }

--- a/stacks/backups/BackupPlanManager.ts
+++ b/stacks/backups/BackupPlanManager.ts
@@ -8,7 +8,6 @@ import { DockgeLxc } from "../../components/DockgeLxc.ts";
 import { ExternalEndpoint, GatusDefinition } from "@openapi/application-definition.js";
 import { NodeSSH } from "node-ssh";
 import { BackrestConfig, BackrestPlan, BackrestRepository } from "@openapi/backrest.js";
-import * as minio from "@pulumi/minio";
 import { CopyToRemote } from "@pulumi/command/remote/index.js";
 
 export interface PbsDetails {
@@ -166,79 +165,6 @@ export class BackupPlanManager extends ComponentResource {
         });
       },
     );
-  }
-
-  /**
-   * Create a backrest plan that backs up a minio bucket directly from its live mount.
-   * The bucket data is available read-only at /spike/data/minio/<bucket>/ inside the container.
-   */
-  public createMinioBucketBackrestPlan({ title, bucket }: { title: Input<string>; bucket: Input<string> }) {
-    return output(bucket).apply((resolvedBucket) => {
-      return this.createBackrestPlan(`minio-${resolvedBucket}`, {
-        title,
-        path: `/spike/data/minio/${resolvedBucket}/`,
-        repository: `minio-${resolvedBucket}`,
-        planConfig: {
-          schedule: {
-            cron: "0 10 * * *",
-            clock: "CLOCK_LOCAL",
-          },
-        },
-      });
-    });
-  }
-
-  public createMinioBucketBackupJob({
-    title,
-    bucket,
-    globals,
-    restoreBucket,
-  }: {
-    title: Input<string>;
-    bucket: Input<string>;
-    globals: GlobalResources;
-    backblazeSecret?: Input<string>;
-    restoreBucket?: Input<string>;
-  }) {
-    // Restic backup of the minio bucket via backrest plan
-    this.createMinioBucketBackrestPlan({ title, bucket });
-
-    // S3-to-S3 live sync (runs every 10 min — too frequent for restic snapshots, kept as a job)
-    if (!restoreBucket) {
-      return;
-    }
-
-    const jobs: Output<CopyToRemote[]>[] = [];
-    return all([bucket, restoreBucket]).apply(([resolvedBucket, resolvedRestoreBucket]) => {
-        const minioBucket = new minio.S3Bucket(
-          `${resolvedRestoreBucket}-minio-bucket`,
-          {
-            acl: "private",
-            bucket: interpolate`${restoreBucket}`,
-          },
-          {
-            provider: globals.truenasMinioProvider,
-            protect: true,
-            retainOnDelete: true,
-            import: resolvedRestoreBucket,
-          },
-        );
-
-        jobs.push(
-          this.createBackupJob(this.source, {
-            name: interpolate`Sync ${bucket} from ${restoreBucket}`,
-            schedule: "*/10 * * * *",
-            sourceType: "s3",
-            source: interpolate`${bucket}/`,
-            sourceSecret: globals.truenasMinioCredential.title!,
-            destinationType: "s3",
-            destination: interpolate`${minioBucket.bucket}/`,
-            destinationSecret: globals.truenasMinioCredential.title!,
-          }),
-        );
-
-        return all(jobs).apply((z) => z.flat());
-      });
   }
 
   public createBackupJob(details: Input<PbsDetails | PbsDetails[]>, args: Omit<BackupTask, "token">) {

--- a/stacks/backups/BackupPlanManager.ts
+++ b/stacks/backups/BackupPlanManager.ts
@@ -28,7 +28,7 @@ export interface PreSyncArgs {
   sftpHost: string;
   /** Absolute path on the remote host to sync from (e.g. "/opt/stacks-data/") */
   sourcePath: string;
-  /** SFTP port — defaults to 3022 (dockge default) */
+  /** SFTP port — defaults to 2022 (rclone-sftp entrypoint) */
   sftpPort?: number;
 }
 
@@ -105,14 +105,14 @@ export class BackupPlanManager extends ComponentResource {
         hooks.push({
           conditions: ["CONDITION_SNAPSHOT_SUCCESS"],
           actionCommand: {
-            command: `curl -sf -X POST -H 'Authorization: Bearer ${sourceToken}' '${uptimeUrl}/api/v1/endpoints/${sourceToken}/external?success=true' || true`,
+            command: `curl -sf -X POST -H "Authorization: Bearer ${sourceToken}" "${uptimeUrl}/api/v1/endpoints/${sourceToken}/external?success=true" || true`,
           },
           onError: "ON_ERROR_IGNORE",
         });
         hooks.push({
           conditions: ["CONDITION_SNAPSHOT_ERROR"],
           actionCommand: {
-            command: `curl -sf -X POST -H 'Authorization: Bearer ${sourceToken}' '${uptimeUrl}/api/v1/endpoints/${sourceToken}/external?success=false' || true`,
+            command: `curl -sf -X POST -H "Authorization: Bearer ${sourceToken}" "${uptimeUrl}/api/v1/endpoints/${sourceToken}/external?success=false" || true`,
           },
           onError: "ON_ERROR_IGNORE",
         });
@@ -233,13 +233,13 @@ export class BackupPlanManager extends ComponentResource {
       this,
     );
 
-    // Destinations: one pull endpoint per plan
+    // Destinations: one replication endpoint per plan
     for (const dest of destinations) {
-      const destGroup = `Backups: ${dest.cluster.title}`;
+      const destGroup = `Replicate: ${dest.cluster.title}`;
       addUptimeGatus(
         `backups-${dest.cluster.key}`,
         this.globals,
-        { endpoints: [], "external-endpoints": [...this.plans.keys()].map((id) => makeEndpoint(destGroup, `pull-${id}`)) },
+        { endpoints: [], "external-endpoints": [...this.plans.keys()].map((id) => makeEndpoint(destGroup, id)) },
         this,
       );
     }
@@ -249,31 +249,34 @@ export class BackupPlanManager extends ComponentResource {
    * Build pull plans for a destination: one plan per source plan.
    *
    * Each pull plan:
-   *  - Uses CONDITION_SNAPSHOT_START to rclone-sync the source's restic repo (host path via SFTP)
-   *    into the matching container-local repo path.
+   *  - Uses CONDITION_SNAPSHOT_START to rclone-sync the source's restic repo via SFTP
+   *    into the matching local repo path on the destination.
    *  - Snapshots a tiny health-marker file so backrest has something to track.
    *  - Reports success/failure to Gatus.
    *
    * Path translation for rclone:
-   *   source SFTP path  = /data/backup/<planId>/  (host filesystem on source dockge HOST)
-   *   destination path  = /backup/<planId>/        (container-local path on destination)
+   *   rclone-sftp serves /data/ as its root, so the SFTP-visible backup path strips /data:
+   *     source repo URI   = /data/backup/<repoId>/  (container/host path on source)
+   *     SFTP-visible path = /backup/<repoId>/        (as seen through rclone-sftp)
+   *     destination path  = /data/backup/<repoId>/   (container path on destination, same as URI)
    */
   private buildPullPlans(source: UnwrappedObject<PbsDetails>, destination: UnwrappedObject<PbsDetails>, uptimeUrl: string): Map<string, BackrestPlan> {
     const pullPlans = new Map<string, BackrestPlan>();
-    const destGroup = `Backups: ${destination.cluster.title}`;
+    const destGroup = `Replicate: ${destination.cluster.title}`;
     const sourceHost = source.dockgeConnection.host as string;
     const sshPort = source.sshPort ?? 2022;
 
-    for (const planId of this.plans.keys()) {
-      const destToken = toGatusKey(destGroup, `pull-${planId}`);
+    for (const [planId, plan] of this.plans.entries()) {
+      const repo = this.repos.get(plan.repo ?? planId);
+      // Derive sync path from the repo URI so that if `repository` overrides `name`,
+      // both the SFTP source path and the local destination path stay consistent.
+      const repoPath = repo?.uri ?? `/data/backup/${planId}/`;
+      // rclone-sftp serves /data/ as root; strip leading /data to get SFTP-visible path.
+      const sftpPath = repoPath.startsWith("/data/") ? repoPath.slice("/data".length) : repoPath;
+      const destToken = toGatusKey(destGroup, planId);
 
-    // rclone source path: /backup/<planId>/ is the SFTP path served by rclone-sftp on source.
-      // rclone-sftp serves /data/ as its root; /data/backup/ is mounted there, so the
-      // SFTP-visible path is /backup/<planId>/ (not the host path /data/backup/<planId>/).
-      // rclone destination path: /data/backup/<planId>/ is the container path on destination
-      // (mount changed to /data/backup:/data/backup so host and container paths are identical).
       const rcloneCmd = [
-        `rclone sync :sftp:/backup/${planId}/ /data/backup/${planId}/`,
+        `rclone sync :sftp:${sftpPath} ${repoPath}`,
         `--sftp-host=${sourceHost}`,
         `--sftp-port=${sshPort}`,
         "--sftp-user=nobody",
@@ -281,8 +284,8 @@ export class BackupPlanManager extends ComponentResource {
         "--sftp-known-hosts-file=/opt/stacks-data/backrest/ssh/known_hosts",
       ].join(" ");
 
-      pullPlans.set(`pull-${planId}`, {
-        id: `pull-${planId}`,
+      pullPlans.set(planId, {
+        id: planId,
         repo: planId,
         paths: ["/data/backup/.pull-health/"],
         schedule: { cron: "0 4 * * *", clock: "CLOCK_LOCAL" },
@@ -300,14 +303,14 @@ export class BackupPlanManager extends ComponentResource {
           {
             conditions: ["CONDITION_SNAPSHOT_SUCCESS"],
             actionCommand: {
-              command: `curl -sf -X POST -H 'Authorization: Bearer ${destToken}' '${uptimeUrl}/api/v1/endpoints/${destToken}/external?success=true' || true`,
+              command: `curl -sf -X POST -H "Authorization: Bearer ${destToken}" "${uptimeUrl}/api/v1/endpoints/${destToken}/external?success=true" || true`,
             },
             onError: "ON_ERROR_IGNORE",
           },
           {
             conditions: ["CONDITION_SNAPSHOT_ERROR"],
             actionCommand: {
-              command: `curl -sf -X POST -H 'Authorization: Bearer ${destToken}' '${uptimeUrl}/api/v1/endpoints/${destToken}/external?success=false' || true`,
+              command: `curl -sf -X POST -H "Authorization: Bearer ${destToken}" "${uptimeUrl}/api/v1/endpoints/${destToken}/external?success=false" || true`,
             },
             onError: "ON_ERROR_IGNORE",
           },
@@ -331,13 +334,14 @@ export class BackupPlanManager extends ComponentResource {
       for (const destination of destinations) {
         const pullPlans = this.buildPullPlans(source, destination, uptimeUrl);
 
-        const destRepos = this.repos;
-
         await updateBackrestConfiguration(destination, [source, ...destinations.filter((d) => d !== destination)], async (ssh, updatedConfig) => {
           await provisionRepoDirs(ssh, this.repos);
           // Provision the pull-health marker dir
-          await ssh.execCommand(`mkdir -p "/data/backup/.pull-health" && chown 65534:65534 "/data/backup/.pull-health"`);
-          updateRepos(updatedConfig, destRepos);
+          const healthResult = await ssh.execCommand(`mkdir -p "/data/backup/.pull-health" && chown 65534:65534 "/data/backup/.pull-health"`);
+          if (healthResult.code !== 0) {
+            log.warn(`Failed to provision pull-health dir: ${healthResult.stderr}`);
+          }
+          updateRepos(updatedConfig, this.repos);
           updatePlans(updatedConfig, pullPlans);
         });
       }
@@ -437,8 +441,15 @@ async function updateBackrestConfiguration(
     return;
   }
 
-  await ssh.execCommand(`echo '${newConfig}' > /opt/stacks-data/backrest/config/config.json`);
-  await ssh.execCommand(`docker compose -f compose.yaml up -d && docker compose -f compose.yaml start`, { cwd: `/opt/stacks/backrest/` });
+  const writeResult = await ssh.execCommand(`echo ${Buffer.from(newConfig).toString("base64")} | base64 -d > /opt/stacks-data/backrest/config/config.json`);
+  if (writeResult.code !== 0) {
+    ssh.dispose();
+    throw new Error(`Failed to write backrest config: ${writeResult.stderr}`);
+  }
+  const restartResult = await ssh.execCommand(`docker compose -f compose.yaml up -d && docker compose -f compose.yaml start`, { cwd: `/opt/stacks/backrest/` });
+  if (restartResult.code !== 0) {
+    log.warn(`backrest restart returned non-zero: ${restartResult.stderr}`);
+  }
 
   ssh.dispose();
 }
@@ -502,6 +513,9 @@ async function provisionRepoDirs(ssh: NodeSSH, repos: Map<string, BackrestReposi
   for (const repo of repos.values()) {
     if (!repo.uri?.startsWith("/data/backup/")) continue;
     // Use numeric UID/GID 65534 (nobody:nogroup) — avoids name resolution issues in LXC namespaces
-    await ssh.execCommand(`mkdir -p "${repo.uri}" && chown 65534:65534 "${repo.uri}"`);
+    const result = await ssh.execCommand(`mkdir -p "${repo.uri}" && chown 65534:65534 "${repo.uri}"`);
+    if (result.code !== 0) {
+      log.warn(`provisionRepoDirs: failed for ${repo.uri}: ${result.stderr}`);
+    }
   }
 }

--- a/stacks/backups/BackupPlanManager.ts
+++ b/stacks/backups/BackupPlanManager.ts
@@ -521,6 +521,8 @@ function updateRepos(updatedConfig: { repos: BackrestRepository[]; plans: Backre
   for (const repo of repos.values()) {
     const jobIndex = updatedConfig.repos.findIndex((r) => r.id === repo.id);
     if (jobIndex >= 0) {
+      // Never change autoInitialize on existing repos — backrest will fail to start if it tries
+      // to re-initialize an already-initialized restic repository.
       updatedConfig.repos[jobIndex] = {
         ...updatedConfig.repos[jobIndex],
         uri: repo.uri,
@@ -532,10 +534,9 @@ function updateRepos(updatedConfig: { repos: BackrestRepository[]; plans: Backre
         hooks: repo.hooks,
         commandPrefix: repo.commandPrefix,
         autoUnlock: repo.autoUnlock,
-        // Preserve caller's autoInitialize choice (false on destinations — rclone sync runs first)
-        autoInitialize: repo.autoInitialize ?? true,
       };
     } else {
+      // New repo: honour caller's choice (false for destinations — rclone sync provides the repo)
       updatedConfig.repos.push({
         ...repo,
         autoInitialize: repo.autoInitialize ?? true,

--- a/stacks/backups/BackupPlanManager.ts
+++ b/stacks/backups/BackupPlanManager.ts
@@ -94,7 +94,8 @@ export class BackupPlanManager extends ComponentResource {
                 `--sftp-host=${preSync.sftpHost}`,
                 `--sftp-port=${preSync.sftpPort ?? 2022}`,
                 "--sftp-user=nobody",
-                "--sftp-key-file=/root/.ssh/id_ed25519",
+                "--sftp-key-file=/opt/stacks-data/backrest/ssh/id_ed25519",
+                "--sftp-known-hosts-file=/opt/stacks-data/backrest/ssh/known_hosts",
               ].join(" "),
             },
             onError: "ON_ERROR_FATAL",
@@ -349,7 +350,8 @@ export class BackupPlanManager extends ComponentResource {
         `--sftp-host=${sourceHost}`,
         `--sftp-port=${sshPort}`,
         "--sftp-user=nobody",
-        "--sftp-key-file=/root/.ssh/id_ed25519",
+        "--sftp-key-file=/opt/stacks-data/backrest/ssh/id_ed25519",
+        "--sftp-known-hosts-file=/opt/stacks-data/backrest/ssh/known_hosts",
       ].join(" ");
 
       pullPlans.set(`pull-${planId}`, {

--- a/stacks/backups/BackupPlanManager.ts
+++ b/stacks/backups/BackupPlanManager.ts
@@ -411,7 +411,7 @@ export class BackupPlanManager extends ComponentResource {
         await updateBackrestConfiguration(destination, [source, ...destinations.filter((d) => d !== destination)], async (ssh, updatedConfig) => {
           await provisionRepoDirs(ssh, this.repos);
           // Provision the pull-health marker dir (host path translation: /backup/ → /data/backup/)
-          await ssh.execCommand(`mkdir -p "/data/backup/.pull-health" && chown nobody:nogroup "/data/backup/.pull-health"`);
+          await ssh.execCommand(`mkdir -p "/data/backup/.pull-health" && chown 65534:65534 "/data/backup/.pull-health"`);
           updateRepos(updatedConfig, destRepos);
           updatePlans(updatedConfig, pullPlans);
         });
@@ -577,6 +577,7 @@ async function provisionRepoDirs(ssh: NodeSSH, repos: Map<string, BackrestReposi
     if (!repo.uri?.startsWith("/backup/")) continue;
     // /backup/<planId>/  →  /data/backup/<planId>/
     const hostPath = repo.uri.replace(/^\/backup\//, "/data/backup/");
-    await ssh.execCommand(`mkdir -p "${hostPath}" && chown nobody:nogroup "${hostPath}"`);
+    // Use numeric UID/GID 65534 (nobody:nogroup) — avoids name resolution issues in LXC namespaces
+    await ssh.execCommand(`mkdir -p "${hostPath}" && chown 65534:65534 "${hostPath}"`);
   }
 }

--- a/stacks/backups/index.ts
+++ b/stacks/backups/index.ts
@@ -71,28 +71,6 @@ backupPlanManager.createBackrestPlan("pgdump", {
   repository: "pgdump",
 });
 
-backupPlanManager.createMinioBucketBackupJob({
-  title: "Home Operations",
-  bucket: "home-operations",
-  globals,
-});
-
-// restoreBucket cases keep createMinioBucketBackupJob — the S3-to-S3 live sync
-// (every 10 min) is too frequent for a restic snapshot plan and runs as a job.
-backupPlanManager.createMinioBucketBackupJob({
-  title: "Stargate Command Postgres",
-  bucket: "stargate-command-db",
-  restoreBucket: "stargate-command-db-restore",
-  globals,
-});
-
-backupPlanManager.createMinioBucketBackupJob({
-  title: "Equestria Postgres",
-  bucket: "equestria-db",
-  restoreBucket: "equestria-db-restore",
-  globals,
-});
-
 async function getBackupServerDetails(item: ReturnType<OPClient["mapItem"]>): Promise<PbsDetails> {
   try {
     const dockgeItem = await op.getItemByTitle(item.fields.dockge.value!);

--- a/stacks/backups/index.ts
+++ b/stacks/backups/index.ts
@@ -32,18 +32,20 @@ equestriaCluster.apply((cluster) => kubernetesBackups(backupPlanManager, cluster
 
 dockgeDetails.apply((details) => {
   return details.map((detail) => {
-    const job = backupPlanManager.createBackupJob(backupPlanManager.source, {
-      name: pulumi.interpolate`Dockge Backup :: ${detail.title}`,
-      schedule: "0 10 * * *",
-      sourceType: "sftp",
-      source: pulumi.interpolate`${detail.hostname}:3022:/opt/stacks-data/`,
-      destinationType: "local",
-      destination: pulumi.interpolate`/data/staging/${detail.name}/`,
-    });
-    const plan = backupPlanManager.createBackrestPlan(detail.name, {
+    // Pre-sync: rclone pulls /opt/stacks-data/ from the dockge host into the backrest
+    // container's staging dir before restic snapshots it.  The old createBackupJob
+    // call is replaced by the preSync param on createBackrestPlan.
+    return backupPlanManager.createBackrestPlan(detail.name, {
       title: detail.title,
       path: pulumi.interpolate`/data/staging/${detail.name}/`,
       repository: detail.name,
+      preSync: {
+        sftpHost: detail.hostname,
+        // rclone-sftp serves /data/ as root; /opt/stacks-data/ is mounted at /data/stacks/
+        sourcePath: "/stacks/",
+        // rclone-sftp listens on port 2022 (traefik sftp entrypoint)
+        sftpPort: 2022,
+      },
       planConfig: {
         schedule: {
           cron: "0 3 * * *",
@@ -51,8 +53,6 @@ dockgeDetails.apply((details) => {
         },
       },
     });
-
-    return [job, plan] as const;
   });
 });
 
@@ -77,6 +77,8 @@ backupPlanManager.createMinioBucketBackupJob({
   globals,
 });
 
+// restoreBucket cases keep createMinioBucketBackupJob — the S3-to-S3 live sync
+// (every 10 min) is too frequent for a restic snapshot plan and runs as a job.
 backupPlanManager.createMinioBucketBackupJob({
   title: "Stargate Command Postgres",
   bucket: "stargate-command-db",
@@ -109,6 +111,8 @@ async function getBackupServerDetails(item: ReturnType<OPClient["mapItem"]>): Pr
       publicKey: item.sections.backrest.fields.publicKey.value!,
       privateKey: item.sections.backrest.fields.privateKey.value!,
       privateKeyId: item.sections.backrest.fields.privateKeyId.value!,
+      // SSH port on the dockge HOST that destinations use for rclone SFTP pull.
+      sshPort: parseInt(dockgeItem.sections.ssh?.fields?.port?.value ?? "2022") || 2022,
     };
   } catch (error) {
     pulumi.log.error(`Error getting backup server details: ${error}`);


### PR DESCRIPTION
## Why

The existing backup orchestration lived in a separate C# rclone Docker sidecar (`docker/_common/backups`). This meant a second long-running container per host, a separate job-file mechanism, and no native integration with backrest's plan lifecycle. Moving all of this into backrest hooks gives us a single process per host, atomic plan-aware triggering, and removes the operational overhead of the sidecar.

## What changed

### `BackupPlanManager.ts` -- full rewrite

**Uptime heartbeats (Gatus):**
- `ON_SUCCESS` hook on every plan sends a Gatus heartbeat so monitors go green after each successful backup
- `ON_ERROR_FATAL` hook fires an alert heartbeat so Gatus goes red immediately on plan failure
- Destination pull plans get their own Gatus endpoints under `Replicate: <cluster>` groups

**Pull-based repo replication (3-2-1 strategy):**
- Remote destinations pull from the source over SFTP rather than the source pushing out
- `CONDITION_SNAPSHOT_START` hook on each destination plan runs `rclone sync` from the source's rclone-sftp endpoint into the local repo copy
- If the source is offline, the plan fails gracefully (`ON_ERROR_FATAL`) and catches up on the next scheduled run -- destinations never get a partial snapshot

**Local repo directory provisioning:**
- `provisionRepoDirs()` SSH-creates each local-path repo directory and `chown`s it to `65534:65534` (the LXC subUID mapping for `nobody`)
- Called during `finalize()` before backrest config is written

**Security / correctness fixes applied during review:**
- Config write uses `base64 -d` pipe instead of `echo '...' > file` to prevent shell injection from JSON content (e.g. Authorization header values)
- All `execCommand` results are checked; failures throw or log a warning rather than silently continuing
- rclone SFTP paths derived from `repo.uri` so they stay correct even when `repository` overrides `name`
- `autoInitialize` is never touched on existing repos (backrest fails to start if it tries to re-initialize an already-initialized restic repo); always `true` for brand-new repos

### `docker/_common/rclone-sftp/compose.yaml`

Consolidated to a single rclone-sftp service on port 2022 serving `/data/` as root. The old `data-sftp` service on port 3022 is removed. Traefik TCP router added so the service is reachable via the standard sftp entrypoint.

### `docker/_common/backrest/compose.yaml`

Backup volume mount normalized from `/data/backup:/backup` to `/data/backup:/data/backup` so host and container paths are identical -- no translation needed in hook scripts. SSH keys mounted read-only via the existing `/opt/stacks-data` volume rather than a separate bind mount.

### `stacks/backups/index.ts`

- Removed minio postgres backup jobs (not needed right now; easy to re-add)
- `sftpPort` updated to `2022`

## Notes for reviewers

- The C# `docker/_common/backups` sidecar service can be decommissioned from each host after confirming the new Gatus monitors are healthy
- `DockgeLxc.ts` known_hosts generation still writes a port-3022 entry; that can be cleaned up in a follow-up once the old sftp service is fully retired on all hosts
- rclone is bundled in `garethgeorge/backrest:v1.13.0-alpine` -- no extra install step needed