### PR TITLE
chore(hk): align hk.pkl with pinned hk 1.53.0 and stop hk fighting crew over .crew/

### DIFF
--- a/.config/hk.pkl
+++ b/.config/hk.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
 
 local excludes = new Listing<String> {
   "**/obj/**/*"
@@ -12,6 +12,7 @@ local excludes = new Listing<String> {
   ".apm/**/*"
   ".copilot/**/*"
   ".squad/**/*"
+  ".crew/**/*"
   "**/*.verified.*"
   "**/*.received.*"
 }


### PR DESCRIPTION
Part of david-driscoll/vault#81 — "Migrate git hooks to hk (and re-home the crew state guard)".

## What

Two small fixes to `.config/hk.pkl`:

1. **Version alignment.** The pkl package import was pinned at `v1.48.0` while `.config/mise.toml` pins the `hk` tool at `1.53.0`. Bumped the import to `v1.53.0`.
2. **Exclude `.crew/`.** The exclude list still named `.squad/**/*` — crew's pre-rename directory — and never picked up `.crew/`. As a result hk's biome step tried to reformat crew-owned state (`.crew/casting/*.json`, `.crew/templates/*`), files crew rewrites itself. That is a churn loop between the two tools. `hk check --all` failed on exactly those files before this change and no longer does.

## Verification

- `hk validate` passes against the 1.53.0 import.
- `hk check --all` no longer reports the two `.crew/` biome failures. (It still reports pre-existing `end-of-file-fixer` findings in ~14 unrelated files; those are untouched here, and they do not block commits because the pre-commit hook is scoped to staged files.)
- Commit and push of this branch were both made with hk installed; hk's steps ran on the staged file and the crew sync hooks fired alongside them.

## Hook coexistence (the thing vault#81 was worried about)

hk 1.53.0 registers via git config (`hook.hk-*.command`) and leaves `.git/hooks/` untouched, so it composes with crew's six hooks rather than replacing them. Re-verified empirically on hk 1.53.0 / git 2.55.0 for **all six** crew hooks (`pre-commit`, `post-commit`, `pre-push`, `post-checkout`, `post-merge`, `post-rewrite`) — every one still fires with hk registered, in both the plain `.git/hooks` layout and the `core.hooksPath` layout the cluster repos use.

Live confirmation on this very push: crew-state advanced and `origin/crew-state` matched it, while hk's steps ran in the same `git push`.

⚠️ **One caveat worth knowing:** hk's config hook is `hk run pre-commit --from-hook`. If `hk` resolves to an *unpinned* mise shim, that command exits non-zero and **aborts the commit outright** — which also means every later hook (`post-commit`, `pre-push`, …) never runs. This repo is safe because `.config/mise.toml` pins `hk = "1.53.0"`. Any repo that registers hk hooks **must** pin hk first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)