### PR TITLE
feat(minio): create the CNPG barman-cloud buckets the ObjectStores point at (vault#119)

### DIFF
--- a/stacks/home/index.ts
+++ b/stacks/home/index.ts
@@ -66,6 +66,41 @@ const spikeVm = new TruenasVm("spike", {
   tailscaleIpAddress: "100.111.10.10",
 });
 
+// CloudNativePG barman-cloud WAL archives + base backups, one bucket per
+// Kubernetes cluster. These are the PITR archive: postgres cannot recycle a WAL
+// segment until barman has put it here, so if a bucket is missing the cluster's
+// pg_wal grows without bound (vault#119 — the ObjectStore manifests shipped
+// pointing at buckets that only ever existed on Backblaze B2, and archiving
+// failed with barman GeneralErrorExit/4 wrapping a NoSuchBucket).
+//
+// protect + retainOnDelete: destroying one of these discards the entire
+// recovery window. Never let a stack destroy take them.
+const _cnpgEquestriaBackups = new minio.S3Bucket(
+  `cnpg-equestria-backups`,
+  {
+    acl: "private",
+    bucket: pulumi.interpolate`cnpg-equestria`,
+  },
+  {
+    provider: globals.truenasMinioProvider,
+    protect: true,
+    retainOnDelete: true,
+  },
+);
+
+const _cnpgSgcBackups = new minio.S3Bucket(
+  `cnpg-sgc-backups`,
+  {
+    acl: "private",
+    bucket: pulumi.interpolate`cnpg-sgc`,
+  },
+  {
+    provider: globals.truenasMinioProvider,
+    protect: true,
+    retainOnDelete: true,
+  },
+);
+
 const thanosStorage = new minio.S3Bucket(
   `thanos-storage`,
   {


### PR DESCRIPTION
## Why

`vault#119`. WAL archiving is failing on **both** CNPG clusters with an opaque

```
ContinuousArchiving=False
unexpected failure invoking barman-cloud-wal-archive: exit status 4
```

Exit 4 is barman's `GeneralErrorExit` (`src/barman/clients/cloud_cli.py`) — the catch-all for an unhandled exception, deliberately uninformative. The sidecar logs carry the real one:

```
Barman cloud WAL archiver exception: An error occurred (NoSuchBucket)
when calling the PutObject operation: The specified bucket does not exist
```

`s3://equestria-db` and `s3://stargate-command-db` do not exist. `mc ls` against truenas Minio returns exactly two buckets — `home-operations` and `thanos*`. Those two names are **Backblaze B2** buckets, sourced from the `${BACKBLAZE_DATABASE}` 1Password item, and eq#2981 / sgc#1738 paired them with the Minio endpoint and Minio credentials. My mistake in those PRs.

Nothing has ever been archived on either cluster. **PITR does not exist on this estate today**, whatever the manifests imply — and vault#114 (PG 17→18) is gated on it.

## What

**This PR touches exactly one file: `stacks/home/index.ts`.** It adds two Minio buckets on truenas and nothing else — no Hermes, no renovate config, no docker stacks. An earlier revision of this branch was cut from the Hermes branch rather than `main` and carried HO#629's changes; it has been rebuilt on `origin/main` and force-pushed. Confirm with the Files tab: one file, +35/-0.

| bucket | cluster | ObjectStore destinationPath after companion PRs |
| --- | --- | --- |
| `cnpg-equestria` | equestria | `s3://cnpg-equestria/barman/equestria` |
| `cnpg-sgc` | stargate-command | `s3://cnpg-sgc/barman/sgc` |

Both `protect: true` + `retainOnDelete: true`. Destroying one of these discards the entire recovery window; a stack destroy must never be able to take them.

## Merge order

1. **this PR**, and it must be *applied*, not just merged
2. david-driscoll/equestria-cluster#2988
3. david-driscoll/stargate-command-cluster#1744

barman-cloud does not create buckets. If the cluster PRs reconcile before these buckets exist they simply re-arm the same NoSuchBucket loop against a new name.

## Applying

`stacks/home` needs a `pulumi up`. **Judge safety from `pulumi stack history`, not from the preview diff** — this stack has known phantom-delete behaviour: `pulumi preview` on home/gulf-of-mexico/ocracoke invents ~40 StandardDns/TailnetKey/DeviceTags deletes, because `tailscale.ts` builds its resources inside `apply()` with an `isDryRun` early-return, so the dry run genuinely cannot see them. That is a preview artifact, but it makes a full-stack `up` an unpleasant thing to eyeball.

Apply this `--target`ed at the two new bucket URNs only:

```
urn:...:minio:index/s3Bucket:S3Bucket::cnpg-equestria-backups
urn:...:minio:index/s3Bucket:S3Bucket::cnpg-sgc-backups
```

Both are pure creates against a provider that touches nothing else in the stack.

I did not run it — creating storage on the estate's object store is David's call, not mine.

## Runway if this waits

pg_wal cannot recycle a segment until it is archived. Measured on the primaries: equestria ~12 seg/h (~190 MB/h) with 38G free; SGC ~26 seg/h (~410 MB/h) with 36G free. **SGC is the binding constraint at roughly 3.5–4 days.** This-week, not tonight — but it is precisely how the 2026-07 SGC out-of-disk cascade opened, and SGC has just exhausted the `wal_keep_size` cushion that was masking the growth, so its `pg_wal` starts genuinely climbing from here.

<!-- crew:agent=seraph -->