### PR TITLE
fix(dns): exclude k8s nodes from tailnet nameservers until stable

### DIFF
--- a/stacks/unifi-network/acl-manager.ts
+++ b/stacks/unifi-network/acl-manager.ts
@@ -454,10 +454,16 @@ export function assignTailscaleAcls(globals: GlobalResources): pulumi.Output<any
         // Technitium cluster nodes only — AdGuard (primary-dns / dockge-as) is
         // retired from tailnet resolution; its host entries and grants remain
         // until decommission.
-        nameservers: dnsNodes.map(node => ({
-          address: node.ip,
-          useWithExitNode: false,
-        })),
+        // TEMPORARY: the k8s nodes are excluded until they hold the zone and
+        // survive cluster sync (equestria segfaults on synced TLS settings
+        // without certs; sgc's zone transfers can't reach the primary) — see
+        // memory: technitium-split-horizon-standarddns.
+        nameservers: dnsNodes
+          .filter(node => !["dns-sgc", "dns-equestria"].includes(node.name))
+          .map(node => ({
+            address: node.ip,
+            useWithExitNode: false,
+          })),
       },
       cro,
     );


### PR DESCRIPTION
The k8s technitium nodes are in the dns-* collection but can't serve the zone yet: equestria's process segfaults (exit 139) during cluster sync — likely the synced DoT/DoQ settings referencing cert paths that don't exist in the pod — and sgc's zone transfers dead-end on the primary's tailscale IP. Their presence in the MagicDNS rotation made `{sgc,equestria}.dns.driscoll.tech` intermittently unresolvable. I've already set the live nameserver list to the three dockge nodes via the API; this makes it survive the next stack reconcile. Remove the filter after the cert-manager PKCS12 certs land and both nodes hold the zone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)