### PR TITLE
fix(dns): reach technitium via tailnet name from all environments

### DIFF
--- a/components/globals.ts
+++ b/components/globals.ts
@@ -99,7 +99,14 @@ export class GlobalResources extends ComponentResource {
     this.technitiumProvider = new TechnitiumProvider(
       "technitium",
       {
-        serverUrl: interpolate`https://${this.technitiumCredential.hostname}`,
+        // The cluster primary's tailnet name resolves everywhere: MagicDNS
+        // returns the tailscale IP for local runs, and the tailscale operator's
+        // nameserver (dnsrecords ConfigMap) returns the dns-celestia egress
+        // service IP for pulumi-operator workspace pods.
+        serverUrl: interpolate`https://dns-celestia.${this.tailscaleDomain}:53443`,
+        // The tailnet name doesn't match the LE certificate — validate TLS
+        // against the real hostname from the credential item (sans port).
+        tlsServerName: this.technitiumCredential.hostname.apply(h => h.split(":")[0]),
         apiToken: this.technitiumCredential.credential,
       },
       cro,


### PR DESCRIPTION
The technitium provider pinged https://celestia.dns.driscoll.tech:53443, which resolves to a tailscale IP that pulumi-operator workspace pods cannot reach — every operator-run stack now fails at provider setup. Switch to the cluster primary's tailnet name (`dns-celestia.<tailnet>:53443`): MagicDNS resolves it for local runs, and the tailscale operator's dnsrecords nameserver resolves it to the dns-celestia egress ClusterIP in-cluster. `tlsServerName` pins certificate validation to the real hostname from the 'Technitium ApiKey' item.

Requires the cluster-side companion PRs that add 53443 to the egress services: stargate-command-cluster#1680, equestria-cluster#2889 (merge those first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)