### PR TITLE
fix(celestia): unstall stacks/home — a commented op:// reference is not inert

### DIFF
--- a/docker/celestia/hermes/.env
+++ b/docker/celestia/hermes/.env
@@ -45,13 +45,25 @@ HERMES_DASHBOARD_OIDC_SCOPES="openid profile email"
 # generation, compression) once a real primary model is in place.
 #
 # Recommendation is OpenRouter — see the review comment on vault#117 for the
-# reasoning. To enable, create the 1Password item, then uncomment:
-# OPENROUTER_API_KEY="op://Eris/Hermes Agent/openrouter_api_key"
+# reasoning. To enable, in this order:
 #
-# WARNING: do not uncomment before the item exists. An op:// reference to a
-# MISSING ITEM aborts the entire stacks/home run, not just this stack — the
-# same trap documented in docker/celestia/homelable/.env under "deliberately
-# not set". Create the item first, deploy second.
+#   1. Create a 1Password item in the Eris vault titled `Hermes Agent`, with a
+#      concealed field named `openrouter_api_key`.
+#   2. Only then, add a real OPENROUTER_API_KEY line here. Its value is a
+#      1Password reference in the same form as the OIDC lines above — the op
+#      scheme, the Eris vault, the item title, the field name — exactly as
+#      those are written, with the title and field from step 1.
+#
+# Do NOT write that reference before step 1 is done, and in particular do not
+# park a ready-to-uncomment copy of it in a comment. This block used to do
+# exactly that, and it took the estate down: replaceOnePasswordPlaceholders
+# (components/store/index.ts) matches a plain global regex against the raw text
+# of this file and has no notion of comments, so a leading `#` disarms nothing.
+# The referenced item did not exist, the lookup threw, and the throw aborted the
+# whole stacks/home program — every stack in it, not just this one. Same trap as
+# the one documented in docker/celestia/homelable/.env under "deliberately not
+# set", and the reason that file describes the syntax in prose instead of
+# spelling it. Create the item first, write the reference second.
 #
 # Until a key is set the gateway still starts, the dashboard still serves, and
 # the healthcheck still passes; the agent simply cannot infer. Verified.


### PR DESCRIPTION
## What this fixes

`stacks/home` has been unable to converge estate-wide since #629 merged. `stacks.pulumi.com/home-operations` is `Ready=False NotReadyStalled` / `Stalled=True UpdateFailed`.

Root cause is one line in `docker/celestia/hermes/.env`:

```
# OPENROUTER_API_KEY="<a 1Password reference to an item that does not exist>"
```

The `#` does nothing. `GlobalResources.replaceOnePasswordPlaceholders` (`components/store/index.ts:115-116`) matches a plain global regex against the **raw text** of every file in every docker stack directory — it has no notion of comment syntax. The reference matched, `getItemByTitle` was called for an item that has never existed, it threw, and the throw propagated out of the `apply` and aborted the **entire `stacks/home` program** — every stack in it, not just this one.

This PR rewrites the OpenRouter block so no resolvable reference appears anywhere in the file, commented or not, following the pattern `docker/celestia/homelable/.env` already uses: it documents the reference *form* in prose rather than spelling it. The guidance stays actionable — a future reader still gets the ordered steps to enable OpenRouter — and now also explains *why* the reference must not be pre-written.

Merging is sufficient to recover. The Pulumi operator clears the stall on a source change and retries on its own. No `pulumi up` was run, and the `Hermes Agent` 1Password item was **not** created — the model-provider decision stays David's, exactly as #629 left it.

## Sweep

I ran the resolver's actual regex (`/op:\/\/Eris\/([\w| -]+)\/([\w| -]+)/g`) over every file under `docker/` after the edit. 22 matches, **all on live uncommented lines**, zero in comments. The only other commented occurrences in the tree are prose that cannot match: `docker/_common/neo4j/.env:1` uses `<vault>`/`<item-name>` placeholders, and `docker/celestia/homelable/.env:78` and `hermes/.env:3` say "op:// reference" without a vault path.

I checked `stacks/` and `components/` too, since the resolver runs over whatever it is handed rather than only `.env` files. `stacks/` has no `op://` references at all. `components/` has three: two are the resolver's own `items.set`/`items.has` keys in `store/index.ts`, and one is a TS comment at `DockgeLxc.ts:790`. None are in the resolver's input path — `DockgeLxc.ts:641-668` feeds it only docker stack files, and `authentik.ts:485` feeds it Gatus definition YAML. `.config/mise.toml:56-58` and `playbook/NodeMigration.dib:47` do have commented references, but neither file is ever passed to the resolver.

So this was the only instance, and it still is.

## What this does NOT do

This unblocks `stacks/home` and lets Hermes deploy for the **first time**. It does not validate Hermes. Specifically, still never executed:

- the dashboard's OIDC login round-trip against authentik
- the Gatus `auth_required == true` assertion
- the container itself — it has never run

Treat the first successful deploy as the start of verification, not the end of it.

## Two open items from #629 now resolved

- **Image arch** — the pinned `nousresearch/hermes-agent:v2026.7.30@sha256:b869e64d…` pulls anonymously, and the digest is an OCI index carrying both `linux/amd64` and `linux/arm64`. The arch concern from the #629 review is dead.
- **OIDC item** — `celestia-hermes-oidc-credentials` exists, so the fail-closed dashboard has its config.

## Follow-up I am deliberately not doing here

The resolver's failure mode deserves its own issue and I would rather not widen an outage fix to reach it. A commented reference to a missing item taking down every stack in the program is a sharp edge, and this is the second time this week a comment turned out to be executable on this estate (the ESO `{{` bug took CrowdSec down twice). My recommendation, in order:

1. **Catch and re-throw with context.** Today the failure surfaces as a bare `getItemByTitle` error with no indication of which file or which reference caused it — diagnosing this one meant grepping the tree by hand. Wrapping the lookup so the error names the missing item, the field, and the file it came from is small, safe, and would have turned this into a two-minute fix. Do this one.
2. **Skipping references on commented lines is *not* trivially safe** and I would not lead with it. The resolver runs over `.env`, `compose.yaml`, and arbitrary app config (`docker/alpha-site/uptime/config/default.yaml`), plus Gatus YAML from `authentik.ts` — `#` means comment in most of those but the resolver has no idea what it is parsing, and a rule that guesses will eventually skip a reference someone intended.

Worth noting there is a **separate** known bug in the same file: `getTailscaleExports` (`components/store/index.ts:36`) returning items unsorted, causing a pure-permutation Tailscale ACL diff every 5 minutes. Different bug, already has a background task, untouched by this PR.

## Separately stalled, not this

`stacks.pulumi.com/unifi-network` is also stalled — `Error Creating Firewall Group: api.err.InvalidPayload (400)` ×3 — but its `lastSuccessfulCommit` is *after* Hermes merged, so it is not a regression from #629 and this PR will not fix it. Filed separately; that stack has armed-delete history and needs its own careful treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- crew:agent=link -->
