### PR TITLE
feat(docker): deploy homelable to celestia dockge stack

### DIFF
--- a/dashboard/externalsecret.yaml
+++ b/dashboard/externalsecret.yaml
@@ -65,6 +65,10 @@ spec:
         GRAFANA_URL: "http://grafana.observability.svc.cluster.local:3000"
         AUTHENTIK_URL: "https://authentik.driscoll.tech"
         UPTIME_URL: "https://uptime.driscoll.tech"
+        # homelable runs on the celestia dockge host; reached cross-cluster over
+        # the public name, same as UPTIME_URL / HEADLAMP_* below.
+        HOMELABLE_URL: "https://homelable.${ROOT_DOMAIN}"
+        HOMELABLE_API_KEY: "{{ .homelable_homepage_api_key }}"
         GLANCE_K8S_SGC_URL: "http://dynacat-sgc-glance.equestria.svc.cluster.local:8080"
         GLANCE_K8S_EQUESTRIA_URL: "http://dynacat-equestria-glance.equestria.svc.cluster.local:8080"
         HEADLAMP_SGC_URL: "https://headlamp.sgc.driscoll.tech"
@@ -126,6 +130,15 @@ spec:
         - regexp:
             source: "(.*)"
             target: "immich_$1"
+    - extract:
+        key: Homelable
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "homelable_$1"
     - extract:
         key: Celestia PBS Backup User
       rewrite:

--- a/dashboard/resources/homelab.yaml
+++ b/dashboard/resources/homelab.yaml
@@ -33,4 +33,35 @@
 
     - size: small
       widgets:
+        # homelable's gethomepage widget endpoint (read-only aggregate counts,
+        # X-API-Key header auth). PENDING is the one worth watching — it is the
+        # "something undeclared appeared on the network" counter, which is
+        # exactly the gap Gatus is structurally blind to.
+        - type: custom-api
+          title: Network
+          title-url: ${HOMELABLE_URL}
+          update-interval: 5m
+          url: ${HOMELABLE_URL}/api/v1/stats/summary
+          headers:
+            X-API-Key: ${HOMELABLE_API_KEY}
+            Accept: application/json
+          template: |
+            <div class="flex justify-between text-center">
+              <div>
+                  <div class="color-highlight size-h3">{{ .JSON.Int "nodes" | formatNumber }}</div>
+                  <div class="size-h6">NODES</div>
+              </div>
+              <div>
+                  <div class="color-positive size-h3">{{ .JSON.Int "online" | formatNumber }}</div>
+                  <div class="size-h6">ONLINE</div>
+              </div>
+              <div>
+                  <div class="color-negative size-h3">{{ .JSON.Int "offline" | formatNumber }}</div>
+                  <div class="size-h6">OFFLINE</div>
+              </div>
+              <div>
+                  <div class="color-highlight size-h3">{{ .JSON.Int "pending_devices" | formatNumber }}</div>
+                  <div class="size-h6">PENDING</div>
+              </div>
+            </div>
         - $include: widgets/nodes.yaml

--- a/docker/celestia/homelable/.env
+++ b/docker/celestia/homelable/.env
@@ -1,0 +1,80 @@
+# --- core -------------------------------------------------------------------
+# >= 32 bytes is a hard requirement when AUTH_MODE=oidc; the app refuses to
+# start otherwise (backend/app/core/config.py validate_auth_settings).
+SECRET_KEY="op://Eris/Homelable/secret_key"
+SQLITE_PATH=/app/data/homelab.db
+# Wildcards are rejected outright in OIDC mode, so both hostnames the app is
+# reachable on are listed explicitly.
+CORS_ORIGINS=["https://homelable.${searchDomain}","https://homelable.${tailscaleDomain}"]
+
+# --- auth: native OIDC against authentik ------------------------------------
+AUTH_MODE=oidc
+# homelable wants the *discovery document*, not the bare issuer. The pipeline
+# writes both to the generated item (components/authentik.ts:235 `issuer`,
+# :242 `openid_configuration_url`), so use the latter.
+OIDC_DISCOVERY_URL="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/openid_configuration_url"
+OIDC_CLIENT_ID="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/client_id"
+OIDC_CLIENT_SECRET="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/client_secret"
+# Single value, pinned to the searchDomain host. Login therefore only works via
+# https://homelable.${searchDomain} — which resolves over the tailnet anyway
+# through Technitium split-horizon. The tailscale router exists for parity and
+# to carry live view; it is not a second login path.
+OIDC_REDIRECT_URI="https://homelable.${searchDomain}/api/v1/auth/oidc/callback"
+OIDC_SCOPES="openid profile email"
+OIDC_COOKIE_SECURE=true
+OIDC_SESSION_EXPIRE_MINUTES=480
+# AUTH_USERNAME / AUTH_PASSWORD_HASH are AUTH_MODE=local only. Left out
+# entirely rather than shipping upstream's admin/admin default hash.
+
+# --- scanner ----------------------------------------------------------------
+# IoT (VLAN 10) and Guest (VLAN 2).
+#
+# Home is deliberately absent. It is a genuinely flat 10.10.0.0/16 with a DHCP
+# pool spanning .0.5-.254.254, so there are no /24s to scope to — and a
+# *scheduled* sweep of 65,536 addresses would push ~65k ARP requests per pass
+# into the broadcast domain, against a gateway that has already had one
+# load-spiral outage. Run the /16 as a manual, off-hours one-off from the scan
+# dialog instead, and watch gateway health while it runs.
+#
+# Guest is very likely to return nothing (client isolation); if so, drop the
+# second entry. Note these are first-run defaults only: the API persists
+# overrides to scan_config.json next to the DB, which then wins.
+SCANNER_RANGES=["192.168.100.0/24","10.1.0.0/24"]
+SCANNER_HTTP_RANGES=[]
+SCANNER_HTTP_PROBE_ENABLED=false
+# Upstream default: the prober accepts any certificate. Fine for internal
+# self-signed gear, but it is a knowing choice.
+SCANNER_HTTP_VERIFY_TLS=false
+
+# --- status checks ----------------------------------------------------------
+# Upstream default, on purpose. This runs *alongside* Gatus, not instead of it
+# — nothing is removed from Gatus, and comparable resolution is the whole
+# point: the question worth measuring is the disagreement rate between the two.
+STATUS_CHECKER_INTERVAL=60
+
+# --- live view (read-only canvas at /view?key=...) --------------------------
+# Reachable on the tailscale entrypoint only. compose.yaml blocks both /view
+# and /api/v1/liveview on websecure; see the comment there for why the data
+# endpoint has to be blocked as well as the page.
+LIVEVIEW_KEY="op://Eris/Homelable/live_view_key"
+
+# --- gethomepage stats widget (consumed by dynacat) -------------------------
+# Enables GET /api/v1/stats/summary, authenticated by the X-API-Key *header*
+# (backend/app/api/routes/stats.py) — a header, not a query string, so unlike
+# the live view key this one does not land in the traefik access log. The
+# route has no session dependency, so it works through nginx without OIDC.
+HOMEPAGE_API_KEY="op://Eris/Homelable/homepage_api_key"
+
+# --- MCP --------------------------------------------------------------------
+# MCP_API_KEY:     AI client -> MCP server (X-API-Key)
+# MCP_SERVICE_KEY: MCP server -> backend, bypassing OIDC
+# Distinct values: they authenticate different hops, and reusing one would
+# collapse two trust boundaries.
+MCP_API_KEY="op://Eris/Homelable/mcp_api_key"
+MCP_SERVICE_KEY="op://Eris/Homelable/mcp_service_key"
+
+# --- deliberately not set ---------------------------------------------------
+# PROXMOX_* — staged to a follow-up PR. The `Homelable Proxmox` 1Password item
+#   does not exist yet, and an op:// reference to a missing *item* aborts the
+#   entire stacks/home run, not just this stack.
+# ZIGBEE_* / ZWAVE_* — cross-cluster from celestia; deferred (vault#109 phase 3).

--- a/docker/celestia/homelable/compose.yaml
+++ b/docker/celestia/homelable/compose.yaml
@@ -1,0 +1,156 @@
+services:
+  # The frontend image bakes in `proxy_pass http://backend:8000` (upstream
+  # docker/nginx.conf), so the backend must answer to the bare name `backend`.
+  # That alias is scoped to the stack-private `homelable` network on purpose —
+  # claiming a name that generic on the host-wide `dockge_default` would
+  # collide with any other stack that ever adds a `backend` service.
+  homelable-backend:
+    image: ghcr.io/pouzor/homelable-backend:3.1.2@sha256:1d7ffebcbbc2de6363ce6c46009e6dd59be8603fcba75b0c6d9bc473ab104d81
+    container_name: homelable-backend
+    hostname: homelable-backend
+    env_file:
+      - .env
+    environment:
+      SQLITE_PATH: /app/data/homelab.db
+    volumes:
+      # The SQLite DB *is* the hand-curated canvas and is not reproducible from
+      # git. Covered by the celestia dockge backrest plan, which syncs all of
+      # /opt/stacks-data minus an explicit exclude list (stacks/backups/index.ts).
+      - /opt/stacks-data/homelable:/app/data
+    # Strictly tighter than upstream, which only adds NET_RAW (a no-op — it is
+    # already in Docker's default set). This sheds the other ~13 defaults and
+    # keeps only the raw-socket cap the ICMP discovery sweep and `nmap -sS`
+    # actually use. No privileged, no NET_ADMIN, no host networking.
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_RAW
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    dns:
+      - 100.100.100.100
+    # No traefik labels and no published ports: the backend is reachable only
+    # through the frontend's nginx proxy.
+    networks:
+      homelable:
+        aliases:
+          - backend
+
+  homelable:
+    image: ghcr.io/pouzor/homelable-frontend:3.1.2@sha256:3c2fa58a512042bd2a5e07340d6b7d7660fa00591e09e646e0302d47e7911230
+    container_name: homelable
+    hostname: homelable
+    depends_on:
+      - homelable-backend
+    restart: unless-stopped
+    dns:
+      - 100.100.100.100
+    networks:
+      - homelable
+      - dockge_default
+    labels:
+      # Enable Traefik
+      traefik.enable: true
+      # This container is on two networks; be explicit about which one traefik
+      # should dial so it never picks the stack-private one.
+      traefik.docker.network: dockge_default
+
+      # homelable has native OIDC (AUTH_MODE=oidc) — no forward-auth
+      # middleware, same pattern as docker/celestia/pdm.
+      traefik.http.routers.homelable.rule: Host(`homelable.${searchDomain}`)
+      traefik.http.routers.homelable.entrypoints: websecure
+      traefik.http.routers.homelable.tls.certresolver: le
+      traefik.http.routers.homelable.service: homelable
+
+      traefik.http.routers.homelable-tailscale.rule: Host(`homelable.${tailscaleDomain}`)
+      traefik.http.routers.homelable-tailscale.entrypoints: tailscale
+      traefik.http.routers.homelable-tailscale.service: homelable
+
+      # --- live view containment ------------------------------------------
+      # LIVEVIEW_KEY enables a read-only canvas that bypasses OIDC entirely.
+      # The key travels in a query string, and traefik's accessLog
+      # (format: common, filters.statusCodes includes "200") writes the full
+      # request line — so every *successful* live-view load logs the key in
+      # plaintext. It also lands in browser history and any outbound Referer.
+      #
+      # So /view is not served on the LAN-facing hostname at all. Live view is
+      # tailnet-only, via the homelable-tailscale router above: every viewer is
+      # already Tailscale-authenticated and governed by the ACLs in git, and a
+      # compromised device on the flat 10.10.0.0/16 cannot reach it.
+      #
+      # TWO paths must be blocked, not one:
+      #   /view             the SPA page — frontend/src/main.tsx switches on
+      #                     window.location.pathname === '/view'
+      #   /api/v1/liveview  the data endpoint that page fetches
+      #                     (backend/app/api/routes/liveview.py). It is
+      #                     key-authenticated only, NOT session-guarded, so
+      #                     blocking the page alone would still leave the whole
+      #                     topology readable as JSON.
+      # /api/v1/liveview/config is deliberately NOT blocked: it is guarded by
+      # the OIDC session and is what the UI reads to build a share link.
+      #
+      # This router is the entire control. Delete it, or let the main router's
+      # priority exceed it, and /view is live on the LAN hostname with nothing
+      # else in the way. The Gatus "Live View Blocked" check in definition.yaml
+      # is the regression alarm.
+      traefik.http.routers.homelable-view-block.rule: Host(`homelable.${searchDomain}`) && (PathPrefix(`/view`) || Path(`/api/v1/liveview`) || Path(`/api/v1/liveview/`))
+      traefik.http.routers.homelable-view-block.entrypoints: websecure
+      traefik.http.routers.homelable-view-block.tls.certresolver: le
+      # Default priority is rule length; the main router's rule is ~30 chars.
+      # Pinned high so it stays dominant even if that rule grows.
+      traefik.http.routers.homelable-view-block.priority: 1000
+      # Defined in docker/_common/traefik/dynamic/middlewares.yaml.
+      traefik.http.routers.homelable-view-block.service: error-pages@file
+
+      traefik.http.services.homelable.loadbalancer.server.port: 80
+
+  homelable-mcp:
+    image: ghcr.io/pouzor/homelable-mcp:3.1.2@sha256:60f9bdb43c0822730b9e3d88567b8b4bcf1a2bc220c33648fca4e5d0e88ddefc
+    container_name: homelable-mcp
+    hostname: homelable-mcp
+    depends_on:
+      - homelable-backend
+    env_file:
+      - .env
+    environment:
+      BACKEND_URL: http://backend:8000
+    restart: unless-stopped
+    dns:
+      - 100.100.100.100
+    networks:
+      - homelable
+      - dockge_default
+    labels:
+      traefik.enable: true
+      traefik.docker.network: dockge_default
+
+      # tailscale entrypoint ONLY — deliberately no websecure router.
+      # MCP clients authenticate with a static X-API-Key header and cannot
+      # complete an interactive OIDC redirect, so authentik forward-auth would
+      # *break* this service rather than protect it. The boundary therefore has
+      # to be network-level: an endpoint whose only credential is a static key
+      # must not be reachable from the flat /16 this stack is about to scan.
+      #
+      # MCP_SERVICE_KEY (mcp -> backend) also bypasses OIDC by design, but only
+      # over the stack-private network, and the backend has no router at all.
+      traefik.http.routers.homelable-mcp.rule: Host(`homelable-mcp.${tailscaleDomain}`)
+      traefik.http.routers.homelable-mcp.entrypoints: tailscale
+      traefik.http.routers.homelable-mcp.service: homelable-mcp
+      traefik.http.services.homelable-mcp.loadbalancer.server.port: 8001
+
+networks:
+  # Stack-private. Carries the `backend` alias the frontend's baked-in
+  # nginx.conf requires, without putting that name on dockge_default.
+  homelable: {}
+  dockge_default:
+    external: true
+
+x-dockge:
+  urls:
+    - https://homelable.${searchDomain}
+    - https://homelable.${tailscaleDomain}
+    - https://homelable-mcp.${tailscaleDomain}/mcp

--- a/docker/celestia/homelable/definition.yaml
+++ b/docker/celestia/homelable/definition.yaml
@@ -1,0 +1,55 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: homelable
+spec:
+  name: Homelable
+  category: ${CLUSTER_TITLE}
+  description: Homelab network topology map and LAN device discovery
+  url: &url https://homelable.${searchDomain}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/homelable.svg
+  access_policy:
+    groups:
+      # This app renders a complete map of the network. Admins only.
+      - admins
+  authentik:
+    oauth2:
+      clientType: confidential
+      allowedRedirectUris:
+        - url: "https://homelable.${searchDomain}/api/v1/auth/oidc/callback"
+      propertyMappings:
+        - email
+        - openid
+        - profile
+      includeClaimsInIdToken: true
+      subMode: user_email
+  gatus:
+    # The SPA shell. nginx serves it regardless of session, so a plain 200 is
+    # the right signal that the frontend is up.
+    - group: ${CLUSTER_TITLE}
+      url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 200"
+    # Deeper: /api/v1/health has no auth dependency and is proxied by nginx to
+    # the backend, so this covers frontend -> nginx -> backend in one check.
+    - name: API
+      group: ${CLUSTER_TITLE}
+      url: https://homelable.${searchDomain}/api/v1/health
+      method: GET
+      conditions:
+        - "[STATUS] == 200"
+        - "[BODY].status == ok"
+    # Regression alarm for the live-view containment in compose.yaml. If the
+    # blocking router is removed, reordered, or out-prioritised, /view starts
+    # answering 200 on the LAN-facing hostname and this fires. Any other
+    # outcome (404 from error-pages, 502 if error-pages is down) still passes,
+    # so it only alerts on the thing that actually matters.
+    - name: Live View Blocked
+      group: ${CLUSTER_TITLE}
+      url: https://homelable.${searchDomain}/view
+      method: GET
+      conditions:
+        - "[STATUS] != 200"


### PR DESCRIPTION
Implements [david-driscoll/vault#109](https://github.com/david-driscoll/vault/issues/109). Where the issue body and the comment thread conflict, the comments win — the body's original recommendations on `LIVEVIEW_KEY`, monitoring, MCP, scanner ranges and gethomepage are all superseded.

## What's here

```
docker/celestia/homelable/{compose.yaml,.env,definition.yaml}
dashboard/externalsecret.yaml        # HOMELABLE_URL + HOMELABLE_API_KEY
dashboard/resources/homelab.yaml     # dynacat custom-api widget
```

Three digest-pinned services on `3.1.2` (the current latest; digests re-resolved against ghcr.io, not copied from the issue):

| Service | Image | Port | Exposure |
|---|---|---|---|
| `homelable-backend` | `homelable-backend` | 8000 | none — no router, no published ports |
| `homelable` (frontend) | `homelable-frontend` | **80** | `websecure` + `tailscale` |
| `homelable-mcp` | `homelable-mcp` | 8001 | `tailscale` **only** |

The frontend serves on `:80`, not `:3000` — `:3000` is just the host side of upstream's `3000:80` mapping. Confirmed against `Dockerfile.frontend`.

## Scope: Proxmox staged to a follow-up, MCP is in

**Proxmox is deliberately not wired.** The `Homelable Proxmox` 1Password item does not exist, and `replaceOnePasswordPlaceholders` → `getItemByTitle` on a missing *item* fails the entire `stacks/home` run, not just this stack. It also needs four PVE tokens first (Celestia, Alpha Site, Luna, Skystar — the issue missed alpha-site). Follow-up issue rather than a landmine here.

**MCP is included** — its keys exist, and the ordering constraint is satisfied (see backrest below).

## Security design

### 1. Live view is tailnet-only — and it took two blocked paths, not one

`LIVEVIEW_KEY` is set (you asked for it), which enables a read-only canvas that bypasses OIDC entirely. The key travels in a **query string**, and `docker/_common/traefik/config.yaml` sets `accessLog.format: common` with `filters.statusCodes` including `"200"` — so every *successful* live-view load writes the key in plaintext to Traefik's access log. Treat it as semi-public once used; rotation means editing 1Password and redeploying.

So a higher-priority `websecure` router sends it to `error-pages@file`, leaving the `tailscale` entrypoint as the only path. Every viewer is then already Tailscale-authenticated.

**The issue flagged this as unverified, and it turned out to matter.** `PathPrefix(/view)` alone is *not* sufficient. The page is client-side only (`frontend/src/main.tsx` switches on `window.location.pathname === '/view'`), and it fetches its data from a **separate unauthenticated API path**, `GET /api/v1/liveview?key=…` (`backend/app/api/routes/liveview.py` — key-checked, no session dependency). Blocking just the page would have left the entire topology readable as JSON. Both are blocked.

`/api/v1/liveview/config` is deliberately left reachable — it *is* OIDC-session-guarded and is what the UI reads to build a share link.

### Verification — I actually tested it

Ran a local Traefik v3.7.10 with the docker provider, the exact labels from this PR, a stub frontend and a stub error-pages, using the real key:

**`websecure` (LAN hostname) — blocked:**

| Path | Result |
|---|---|
| `/view` | 404 error-pages |
| `/view?key=<real key>` | 404 error-pages |
| `/view?design=abc` | 404 error-pages |
| `/api/v1/liveview?key=<real key>` | 404 error-pages |
| `/api/v1/liveview/?key=<real key>` | 404 error-pages |
| `/` | 200 app shell |
| `/api/v1/health` | 200 |
| `/api/v1/liveview/config` | 200 |

**`tailscale` entrypoint — still works:** `/view?key=…` → 200 page, `/api/v1/liveview?key=…` → 200 data.

**Bypass attempts, all blocked:** `//view`, `/view/`, `/./view`, `/foo/../view`, `/%76iew`, `/api/v1//liveview`, `/api/v1/liveview/../liveview` — Traefik normalises before matching.

Two case-variants (`/VIEW`, `/api/v1/LIVEVIEW`) fall through to the main router, but they are **not** a bypass: the SPA check is an exact case-sensitive `=== '/view'`, and Starlette routing is case-sensitive, so they land on the OIDC-guarded app and a backend 404 respectively.

A Gatus check (`Homelable Live View Blocked`) asserts `[STATUS] != 200` on `/view` so a regression pages you. It only fails on the one outcome that matters — a 502 from a down error-pages still passes.

### 2. MCP is network-bounded, not auth-bounded

Tailscale entrypoint only, no `websecure` router, and **no forward-auth**. Forward-auth would *break* it: MCP clients present a static `X-API-Key` and cannot complete an interactive OIDC redirect. `MCP_SERVICE_KEY` (mcp → backend) also bypasses OIDC by design, but only over the stack-private network, and the backend has no router at all. Endpoint: `https://homelable-mcp.<tailnet>/mcp`.

### 3. Backrest — already covered, no wiring needed

`/opt/stacks-data/homelable` is **already in the backup plan** and needs no change. `stacks/backups/index.ts` builds a per-dockge-host plan whose `preSync` rclone-syncs `/stacks/` — which `docker/_common/rclone-sftp/compose.yaml` maps to the whole of `/opt/stacks-data/` — minus an explicit exclude list. `homelable` is not on it, so it is picked up on the next `stacks/backups` run. Retention 7 daily / 4 weekly / 3 monthly, with Gatus heartbeat + pushover alerting already attached.

The MCP-after-backup ordering constraint is therefore satisfied at deploy time. It is also moot on day one: `delete_design` / `delete_node` have nothing to destroy until you've curated a canvas. **Still worth doing a real restore test before the canvas is worth anything.**

### 4. Container privileges

`cap_drop: [ALL]` + `cap_add: [NET_RAW]` — strictly tighter than upstream, which only adds `NET_RAW` (a no-op, it's already in Docker's default set). This sheds the other ~13 defaults. No `privileged`, no `NET_ADMIN`, no `network_mode: host`.

The non-root `user: "1000:1000"` / `-sT` stretch is **not** taken here: it needs `net.ipv4.ping_group_range` or ICMP discovery silently returns nothing, and a silent-failure mode is a bad trade on first deploy. Worth knowing if we revisit — `DockgeLxc.createStack` already chowns `/opt/stacks-data/<stack>` to any `user:` it finds in the compose, so that half is free.

## Decisions from the thread, as implemented

| Topic | Value |
|---|---|
| `SCANNER_RANGES` | `["192.168.100.0/24","10.1.0.0/24"]` — IoT + Guest. Home's flat `/16` deliberately excluded from the *scheduled* scan; run it manually off-hours. Guest may return nothing under client isolation — one line to remove. |
| `STATUS_CHECKER_INTERVAL` | `60` (upstream default). Runs alongside Gatus, deliberate overlap, **no Gatus endpoint removed**. Judge on disagreement rate later. |
| `LIVEVIEW_KEY` | Set, contained as above. |
| MCP | Enabled. |
| gethomepage | Wired to dynacat. |
| Domain | `${searchDomain}` → `homelable.driscoll.tech`. Single global instance, so per `docker/AGENTS.md` this is the right side of the `${CLUSTER_DOMAIN}` rule. |
| Icon | `dashboard-icons/svg/homelable.svg` — it does exist upstream (verified 200). |

## Things the issue got wrong or left unverified — now resolved

**`OIDC_DISCOVERY_URL` (issue: unverified).** `issuer` is the *bare* issuer and would fail discovery. The pipeline also writes `openid_configuration_url` (`components/authentik.ts:242`), which is exactly `${issuer}.well-known/openid-configuration`. Confirmed against the existing `celestia-arcane-oidc-credentials` item. Using that field.

**`/api/v1/stats/summary` auth (issue: unverified, "gates the whole §5").** Confirmed in `backend/app/api/routes/stats.py`: `X-API-Key` header only, **no session dependency**, and `main.py` adds no global auth middleware. It works straight through nginx. The dynacat widget needs no backend-direct route.

**1Password field names (brief: `live_view_key` snake_case vs SCREAMING_CASE others).** Not the case any more — David normalised the item mid-flight. All five fields are now lower snake_case, all in the `add more` section. Referenced as:

`op://Eris/Homelable/{secret_key, live_view_key, mcp_api_key, mcp_service_key, homepage_api_key}`

Two-segment references are correct even though the fields live in a section: `components/op.ts:210` promotes fields in a section literally named `add more` to the item root (same as `Arcane`). All five verified to resolve; none contain `$`, quotes, backticks or newlines, so they're safe through the `.env`.

**`secret_key` is present** — it was the startup blocker and it no longer is. It is **exactly 32 bytes**, and the OIDC check is `>= 32`, so it passes with zero margin. If it's ever regenerated shorter, the backend refuses to start.

**Renovate needs no annotation.** `.github/renovate.json5` sets `docker-compose: {pinDigests: true}` and `compose.yaml` matches the manager's default file pattern. Unprefixed `3.1.2` is plain semver — the *normal* case for the docker datasource. `v`-prefixed tags 404 on this registry; the pinned form here is correct.

**nginx upstream naming.** nginx bakes in `proxy_pass http://backend:8000`. Rather than claim the name `backend` on the host-wide `dockge_default` — which would collide with any future stack that adds a `backend` service — the alias is scoped to a stack-private `homelable` network. `traefik.docker.network: dockge_default` is set on the two routed containers so Traefik never dials the private one.

**DNS is automatic.** `DockgeLxc.createStack` turns every non-tailnet `Host(...)` into a `StandardDns` CNAME, and every `*.${tailscaleDomain}` host into a Tailscale VIP service with `tailscale serve --https=443 → :8443`. Nothing to hand-add, and no Cloudflare record — the duplicate `Host()` in the blocking router is deduped by a `Set`.

## Not done / follow-ups

- **Proxmox** — needs 4 PVE `homelable@pve!api` tokens (PVEAuditor at `/`) and a `Homelable Proxmox` item. Only one can auto-sync (`PROXMOX_HOST` is singular); the rest are one-off UI imports. Skystar is offsite and will likely need `PROXMOX_VERIFY_TLS=false` over the tailnet.
- **Zigbee2MQTT / Z-Wave** — cross-cluster, deferred.
- **Scan duration on the `/16`** — the acceptance criterion asks for it recorded; that needs a live run, so it belongs to deployment rather than this PR.
- `pulumi preview` on `stacks/home` was **not** run (this PR does not deploy). Note the known phantom-delete behaviour on that stack — judge from `pulumi stack history`, not preview.

Refs: david-driscoll/vault#109

🤖 Generated with [Claude Code](https://claude.com/claude-code)
