### PR TITLE
fix(unifi-network): import createTailscaleAttDropFirewallRule

### DIFF
--- a/stacks/unifi-network/index.ts
+++ b/stacks/unifi-network/index.ts
@@ -1,6 +1,7 @@
 import { GlobalResources } from "../../components/globals.ts";
 import { assignTailscaleAcls } from "./acl-manager.ts";
 import { configureLocalDns } from "./local-dns.ts";
+import { createTailscaleAttDropFirewallRule } from "./tailscale-drop-firewall-rule.ts";
 import { configureTechnitiumZones } from "./technitium-zone.ts";
 
 const globals = new GlobalResources({}, {});


### PR DESCRIPTION
## Problem

The `unifi-network` stack has been failing on every run since `f45dd79e` ("re-enable AT&T firewall rules"):

```
error: Running program '/share/source/stacks/unifi-network/index.ts' failed with an unhandled exception:
ReferenceError: createTailscaleAttDropFirewallRule is not defined
```

That commit re-enabled the call at `stacks/unifi-network/index.ts:7` but did not add the matching import. The four existing imports don't include `./tailscale-drop-firewall-rule.ts`, so the symbol is unbound at runtime.

## Fix

One line — add the missing import. `createTailscaleAttDropFirewallRule` is exported from `stacks/unifi-network/tailscale-drop-firewall-rule.ts:12` and is otherwise unchanged.

Import position follows biome's path-sorted ordering (`./acl-manager.ts`, `./local-dns.ts`, `./tailscale-drop-firewall-rule.ts`, `./technitium-zone.ts`).

## Blast radius

**Nothing was written to the UniFi controller while this was broken.** The program throws during evaluation, before any resource is registered — so no partial apply, no drift. The stack simply hasn't converged since the commit landed, which means the AT&T drop firewall rules, tailnet ACLs, local DNS, and Technitium zones have all been un-reconciled for that window.

This is distinct from the earlier `unifi-network` failure, which was a transient 502 from the controller and cleared on its own. The controller is currently healthy (HTTP 200 in 29ms).

## Verification

`biome check` clean on the changed file. The hk pre-commit suite (biome, newlines, trailing-whitespace, detect-private-key, check-added-large-files, check-merge-conflict) passed on commit.

Found by the Ralph work-monitor loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)