### PR TITLE
feat(dns): publish technitium cluster TLS port on the LAN

### DIFF
--- a/docker/_common/technitium/compose.yaml
+++ b/docker/_common/technitium/compose.yaml
@@ -32,6 +32,9 @@ services:
       - "853:853/tcp"
       - "853:853/udp"
       - "5380:5380/tcp"
+      # cluster/admin TLS — lets k8s secondaries reach the primary via its LAN
+      # IP (their pods cannot route tailscale addresses)
+      - "53443:53443/tcp"
     sysctls:
       - net.ipv4.ip_local_port_range=1024 65535
     # Traefik labels live here for the same reason — technitium has no network identity of its own


### PR DESCRIPTION
Companion to keeping the standalone L3 tailscale ingress for the k8s technitium nodes (instead of a sidecar): their pods can't route tailscale IPs, so the primary's zone records now include its LAN IP (10.10.18.4, added live) and this exposes 53443 there for the cluster heartbeat/sync channel. Zone transfers already work via LAN port 53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)