### PR TITLE
build: adopt hk for lint hooks (non-mutating pre-commit)

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -1,0 +1,49 @@
+amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
+
+// hk hook configuration — see david-driscoll/vault#81
+//
+// Deliberate safety posture for this repo:
+//
+//   * `fix = false` on pre-commit. hk NEVER mutates the working tree during a
+//     commit. This repo is frequently worked in by several concurrent agents
+//     sharing one checkout; an auto-fixer that rewrites files mid-commit can
+//     pick up a neighbour's unstaged edits. Auto-fixing is still available on
+//     demand via `hk fix`.
+//   * `stash = "none"` follows from the above — with no mutation there is
+//     nothing to stash, so hk never runs `git stash` and can never strand work
+//     in the stash if it is interrupted.
+//
+// Crew's own hooks are NOT re-expressed here. hk registers via git config
+// (`hook.hk-pre-commit.*`) and git 2.55 runs that channel *alongside*
+// `.git/hooks/*`, so crew's state-sync hooks keep working untouched.
+// See the PR body for why the crew state guard deliberately stays with crew.
+
+local linters = new Mapping<String, Step> {
+    // Formatter + linter. Config lives in biome.json (which already excludes sdks/).
+    ["biome"] = Builtins.biome
+
+    // Repo-hygiene guards. These are pure checks — they never rewrite a file.
+    ["check-merge-conflict"] = Builtins.check_merge_conflict
+    ["detect-private-key"] = Builtins.detect_private_key
+    ["check-added-large-files"] = Builtins.check_added_large_files
+}
+
+hooks {
+    ["pre-commit"] {
+        fix = false
+        stash = "none"
+        steps = linters
+    }
+
+    // `hk check` — read-only, used by CI and by hand.
+    ["check"] {
+        steps = linters
+    }
+
+    // `hk fix` — explicit, human-invoked auto-fix.
+    ["fix"] {
+        fix = true
+        steps = linters
+    }
+}


### PR DESCRIPTION
Part of **david-driscoll/vault#81** — migrate git hook management to [hk](https://hk.jdx.dev/) across the estate. This is the `home-operations` slice.

## What this does

Adds `hk.pkl` wiring `biome` plus three repo-hygiene guards (`check_merge_conflict`, `detect_private_key`, `check_added_large_files`).

`hk` is **already pinned** in `.config/mise.toml` (`hk = "1.53.0"`) and **already registered** in this repo's git config (`hook.hk-pre-commit.*`, `hook.hk-pre-push.*`) — but with no `hk.pkl` present it has been inert (`hk no files to run`, exit 0). This PR is what makes it live.

## Blast radius

Merging this **activates a pre-commit hook for everyone working in this repo.** That is the whole change — there is no gradual rollout. Reviewers should weigh that directly.

Mitigations baked into the config:

- **`fix = false` on pre-commit — hk never mutates the working tree during a commit.** This repo is regularly worked in by several concurrent agents sharing one checkout. An auto-fixer that rewrites files mid-commit can silently absorb a neighbour's unstaged edits. Verified empirically: on a deliberately mis-formatted staged file hk exits 1 and leaves the file byte-identical.
- **`stash = "none"`** follows from that. hk's default is `stash = "git"`; with no mutation there is nothing to stash, so hk never runs `git stash` and cannot strand work in the stash if interrupted.
- Auto-fix is still available, explicitly and on demand, via `hk fix`.

## Crew hooks are untouched

hk 1.53.0 no longer writes `.git/hooks/*` — it registers via git config. Git 2.55.0 runs **both** channels on the same commit; re-verified on the installed versions in a scratch repo (config-registered hook fires first, then the `.git/hooks/` file, and a failure in either aborts the commit). So crew's six hooks — including the five load-bearing `crew-state` sync hooks — keep running exactly as before. No crew hook is re-expressed here.

## Deliberate omissions

- **`typos`** — pinned in mise, but reports 43 findings that are overwhelmingly false positives: `Hashi` (HashiCorp), NHL abbreviations, ISO country codes in generated `sdks/`, and matches inside **sops ciphertext**. Wants a `.typos.toml` exclusion list first; that is a separate change.
- **`prettier` / `eslint`** — listed as candidates in vault#81, but this repo has neither configured and uses biome instead. Adding them would fight biome.
- **The crew state guard** — see vault#81 for the full reasoning; short version is that re-homing it into hk cannot fix the underlying bug, because crew's own hook still runs and still carries the buggy glob.

## Current noise level

`biome check` over the repo: 10 errors across 109 files (9 formatting, 1 `a11y/useButtonType` in `dashboard/resources/temp.html`). Pre-commit only sees staged files, so day-to-day friction is lower than that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)