### PR TITLE
fix(dns): stop adopting UniFi records via `import`

### DIFF
--- a/components/StandardDns.ts
+++ b/components/StandardDns.ts
@@ -6,7 +6,7 @@ import * as cloudflare from "@pulumi/cloudflare";
 import { all, ComponentResource, type ComponentResourceOptions, getStack, type Input, interpolate, mergeOptions, type Output, output } from "@pulumi/pulumi";
 import * as technitium from "@pulumi/technitium";
 import * as unifi from "@pulumiverse/unifi";
-import { addUptimeGatus, awaitOutput } from "./helpers.ts";
+import { addUptimeGatus } from "./helpers.ts";
 
 export class StandardDns extends ComponentResource {
   public readonly hostname: Output<string>;
@@ -33,8 +33,6 @@ export class StandardDns extends ComponentResource {
         throw new Error("Either ipAddress or record must be provided");
       })();
 
-    const unifiRecords = unifi.dns.getRecordsOutput({}, { provider: globals.unifiProvider });
-    const unifiRecordId = unifiRecords.results.apply(results => results.find(r => r.name === args.hostname)?.id).apply(id => (id ? `default:${id}` : undefined));
     // Deliberately NOT adopting pre-existing Cloudflare records via `import`.
     //
     // The provider's import id is `<zoneId>/<recordId>` but the id it stores in state is the
@@ -48,7 +46,28 @@ export class StandardDns extends ComponentResource {
     // reusing the old Pulumi resource name so it becomes a replacement rather than a create
     // — see the technitium record in `components/DockgeLxc.ts`.
     const cloudflareId = undefined;
-    const unifiId = await awaitOutput(unifiRecordId);
+    // Deliberately NOT adopting pre-existing UniFi records via `import` either — same
+    // structural defect as the Cloudflare half above, disarmed here on 2026-07-28.
+    //
+    // `@pulumiverse/unifi` v0.3.0 bridges `filipowm/terraform-provider-unifi` v1.1.0, whose
+    // plugin-framework importer (`internal/provider/base/importer.go`, `ImportIDWithSite`)
+    // *requires* a `<site>:<id>` import id — it errors with "ID does not contain site part.
+    // Format should be 'site:id'" otherwise — and then splits it, assigning the part after
+    // the colon to `id` and the part before it to the separate `site` attribute. So state
+    // always holds the bare `<id>` (verified: every `unifi:dns/record:Record` in state has
+    // `id: "6a67…"` alongside `site: "default"`), while the now-removed
+    // `unifi.dns.getRecordsOutput` lookup fed `default:<id>` into `import` on the record
+    // below. Those two can never be equal, so Pulumi re-ran the
+    // import step on every update — and `deleteBeforeReplace: true` on the record makes that
+    // a destroy-then-recreate of live DNS each run. This is exactly the Cloudflare failure
+    // mode, and unlike the Cloudflare lookup (which matched the short name and therefore
+    // always returned nothing) the UniFi lookup matched the full hostname, so this half was
+    // live-armed. Six UniFi records were found missing from the controller while state still
+    // claimed their ids — the signature of an interrupted destroy/re-import.
+    //
+    // Adoption of an existing UniFi record is handled the same way as Cloudflare: reuse the
+    // old Pulumi resource name so the change is a replacement rather than a create.
+    const unifiId = undefined;
     return new StandardDns(
       name,
       {


### PR DESCRIPTION
## The hazard

`components/StandardDns.ts` did a live `unifi.dns.getRecordsOutput` lookup and fed
`default:<recordId>` into the `import` resource option of a `unifi.dns.Record` that also
carries `deleteBeforeReplace: true`.

This is the **same structural defect** deliberately removed for Cloudflare in 81118ad1
(#582). `cloudflareId` was hard-coded to `undefined` there with a long explanatory
comment; the UniFi half never got the same treatment.

## Evidence that the id formats can never match

`@pulumiverse/unifi` v0.3.0 bridges `filipowm/terraform-provider-unifi` v1.1.0 (confirmed
from the provider plugin binary's embedded module paths).

Its plugin-framework importer — `internal/provider/base/importer.go`, `ImportIDWithSite` —
**requires** a `<site>:<id>` import id. The literal error string is present in the shipped
plugin binary:

> `ID does not contain site part. Format should be 'site:id'`

It then splits on the colon and assigns:

- the part **after** the colon → the resource's `id`
- the part **before** the colon → the separate `site` attribute

`dns_record` is a plugin-framework resource (`resource.ResourceWithImportState`) delegating
to that base importer, so it takes the strict path.

Every `unifi:dns/record:Record` in live Pulumi state confirms the split — bare `id`
alongside a separate `site`:

```json
{"id":"6a677f3ff95f1e0084e33299","site":"default","name":"celestia.dns.driscoll.tech"}
```

So `import: "default:6a677f3f…"` can never equal the state id `6a677f3f…`. Pulumi therefore
re-runs the import step on **every** update, and `deleteBeforeReplace: true` turns that into
a destroy-then-recreate of live DNS each run. Any interruption leaves the record simply
gone while state still claims the old id.

**The UniFi half was more dangerous than the Cloudflare half ever was.** The Cloudflare
lookup stripped the search domain while Cloudflare matches `name.exact` on the FQDN, so it
always returned nothing and `import` was effectively never set — fixing that lookup is what
armed the 2026-07-25 outage that wiped all 56 managed Cloudflare records twice. The UniFi
lookup matches on the **full** hostname and works, so this path has been live-armed the
whole time.

Corroborating: six `unifi:dns/record:Record` entries across the `gulf-of-mexico`,
`home-operations` and `ocracoke` states currently hold ids that **do not exist** on the
controller — `pbs.luna`, `pbs.celestia`, `netbootxyz`, `arcane`, `pbs.skystar`,
`backrest.skystar` (all `.driscoll.tech`). Those names are absent from the live controller
entirely. That is the exact signature of an interrupted destroy/re-import cycle.

## The fix

Same shape as 81118ad1: hard-code `unifiId = undefined`, drop the now-dead
`getRecordsOutput` lookup, and record the reasoning and date in a comment next to the
Cloudflare one. `awaitOutput` became unused in this file and was dropped from the import.

Public API is unchanged — `unifiId` was never exposed; it is internal to
`StandardDns.create` and the private constructor, both of which keep their existing
signatures. `StandardDns.create` stays `async` so no caller changes.

Adoption of a pre-existing record is handled the way it already is for Cloudflare: reuse
the old Pulumi resource name so the change is a *replacement* rather than a create.

## Verification

`npx tsc --noEmit` produces an error set identical to `main` (6 errors in
`components/helpers.ts` and `components/truenas/truenas-types.ts`, both pre-existing and
unrelated). `npx biome check components/StandardDns.ts` is clean. No `pulumi preview` was
run against a live stack.

## ⚠️ This does NOT fix the three failing stacks

`gulf-of-mexico`, `home-operations` and `ocracoke` are currently `Stalled=UpdateFailed`,
each on a `(delete)` of an orphaned `unifi:dns/record:Record` whose id no longer exists
(404 on DELETE). Those are **orphaned state entries** left behind when 189141b9 (#586)
removed `DockgeLxc.technitiumInit()` and moved ownership of `<cluster>.dns.driscoll.tech`
to `stacks/unifi-network/local-dns.ts`. The live records must stay — split-horizon DNS
depends on them.

Clearing that requires `pulumi state delete` on those URNs, which is **awaiting human
approval and has not been run**. This PR only prevents the class of bug from re-arming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
