### PR TITLE
feat(celestia): deploy Hermes Agent behind authentik OIDC

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -122,6 +122,17 @@
       matchDepNames: ["1password-cli"],
       overrideDatasource: "custom.1password-cli",
     },
+    {
+      // Hermes Agent tags are CalVer and inconsistently shaped: v2026.7.30 has
+      // three components, v2026.7.7.2 and v2026.5.29.2 have four. Renovate's
+      // default docker versioning is semver-like and silently skips the
+      // four-component releases, which would strand the pin on an older tag
+      // with no visible failure. `loose` orders them all.
+      description: "Hermes Agent uses 4-component CalVer tags that semver versioning skips",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["nousresearch/hermes-agent"],
+      versioning: "loose",
+    },
   ],
   customManagers: [
     {

--- a/docker/celestia/hermes/.env
+++ b/docker/celestia/hermes/.env
@@ -1,0 +1,82 @@
+# Hermes Agent — celestia
+#
+# Every value here is either a literal or an op:// reference resolved at deploy
+# time by the Pulumi pipeline (GlobalResources.replaceOnePasswordPlaceholders).
+# Never commit a plaintext key.
+
+# --- dashboard auth: native OIDC against authentik --------------------------
+# Registers the bundled `dashboard_auth/self_hosted` provider. The plugin's
+# register() activates on the presence of ISSUER + CLIENT_ID alone and does no
+# network I/O at registration time, so a brief authentik outage delays login
+# rather than preventing the container from starting.
+#
+# Hermes performs discovery itself at {issuer}/.well-known/openid-configuration,
+# so this wants the bare `issuer` field — NOT `openid_configuration_url`, which
+# is what homelable needs. Both fields are written to the generated item by
+# components/authentik.ts; picking the wrong one fails at first login, not at
+# boot, so it is worth getting right here.
+#
+# This item is created by the authentik pipeline from definition.yaml in this
+# same directory, so unlike a hand-made item it is guaranteed to exist by the
+# time the stack deploys.
+HERMES_DASHBOARD_OIDC_ISSUER="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/issuer"
+HERMES_DASHBOARD_OIDC_CLIENT_ID="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/client_id"
+# Confidential client — definition.yaml declares clientType: confidential.
+HERMES_DASHBOARD_OIDC_CLIENT_SECRET="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/client_secret"
+HERMES_DASHBOARD_OIDC_SCOPES="openid profile email"
+
+# --- model provider — NOT YET CONFIGURED, DAVID'S CALL ----------------------
+# Deliberately unset. This is the one decision in vault#117 that is not mine to
+# make, and shipping a guess would be worse than shipping nothing.
+#
+# The Eris vault currently holds NO usable LLM API key (checked by title scan:
+# no OpenAI, Anthropic, OpenRouter, Nous, Fireworks, or Gemini item exists).
+# There IS a "Claude OAuth Token" item — do NOT point Hermes at it. It is a
+# Claude Code OAuth credential, not an API key, and reusing a subscription
+# credential to drive a third-party agent runtime crosses both a trust boundary
+# and a terms boundary.
+#
+# The estate DOES already run local inference: docker/_common/llama-vulkan is a
+# llama.cpp server on :8080 deployed to every dockge host, celestia included.
+# It is serving gemma-3-4b-it. That is a fine auxiliary model and a poor primary
+# one — a 4B model driving an agent that holds a shell will loop, mis-call
+# tools, and burn the iteration budget. It is not a credible driver for this
+# workload, though it is a reasonable target for `auxiliary:` tasks (title
+# generation, compression) once a real primary model is in place.
+#
+# Recommendation is OpenRouter — see the review comment on vault#117 for the
+# reasoning. To enable, create the 1Password item, then uncomment:
+# OPENROUTER_API_KEY="op://Eris/Hermes Agent/openrouter_api_key"
+#
+# WARNING: do not uncomment before the item exists. An op:// reference to a
+# MISSING ITEM aborts the entire stacks/home run, not just this stack — the
+# same trap documented in docker/celestia/homelable/.env under "deliberately
+# not set". Create the item first, deploy second.
+#
+# Until a key is set the gateway still starts, the dashboard still serves, and
+# the healthcheck still passes; the agent simply cannot infer. Verified.
+
+# --- deliberately not set ---------------------------------------------------
+# API_SERVER_ENABLED / API_SERVER_KEY / API_SERVER_HOST — the OpenAI-compatible
+#   API server. Off, and it stays off. Upstream gates it on a usable
+#   API_SERVER_KEY (>=16 chars, gateway/config.py) so absence is sufficient;
+#   nothing needs to be set to disable it. An exposed API server was the second
+#   half of the June 2026 campaign that abused exposed dashboards, and this
+#   stack has no consumer that needs it. Turning it on also means opening a
+#   second Traefik route to an endpoint whose only credential is a static
+#   bearer token, which would need the tailscale-only treatment
+#   docker/celestia/homelable gives its MCP service.
+#
+# TELEGRAM_* / DISCORD_* / SLACK_* / TEAMS_* / GOOGLE_CHAT_* — no messaging
+#   gateway in the first pass. Each one is an additional untrusted input surface
+#   feeding a model that holds a shell, and upstream's threat model treats
+#   inbound chat as exactly that. Add them one at a time, deliberately, with the
+#   per-platform toolset narrowed in config.seed.yaml.
+#
+# BROWSERBASE_API_KEY — the browser toolset needs it and the toolset is off.
+#
+# SUDO_PASSWORD — stores a sudo password in plaintext for the agent to use.
+#   Never.
+#
+# TERMINAL_SSH_* — would let the agent execute on another host. The whole point
+#   of this shape is that the blast radius stops at the container.

--- a/docker/celestia/hermes/compose.yaml
+++ b/docker/celestia/hermes/compose.yaml
@@ -1,0 +1,166 @@
+services:
+  # Hermes Agent — NousResearch's agent runtime. This is an agent with a shell,
+  # a filesystem, and (optionally) a browser, running inside the home network.
+  # Upstream's own SECURITY.md §2.2 is explicit that the ONLY boundary against
+  # an adversarial model is the OS: "Nothing inside the agent process
+  # constitutes containment — not the approval gate, not output redaction, not
+  # any pattern scanner, not any tool allowlist." This container IS the
+  # boundary, which is why the hardening below is load-bearing rather than
+  # decorative. Read vault#117 before loosening any of it.
+  hermes:
+    # Upstream's docker-compose.yml uses `build: .` with a local `image:
+    # hermes-agent` tag, which is what the issue was written against — but the
+    # project DOES publish a multi-arch image. .github/workflows/docker.yml has
+    # a `publish` job (environment: container-publish) that pushes amd64+arm64
+    # by digest to Docker Hub on every main push and every release, and a
+    # `merge` job that stitches the manifest list and tags it `:<release_tag>`.
+    # So this is a normal digest-pinned upstream image and Renovate's
+    # docker-compose manager owns it like every other celestia service.
+    #
+    # Tags are CalVer and NOT consistently semver-shaped (v2026.7.30 is three
+    # components, v2026.7.7.2 is four), so a `versioning: loose` package rule
+    # is added in .github/renovate.json5 — without it Renovate silently skips
+    # the four-component releases.
+    #
+    # Image is ~1GB compressed / ~5GB extracted. That is upstream's size, not a
+    # packaging mistake on our side: the image bakes a full Python 3.13 venv,
+    # a Node toolchain, ffmpeg, and the dashboard's web bundle.
+    image: nousresearch/hermes-agent:v2026.7.30@sha256:b869e64d6496d4763d5e4fb675b5f504cb23b0e35ec9b790481a56118602b10f
+    container_name: hermes
+    hostname: hermes
+    env_file:
+      - .env
+    environment:
+      # The image starts as root, remaps its internal `hermes` user to these
+      # IDs via usermod/groupmod in the s6 stage2 hook, chowns /opt/data, and
+      # then drops every supervised service to that user with s6-setuidgid.
+      #
+      # DELIBERATE DEVIATION — no `user:` key. The upstream entrypoint
+      # hard-fails on `docker run --user <uid>` (docker/main-wrapper.sh and
+      # docker/stage2-hook.sh both reject it) because the bootstrap needs root
+      # and the baked /opt/hermes tree is root-owned and read-only to the
+      # runtime user. HERMES_UID/HERMES_GID is upstream's supported equivalent.
+      # Setting `user:` here would also make DockgeLxc chown the stack dir
+      # (components/DockgeLxc.ts) to a UID the container refuses to start as.
+      HERMES_UID: "1000"
+      HERMES_GID: "1000"
+      # Dashboard runs as an s6-supervised service INSIDE this container.
+      #
+      # This is the whole reason we don't need upstream's `network_mode: host`.
+      # Upstream ships the dashboard as a second container, and that second
+      # container needs a shared PID namespace with the gateway for its
+      # liveness detection — which is what forces host networking in their
+      # compose. In-container there is no namespace to share and the question
+      # disappears. Verified against v2026.7.30: single container, bridged,
+      # dashboard healthy.
+      HERMES_DASHBOARD: "1"
+      # Binds 0.0.0.0 *inside the container* so Traefik can reach it over the
+      # stack network. It is never published to the host — see `ports:` (absent)
+      # and the traefik labels below.
+      #
+      # A non-loopback bind arms upstream's auth gate, which FAILS CLOSED at
+      # startup unless a DashboardAuthProvider is registered. That is a feature
+      # and we are relying on it: HERMES_DASHBOARD_OIDC_* in .env registers the
+      # bundled self-hosted OIDC provider against authentik. Verified: with the
+      # OIDC vars unset the dashboard refuses to bind and logs "Refusing to
+      # bind dashboard to 0.0.0.0"; with them set, `/` returns 302 to
+      # /auth/login?provider=self-hosted and /api/config returns 401.
+      #
+      # HERMES_DASHBOARD_INSECURE is a deprecated no-op upstream as of the June
+      # 2026 hardening and must not be reintroduced — an unauthenticated public
+      # dashboard was the entry point for the MCP-config persistence campaign
+      # that drove agents into planting SSH backdoors.
+      HERMES_DASHBOARD_HOST: "0.0.0.0"
+      HERMES_DASHBOARD_PORT: "9119"
+      TZ: ${TIMEZONE}
+    volumes:
+      # /opt/data is the single source of truth for ALL Hermes state: config,
+      # .env, sessions, memories, skills, cron jobs, hooks, logs, and the
+      # agent's workspace. Upstream's compose mounts ~/.hermes; that would put
+      # it outside the celestia dockge backrest plan and it would silently not
+      # be backed up.
+      #
+      # /opt/stacks-data/hermes IS in scope: stacks/backups/index.ts syncs the
+      # whole of /stacks/ (the sftp view of /opt/stacks-data) minus an explicit
+      # exclude list, and `hermes` is not on that list.
+      - /opt/stacks-data/hermes:/opt/data
+    # DELIBERATE: no docker socket, no host bind mounts beyond the data volume.
+    # The image ships `docker-cli` and Hermes has a docker terminal backend, so
+    # mounting the socket would hand the agent full control of every container
+    # on celestia — including its own. There is no first-pass use case worth
+    # that. Same reasoning for /opt/stacks: the agent must not be able to
+    # rewrite the compose files that constrain it.
+    cap_drop:
+      - ALL
+    cap_add:
+      # Minimum set for the s6-overlay bootstrap, verified empirically against
+      # this exact digest — the container starts, the supervision tree comes
+      # up, and the dashboard binds with these six and ALL others dropped.
+      #   CHOWN + DAC_OVERRIDE + FOWNER — stage2 hook chowns /opt/data to the
+      #     remapped UID and usermod/groupmod rewrite /etc/passwd + /etc/group.
+      #   SETUID + SETGID              — s6-setuidgid drops each supervised
+      #     service (gateway, dashboard) from root to the hermes user.
+      #   KILL                         — s6-supervise signals its now-non-root
+      #     children on restart/shutdown.
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETUID
+      - SETGID
+      - KILL
+    security_opt:
+      # The agent can execute arbitrary shell as the unprivileged hermes user;
+      # this stops any setuid binary in the image from being a path back up.
+      - no-new-privileges:true
+    healthcheck:
+      # The dashboard's /api/health is an unauthenticated liveness probe by
+      # design (hermes_cli/web_server.py — no _require_token) and returns
+      # {"ok":true,"version":...,"auth_required":true}. Verified in-container.
+      #
+      # NOT the gateway's /health on 8642: that route only exists when the
+      # OpenAI-compatible API server is running, and the API server is
+      # deliberately off (see .env). This is the only HTTP health surface this
+      # stack actually has, which is a second reason the dashboard ships.
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9119/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      # First boot seeds the data volume and starts the supervision tree; on a
+      # cold LXC that is comfortably slower than the 30s interval would allow.
+      start_period: 180s
+    restart: unless-stopped
+    dns:
+      - 100.100.100.100
+    networks:
+      - dockge_default
+    labels:
+      traefik.enable: true
+
+      # Hermes has native OIDC (the bundled dashboard_auth/self_hosted
+      # provider) — no authentik forward-auth middleware, same pattern as
+      # docker/celestia/pdm and docker/celestia/homelable.
+      #
+      # Routed on websecure like arcane (which controls Docker) and pdm (which
+      # controls Proxmox). Those are comparable or greater blast radius and sit
+      # behind the same authentik gate, so this is the estate's existing bar,
+      # not a loosening of it. The gate is genuinely enforced here: the
+      # dashboard refuses to serve a single protected route without a
+      # completed OIDC login.
+      traefik.http.routers.hermes.rule: Host(`hermes.${searchDomain}`)
+      traefik.http.routers.hermes.entrypoints: websecure
+      traefik.http.routers.hermes.tls.certresolver: le
+      traefik.http.routers.hermes.service: hermes
+
+      traefik.http.routers.hermes-tailscale.rule: Host(`hermes.${tailscaleDomain}`)
+      traefik.http.routers.hermes-tailscale.entrypoints: tailscale
+      traefik.http.routers.hermes-tailscale.service: hermes
+
+      traefik.http.services.hermes.loadbalancer.server.port: 9119
+
+networks:
+  dockge_default:
+    external: true
+
+x-dockge:
+  urls:
+    - https://hermes.${searchDomain}

--- a/docker/celestia/hermes/config.seed.yaml
+++ b/docker/celestia/hermes/config.seed.yaml
@@ -1,0 +1,97 @@
+# Hermes Agent — first-boot config seed for celestia.
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# On first boot the image seeds /opt/data/config.yaml from its bundled 89KB
+# example, which enables a very broad default toolset (see below). Everything
+# that matters for containment lives in config.yaml, not in env vars, so the
+# hardening has to be in place BEFORE the container first starts.
+#
+# init.sh copies this file into /opt/stacks-data/hermes/config.yaml only when
+# no config.yaml is present. After that Hermes owns the file — it is a live,
+# self-modifying config (`hermes model`, the dashboard's settings tab, and
+# `hermes update`'s schema migrations all write to it), so this is a seed and
+# NOT a bind mount. Editing this file does not change a running deployment;
+# change it in the dashboard or with `hermes config set`, and update this file
+# so a rebuilt host comes back the same way.
+#
+# A partial config is fine — Hermes merges it over its defaults. Verified
+# against v2026.7.30: the container boots and `hermes tools list` reflects the
+# narrowed toolset below.
+
+# --- terminal ---------------------------------------------------------------
+terminal:
+  # "local" means tool commands run inside THIS container as the unprivileged
+  # hermes user. That is the correct choice here and it is a deliberate one:
+  # upstream calls this posture "whole-process wrapping" (SECURITY.md §2.2) and
+  # it is the supported way to contain everything — shell, code execution, MCP
+  # subprocesses, plugins, hooks, skill loading. The alternative,
+  # terminal-backend isolation, only confines what goes through the shell and
+  # would additionally require handing this container a docker socket.
+  backend: "local"
+  # Anchor tool commands in a dedicated workspace rather than letting them
+  # start in the data root next to sessions/, memories/, and .env.
+  cwd: "/opt/data/workspace"
+  timeout: 180
+
+# --- tool loop guardrails ---------------------------------------------------
+# Upstream ships hard stops OFF, which they document as reasonable for
+# interactive use "where a person can see repeated tool-call warnings" and
+# explicitly call out as wrong for unattended gateway deployments. This is an
+# unattended gateway deployment.
+tool_loop_guardrails:
+  warnings_enabled: true
+  hard_stop_enabled: true
+  hard_stop_after:
+    exact_failure: 5
+    same_tool_failure: 8
+    idempotent_no_progress: 5
+
+# --- toolsets ---------------------------------------------------------------
+# The dashboard's chat tab drives the `cli` platform, so this is the list that
+# governs the first pass.
+#
+# Enabled-by-default upstream, verified by running v2026.7.30 and reading
+# `hermes tools list`:
+#   web, browser, terminal, file, code_execution, vision, image_gen, bfl, tts,
+#   skills, todo, memory, session_search, clarify, delegation, cronjob,
+#   computer_use
+#
+# Turned off here, with reasons:
+#   code_execution — spawns a HOST subprocess from the agent's own interpreter.
+#       Upstream is explicit that this path bypasses terminal-backend isolation.
+#       `terminal` already covers running things and is the better-guarded of
+#       the two.
+#   cronjob        — lets the agent schedule its own recurring work. That is a
+#       persistence mechanism, and self-scheduled agent tasks are precisely the
+#       shape of the June 2026 MCP-config persistence campaign. If scheduled
+#       work is wanted later it should be a job David creates, not one the
+#       model can create for itself.
+#   delegation     — spawns sub-agents; multiplies iteration spend and makes the
+#       audit trail much harder to follow. Off until there is a reason.
+#   browser        — needs BROWSERBASE_API_KEY (an external cloud browser with
+#       residential proxies and CAPTCHA solving) and is inert without it.
+#       Listing it explicitly so "off" is a decision rather than an accident of
+#       a missing key.
+#   computer_use   — no display in this container; inert, and it should stay
+#       that way.
+#   vision / image_gen / tts / stt — all need provider keys we do not set.
+#
+# Kept: web (search/extract), terminal, file, skills, todo, memory,
+# session_search, clarify. That is enough to be a useful agent while the shell
+# stays the only high-power verb, contained by the container boundary.
+#
+# NOTE: `bfl` (BFL FLUX 3 Video) reports enabled even when omitted from this
+# list — it appears to register outside platform_toolsets. It requires an API
+# key we do not set, so it is inert, but the mechanism is UNVERIFIED and worth
+# a look if the toolset list ever seems not to apply.
+platform_toolsets:
+  cli:
+    - web
+    - terminal
+    - file
+    - skills
+    - todo
+    - memory
+    - session_search
+    - clarify

--- a/docker/celestia/hermes/definition.yaml
+++ b/docker/celestia/hermes/definition.yaml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: hermes
+spec:
+  name: Hermes Agent
+  category: ${CLUSTER_TITLE}
+  description: NousResearch agent runtime — dashboard, gateway, and skills
+  url: &url https://hermes.${searchDomain}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/nous-research.svg
+  access_policy:
+    groups:
+      # This agent holds a shell inside the home network. Admins only, and
+      # deliberately narrower than "anyone who can reach the hostname".
+      - admins
+  authentik:
+    oauth2:
+      clientType: confidential
+      allowedRedirectUris:
+        # The self-hosted OIDC provider validates that the redirect_uri path
+        # ends in exactly `/auth/callback` before it will even bounce to the
+        # IDP (plugins/dashboard_auth/self_hosted: _validate_redirect_uri).
+        # Any other path fails fast at login with a confusing error, so this
+        # value is not free-form.
+        - url: "https://hermes.${searchDomain}/auth/callback"
+      propertyMappings:
+        - email
+        - openid
+        - profile
+      includeClaimsInIdToken: true
+      subMode: user_email
+  gatus:
+    # /api/health is the dashboard's unauthenticated liveness probe and the
+    # same endpoint the container healthcheck uses. It is the only health
+    # surface this stack has: the gateway's own /health lives on the
+    # OpenAI-compatible API server, which is deliberately off.
+    #
+    # `auth_required == true` is the load-bearing assertion here, not a
+    # nicety. It is the regression alarm for the dashboard's auth gate — if
+    # the OIDC env vars ever go missing or get misconfigured, the gate
+    # disengages and this check fires. A plain 200 would not catch that.
+    - name: Dashboard
+      group: ${CLUSTER_TITLE}
+      url: https://hermes.${searchDomain}/api/health
+      method: GET
+      conditions:
+        - "[STATUS] == 200"
+        - "[BODY].ok == true"
+        - "[BODY].auth_required == true"
+    # DELIBERATELY NOT ADDED: a check asserting that `/` 302s to the authentik
+    # login. Unauthenticated `/` does return 302 (verified locally against
+    # v2026.7.30), but whether Gatus reports 302 or silently follows to
+    # authentik's 200 login page depends on redirect handling this repo has no
+    # prior art for and I could not verify — so the assertion would be a coin
+    # flip. The `auth_required == true` condition above is the real regression
+    # alarm for the gate and needs no such assumption.

--- a/docker/celestia/hermes/init.sh
+++ b/docker/celestia/hermes/init.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Hermes Agent — pre-compose seed.
+#
+# DockgeLxc runs init.sh before `docker compose up` on every deploy
+# (components/DockgeLxc.ts uses triggers: [Date.now()], i.e. always), so this
+# must be idempotent. It is: every step is guarded.
+set -euo pipefail
+
+DATA_DIR="/opt/stacks-data/hermes"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The container starts as root and chowns /opt/data itself via the s6 stage2
+# hook (using HERMES_UID/HERMES_GID from compose.yaml), so ownership is not our
+# job — but the directory has to exist first, and the workspace subdir needs to
+# be there before the agent's first tool call rather than created on demand.
+mkdir -p "${DATA_DIR}/workspace"
+
+# Seed config.yaml ONLY on a genuinely fresh volume.
+#
+# This is a one-way door on purpose. config.yaml is live, self-modifying state:
+# `hermes model`, the dashboard settings tab, and `hermes update`'s schema
+# migrations (v0 -> v33 as of 0.19.1) all rewrite it. Copying our seed over an
+# existing file on every deploy would silently revert David's model choice and
+# clobber migrated schema — so if the file exists, we leave it completely alone
+# and say so in the log.
+if [[ -f "${DATA_DIR}/config.yaml" ]]; then
+  echo "[hermes] config.yaml already present — leaving it untouched."
+  echo "[hermes] To re-apply the seed, move the existing file aside first."
+else
+  echo "[hermes] Fresh data volume — seeding config.yaml from config.seed.yaml"
+  cp "${SCRIPT_DIR}/config.seed.yaml" "${DATA_DIR}/config.yaml"
+  # Match the UID/GID the container remaps its hermes user to (compose.yaml
+  # HERMES_UID/HERMES_GID). The stage2 hook would chown this anyway; doing it
+  # here keeps the file sane if anyone inspects it before first boot.
+  chown 1000:1000 "${DATA_DIR}/config.yaml"
+fi
+
+echo "[hermes] init complete."


### PR DESCRIPTION
Closes david-driscoll/vault#117.

Adds `docker/celestia/hermes/` — NousResearch's Hermes Agent as a single digest-pinned container on the celestia dockge host. **The full review is on [vault#117](https://github.com/david-driscoll/vault/issues/117#issuecomment-PENDING)**; this is the short version.

## Three premises in the issue changed after reading the source

**A published image exists.** The compose does `build: .`, but `.github/workflows/docker.yml` has a protected `publish` job pushing amd64+arm64 to Docker Hub on every release, plus a `merge` job that tags the manifest list. Pinned to `nousresearch/hermes-agent:v2026.7.30` by digest; Renovate's `docker-compose` manager owns it from here. The GHCR 401 was a red herring — they publish to Docker Hub.

**Host networking is not required.** It exists upstream only because their dashboard is a *separate container* needing a shared PID namespace with the gateway. Running the dashboard in-container (`HERMES_DASHBOARD=1`) removes the constraint. Upstream also ships `docs/security/network-egress-isolation.md`, which is a guide to removing host mode. Bridged onto `dockge_default` with Traefik labels.

**The dashboard is safe to ship, because it fails closed.** Since upstream's June 2026 hardening, a non-loopback bind *requires* a registered auth provider or the dashboard refuses to start, and `HERMES_DASHBOARD_INSECURE` is a deprecated no-op. One of the bundled providers is self-hosted OIDC — that's authentik, native, no forward-auth middleware, same pattern as `pdm` and `homelable`.

## Verified by running the pinned digest locally

| Check | Result |
|---|---|
| `cap_drop: ALL` + 6 caps + `no-new-privileges` | container boots, s6 tree healthy |
| OIDC vars unset, bind `0.0.0.0` | refuses to bind — fails closed |
| OIDC vars set | binds, `HERMES_DASHBOARD_READY port=9119` |
| `GET /` unauth | `302 → /auth/login?provider=self-hosted` |
| `GET /api/config` unauth | `401` |
| `GET /api/health` | `200 {"ok":true,"auth_required":true}` |
| narrowed `platform_toolsets` | takes effect |

## Containment

This is an agent holding a shell inside the home network, and upstream's `SECURITY.md` §2.2 is explicit that the OS is the only real boundary — so the container *is* the boundary.

Default-enabled toolsets included `terminal`, `code_execution`, `browser`, `computer_use`, `delegation` and `cronjob`. Disabled `code_execution` (spawns a host subprocess from the agent's own interpreter, bypassing terminal-backend isolation), `cronjob` (self-scheduling is a persistence mechanism), `delegation`, `browser`, `computer_use`. Kept `web`, `terminal`, `file`, `skills`, `todo`, `memory`, `session_search`, `clarify`.

Also: no docker socket (the image ships `docker-cli`), no host mounts beyond the data volume, `/opt/stacks` deliberately not mounted, OpenAI-compatible API server off, no messaging gateways, `tool_loop_guardrails.hard_stop_enabled: true` per upstream's unattended-gateway guidance.

**Not done:** egress restriction. The container can reach the flat `/16` and the internet. Upstream documents the fix; it needs its own issue and a decision about what the agent may reach. Largest remaining gap.

## Conventions

- Data at `/opt/stacks-data/hermes` — confirmed inside the backrest plan's scope (`stacks/backups/index.ts` syncs all of `/stacks/` minus an exclude list not containing `hermes`)
- Secrets via `op://Eris/…` only; **no model provider key committed** — that decision is David's, and no usable LLM key exists in Eris today. The `.env` line is commented out because an `op://` ref to a *missing item* aborts the whole `stacks/home` run.
- `/init` preserved as PID 1; only `command:` is set
- Deviations documented inline: no `user:` key (upstream hard-rejects `--user`), the six retained capabilities, and why `config.yaml` is seeded rather than bind-mounted

## Renovate

Added a `versioning: "loose"` rule — Hermes tags mix three- and four-component CalVer (`v2026.7.30` vs `v2026.7.7.2`), and default semver-like versioning would silently skip the four-component releases.

## Note

Not deployed. Live OIDC round-trip against real authentik and the first on-host `hermes doctor` are post-merge steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)