### PR TITLE
fix(technitium): move hostname to tailscale netns owner

### DIFF
--- a/docker/_common/technitium/compose.yaml
+++ b/docker/_common/technitium/compose.yaml
@@ -2,6 +2,9 @@ services:
   tailscale:
     image: tailscale/tailscale:latest@sha256:25cde9ad76020b0e29229136d0c38b5962e9a0e1774ffac9b0df68e4a37d6cf0
     container_name: technitium-ts
+    # hostname lives on the netns owner; technitium shares this namespace and
+    # therefore cannot set its own hostname (network_mode: service:tailscale)
+    hostname: ${CLUSTER_KEY}
     restart: unless-stopped
     dns:
       - 100.100.100.100
@@ -69,7 +72,6 @@ services:
     restart: unless-stopped
     image: technitium/dns-server:15.2.0@sha256:23d3b63d959e997800b095fe93009b3fae271b5258234ff2ade8535cb33682c8
     container_name: technitium
-    hostname: ${CLUSTER_KEY}
     network_mode: service:tailscale
     depends_on:
       tailscale:


### PR DESCRIPTION
## Problem

`home-operations` and `ocracoke` Pulumi stacks have been failing since commit `9c92e7e` (2026-06-28) with:

```
Container technitium  Error response from daemon: conflicting options: hostname and the network mode
```

That commit switched the technitium service to `network_mode: service:tailscale`, but the pre-existing `hostname: ${CLUSTER_KEY}` (added in `824e0e6`) was left in place. A container that joins another container's network namespace cannot set its own hostname — Docker rejects the compose.

## Fix

Move `hostname: ${CLUSTER_KEY}` to the `tailscale` service (the netns owner) and remove it from `technitium`. The shared namespace still gets the intended hostname.

## Impact

Unblocks the `home-operations` and `ocracoke` Pulumi stacks (Dockge deploy of the technitium stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)