### PR TITLE
fix(dns): reuse generic record name for technitium A record

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -1033,7 +1033,13 @@ export class DockgeLxc extends ComponentResource {
 
     return hostname.apply(h =>
       StandardDns.create(
-        `${this.shortName}-technitium-dns`,
+        // Deliberately reuses the name the generic loop above would have produced for this
+        // host (`${stackName}-dns-${host_with_underscores}`). Both records carry the same DNS
+        // name, and Pulumi runs creates before deletes — so introducing this as a *new*
+        // resource would try to create the A record while the generic CNAME still exists and
+        // fail with Cloudflare 81054. Keeping the name makes it a replacement of the resource
+        // already in state, which `deleteBeforeReplace` turns into delete-then-create.
+        `technitium-dns-${h.replace(/\./g, "_")}`,
         {
           hostname: h,
           ipAddress,


### PR DESCRIPTION
The technitium DNS record and the generic CNAME-to-host record produced by the compose Host() loop both target `${CLUSTER_KEY}.dns.${ROOT_DOMAIN}`. Introducing the technitium record under a new Pulumi name made it a *create* while the generic record became a *delete* — and Pulumi runs creates before deletes, so the A record was created against a name Cloudflare still had a CNAME on:

  81054: A CNAME record with that host already exists.

This stalled home-operations, gulf-of-mexico and ocracoke after 3 retries.

Naming the technitium record `technitium-dns-<host_with_underscores>` — what the generic loop would have produced — keeps it the same logical resource, so the CNAME -> A transition becomes a replacement that `deleteBeforeReplace` resolves as delete-then-create.