### PR TITLE
fix(dns): stop adopting pre-existing UniFi records via `import`

### DIFF
--- a/components/StandardDns.ts
+++ b/components/StandardDns.ts
@@ -6,7 +6,7 @@ import * as cloudflare from "@pulumi/cloudflare";
 import { all, ComponentResource, type ComponentResourceOptions, getStack, type Input, interpolate, mergeOptions, type Output, output } from "@pulumi/pulumi";
 import * as technitium from "@pulumi/technitium";
 import * as unifi from "@pulumiverse/unifi";
-import { addUptimeGatus, awaitOutput } from "./helpers.ts";
+import { addUptimeGatus } from "./helpers.ts";
 
 export class StandardDns extends ComponentResource {
   public readonly hostname: Output<string>;
@@ -33,8 +33,30 @@ export class StandardDns extends ComponentResource {
         throw new Error("Either ipAddress or record must be provided");
       })();
 
-    const unifiRecords = unifi.dns.getRecordsOutput({}, { provider: globals.unifiProvider });
-    const unifiRecordId = unifiRecords.results.apply(results => results.find(r => r.name === args.hostname)?.id).apply(id => (id ? `default:${id}` : undefined));
+    // Deliberately NOT adopting pre-existing UniFi records via `import` either — same defect
+    // as Cloudflare below, confirmed against live state on 2026-07-28.
+    //
+    // The provider's import id is `<site>:<recordId>` (`default:6a12…`) but the id it stores
+    // in state is the bare `<recordId>`, so `import` can never equal the resource's own state
+    // id. This used to be fed from a live `unifi.dns.getRecordsOutput` lookup, which meant a
+    // record was created with `import: undefined` on the run that made it and then, on the
+    // very next run, the lookup found it and supplied `import: "default:<id>"`. That
+    // transition makes Pulumi plan a replace-by-import, and the `deleteBeforeReplace` below
+    // turns it into delete-then-adopt: the live record is destroyed first. If the update dies
+    // before the import checkpoint lands, the record stays deleted and state keeps the dead
+    // id — every subsequent delete then 404s and wedges the stack.
+    //
+    // Evidence at the time of removal: across gulf-of-mexico/home-operations/ocracoke, 45/45
+    // records carrying an `importID` had `importID == "default:" + id` and were healthy,
+    // while every entry that had *not* completed the cycle pointed at an id the controller no
+    // longer had — nine destroyed records in total (`pbs.luna`, `pbs.celestia`,
+    // `netbootxyz`, `arcane`, `pbs.skystar`, `backrest.skystar`, and the three
+    // `<node>.dns` records), plus three `delete: true` twins still queued to destroy the
+    // `arcane-agent.*` records they share an id with.
+    //
+    // A collision with an existing UniFi record is handled the same way as Cloudflare: reuse
+    // the old Pulumi resource name so it becomes a replacement rather than a create.
+    const unifiId = undefined;
     // Deliberately NOT adopting pre-existing Cloudflare records via `import`.
     //
     // The provider's import id is `<zoneId>/<recordId>` but the id it stores in state is the
@@ -48,7 +70,6 @@ export class StandardDns extends ComponentResource {
     // reusing the old Pulumi resource name so it becomes a replacement rather than a create
     // — see the technitium record in `components/DockgeLxc.ts`.
     const cloudflareId = undefined;
-    const unifiId = await awaitOutput(unifiRecordId);
     return new StandardDns(
       name,
       {


### PR DESCRIPTION
## What

Stops `StandardDns` from adopting pre-existing **UniFi** DNS records via the `import` resource option, mirroring the treatment Cloudflare already got in 81118ad1.

## The defect

`StandardDns.create` did a live lookup and fed the result into `import`:

```ts
const unifiRecords = unifi.dns.getRecordsOutput({}, { provider: globals.unifiProvider });
const unifiRecordId = unifiRecords.results
  .apply(results => results.find(r => r.name === args.hostname)?.id)
  .apply(id => (id ? `default:${id}` : undefined));
```

The provider's **import** id is `<site>:<recordId>` (`default:6a12…`); the id it **stores in state** is the bare `<recordId>`. They can never be equal.

Because the value comes from a live lookup, every record follows the same two-step path:

1. The run that **creates** the record has `import: undefined` — the lookup cannot see a record that does not exist yet.
2. The **next** run's lookup finds it and supplies `import: "default:<id>"`.

That `undefined → value` transition makes Pulumi plan a **replace-by-import**, and `deleteBeforeReplace: true` on the same resource turns it into *delete-then-adopt*: the live record is destroyed first. If the update dies before the import checkpoint lands, the record stays deleted and state keeps the dead id — and every later delete 404s and wedges the whole stack.

## Evidence (live state, 2026-07-28)

Across `gulf-of-mexico` / `home-operations` / `ocracoke`:

| | count |
|---|---|
| `unifi:dns/record:Record` entries | 57 |
| entries carrying an `importID` | 45 |
| `importID == id` | **0** |
| `importID == "default:" + id` | **45** |

The correlation with live controller state is exact:

- Every entry **with** an `importID` → id still exists on the controller.
- Every entry **without** an `importID` (and not a pending-delete twin) → **id no longer exists on the controller**.

Nine records were destroyed this way. Six are still missing from the controller entirely and nobody noticed, because Pulumi's state says they exist and so no plan touches them:

`pbs.luna.driscoll.tech`, `pbs.celestia.driscoll.tech`, `netbootxyz.driscoll.tech`, `arcane.driscoll.tech`, `pbs.skystar.driscoll.tech`, `backrest.skystar.driscoll.tech`

The other three are the `<node>.dns.driscoll.tech` records that currently block all three stacks; they still resolve only because `stacks/unifi-network/local-dns.ts` independently re-created them under new ids on 2026-07-27.

Three more are mid-cycle right now: `arcane-agent.{luna,as,skystar}.driscoll.tech` each have a `delete: true` twin holding **the same live record id** as their imported sibling. `pulumi preview` shows these as `delete original` — they are queued to destroy those records on the next successful update.

`unifi-network` builds its records with a plain `unifi.dns.Record` and no `import`. It has 6 records, 0 `importID`s, 0 pending deletes, and it is the only one of the four stacks that is green. Useful control group.

## Why this is safe for records already adopted

`pulumi preview` against the real `gulf-of-mexico` stack, before and after this change, produces an **identical plan for every `unifi:dns/record:Record`**:

```
before:  ~ 3 to update,  - 40 to delete,  +-52 to replace,  95 changes,  268 unchanged
after:   ~ 3 to update,  - 40 to delete,  +-51 to replace,  94 changes,  269 unchanged
```

The only step-list differences are `command:remote:CopyToRemote` / `backrest-restart` host-key churn that flips between runs regardless of this change. No DNS resource differs. Going from `import: "default:<id>"` → `import: undefined` is inert for resources already in state.

Cloudflare corroborates: since 81118ad1 there are 51 `cloudflare:index/dnsRecord:DnsRecord` entries across the three stacks with 0 `importID`s, 0 pending deletes, and 0 duplicate URNs.

## Collision handling

Unchanged in spirit from the Cloudflare note: if a `StandardDns` name collides with a record that already exists in UniFi, reuse the old Pulumi resource name so it becomes a replacement rather than a create.

## Not included here

This PR does **not** clean up the orphaned state entries that are currently wedging the three stacks, and does not defuse the three `arcane-agent` pending deletes. Those are `pulumi state delete` operations against production state and are being handled separately, under human approval. **Do not fix them with `pulumi refresh` or a re-import** — either rebinds state to the live ids and lets the queued delete wipe the records for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
