### PR TITLE
fix(hermes): stamp seed config schema version, correct the false provider comment

### DIFF
--- a/docker/celestia/hermes/.env
+++ b/docker/celestia/hermes/.env
@@ -65,8 +65,43 @@ HERMES_DASHBOARD_OIDC_SCOPES="openid profile email"
 # set", and the reason that file describes the syntax in prose instead of
 # spelling it. Create the item first, write the reference second.
 #
-# Until a key is set the gateway still starts, the dashboard still serves, and
-# the healthcheck still passes; the agent simply cannot infer. Verified.
+# WITHOUT A PROVIDER THIS CONTAINER DOES NOT RUN.
+#
+# An earlier version of this note said the opposite — that the gateway still
+# starts, the dashboard still serves, the healthcheck still passes, and only
+# inference is unavailable — and asserted it was verified. All three clauses
+# were wrong. What actually happens, read out of upstream at the pinned tag
+# v2026.7.30:
+#
+#   1. Dockerfile sets ENTRYPOINT ["/init", "/opt/hermes/docker/main-wrapper.sh"]
+#      with an empty CMD, so main-wrapper.sh execs `hermes` with no arguments.
+#      Under s6-overlay this is the container's MAIN PROGRAM, not a supervised
+#      service. (docker/s6-rc.d/main-hermes/run is `exec sleep infinity` — a
+#      placeholder slot that exists only because s6-rc rejects an empty user
+#      bundle. It does not run the agent.)
+#   2. hermes_cli/main.py has a first-run guard: when
+#      `_has_any_provider_configured()` is false it prints "It looks like
+#      Hermes isn't configured yet", then checks `is_interactive_stdin()`.
+#      Dockge starts the stack detached, so there is no TTY, and the guard
+#      calls `sys.exit(1)` without ever reaching the agent.
+#   3. In the s6-overlay main-program model the CMD exiting brings /init and
+#      the ENTIRE supervision tree down with it — including the `dashboard`
+#      longrun. The dashboard never binds, /api/health never answers, and the
+#      healthcheck cannot pass. `restart: unless-stopped` then restarts the
+#      container, which fails identically, and Docker's backoff climbs to its
+#      ~60s ceiling. Observed on celestia: 31 boot cycles, now at max backoff.
+#
+# So a model provider is REQUIRED for the container to run at all, not merely
+# for the agent to infer. Everything above and below about OIDC, toolsets, and
+# Traefik is correct and entirely inert until that decision is made.
+#
+# One consequence worth knowing when the decision does get made:
+# `_has_any_provider_configured()` (hermes_cli/main.py) is satisfied by ANY of
+# a provider API-key env var, `OPENAI_BASE_URL` on its own (local
+# OpenAI-compatible servers frequently need no key), a logged-in provider in
+# $HERMES_HOME/auth.json, or an explicit provider in config.yaml's model
+# section. Pointing it at a local endpoint is therefore enough to end the boot
+# loop even with no key anywhere.
 
 # --- deliberately not set ---------------------------------------------------
 # API_SERVER_ENABLED / API_SERVER_KEY / API_SERVER_HOST — the OpenAI-compatible

--- a/docker/celestia/hermes/config.seed.yaml
+++ b/docker/celestia/hermes/config.seed.yaml
@@ -15,9 +15,57 @@
 # change it in the dashboard or with `hermes config set`, and update this file
 # so a rebuilt host comes back the same way.
 #
-# A partial config is fine — Hermes merges it over its defaults. Verified
-# against v2026.7.30: the container boots and `hermes tools list` reflects the
-# narrowed toolset below.
+# A partial config is fine — Hermes merges it over its defaults.
+# `hermes_cli/config.py::_load_config_impl` deep-copies DEFAULT_CONFIG and
+# `_deep_merge`s this file over it on every read, with no reference to the
+# schema version. Dict sections merge key-by-key; a list (like
+# `platform_toolsets.cli` below) REPLACES the default outright, which is the
+# behaviour the narrowed toolset depends on.
+
+# --- schema version ---------------------------------------------------------
+# Not decoration. Without this key the container logged, on every single boot:
+#
+#   [config-migrate] WARNING: This config predates version 12 (~2 years old)
+#   and can no longer be auto-migrated.
+#
+# The cause is a gap between two upstream code paths at v2026.7.30:
+#
+#   * `hermes_cli/config.py::migrate_config` deliberately does NOT floor-refuse
+#     a config with no `_config_version` key. It calls
+#     `_raw_config_has_explicit_version()` first and treats a missing key as "a
+#     fresh minimal config (profile clones write bare keys; users hand-write
+#     two-line configs), not an ancient install" — exactly our case — so the
+#     CLI would migrate and stamp it normally.
+#   * `scripts/docker_config_migrate.py`, which is what actually runs at boot,
+#     does NOT make that distinction. It compares
+#     `check_config_version()` (a missing key coerces to 0) against
+#     SUPPORT_FLOOR_VERSION and takes the below-floor branch, printing the
+#     warning and returning 0 without ever calling `migrate_config`.
+#
+# So the file was never stamped and the warning repeated forever.
+#
+# WHAT IT DID NOT DO: discard this file. The below-floor branch is
+# warn-and-continue by design — `config_migrations.py` documents it as
+# "left byte-for-byte untouched ... the process continues with the config as-is
+# (defaults deep-merged at read time)". `load_config()` has no version gate at
+# all, and `tools_config.py::_get_platform_tools` reads `platform_toolsets`
+# straight off the merged config. The containment below was in force the whole
+# time; the warning was noise, not a silent revert to upstream defaults.
+#
+# 33 is not a guess: it is `DEFAULT_CONFIG["_config_version"]` in
+# `hermes_cli/config_defaults.py` at the tag pinned in compose.yaml, and it is
+# what a fresh `hermes setup` on this image writes. Stamping it latest means
+# `docker_config_migrate.py` returns at its `current_ver >= latest_ver`
+# short-circuit — no warning, and no migration pass that would rewrite this
+# file and strip every comment in it.
+#
+# WHEN RENOVATE BUMPS THE IMAGE: if the new tag raises the latest version, the
+# boot migrator will run the ladder against the LIVE /opt/data/config.yaml and
+# rewrite it (comments included — that file is Hermes-owned state, see above).
+# That is the normal upgrade path and needs no action here, but bump this
+# number to match when re-seeding a rebuilt host, or the next fresh volume
+# starts one schema behind.
+_config_version: 33
 
 # --- terminal ---------------------------------------------------------------
 terminal:

--- a/docker/celestia/hermes/init.sh
+++ b/docker/celestia/hermes/init.sh
@@ -18,11 +18,13 @@ mkdir -p "${DATA_DIR}/workspace"
 # Seed config.yaml ONLY on a genuinely fresh volume.
 #
 # This is a one-way door on purpose. config.yaml is live, self-modifying state:
-# `hermes model`, the dashboard settings tab, and `hermes update`'s schema
-# migrations (v0 -> v33 as of 0.19.1) all rewrite it. Copying our seed over an
-# existing file on every deploy would silently revert David's model choice and
-# clobber migrated schema — so if the file exists, we leave it completely alone
-# and say so in the log.
+# `hermes model`, the dashboard settings tab, and the boot-time schema
+# migrator (scripts/docker_config_migrate.py; the ladder spans v12 -> v33 at
+# the pinned image tag, v12 being upstream's auto-migration support floor and
+# 33 the current schema — see config.seed.yaml) all rewrite it. Copying our
+# seed over an existing file on every deploy would silently revert David's
+# model choice and clobber migrated schema — so if the file exists, we leave it
+# completely alone and say so in the log.
 if [[ -f "${DATA_DIR}/config.yaml" ]]; then
   echo "[hermes] config.yaml already present — leaving it untouched."
   echo "[hermes] To re-apply the seed, move the existing file aside first."


### PR DESCRIPTION
## Hermes is still down after this PR

Say it up front so nobody reads this as the fix: **`hermes` on celestia remains
in a crash loop after this merges.** Neither change touches the cause. The cause
is that no model provider is configured, that is David's call, and vault#117
records why it is deferred — no usable LLM key exists in the Eris vault. This PR
fixes two things that are wrong *independently* of that decision.

---

## (b) `config.seed.yaml` had no `_config_version` — the important one

Every boot logged:

```
[config-migrate] WARNING: This config predates version 12 (~2 years old) and can no longer be auto-migrated.
```

### Why

Read out of upstream at the tag `compose.yaml` pins, `v2026.7.30`:

- `hermes_cli/config.py::check_config_version()` coerces a missing
  `_config_version` to **0** via `_coerce_config_version()`.
- `hermes_cli/config.py::migrate_config()` — the CLI path — deliberately does
  **not** floor-refuse that shape. It calls `_raw_config_has_explicit_version()`
  first and only refuses when the key is *present and old*, because a missing key
  is "a fresh minimal config (profile clones write bare keys; users hand-write
  two-line configs), not an ancient install." That is exactly our seed.
- `scripts/docker_config_migrate.py` — the path that actually runs at boot,
  invoked from `docker/stage2-hook.sh` (`/etc/cont-init.d/01-hermes-setup`) on
  every start — does **not** make that distinction. It compares `current_ver`
  against `SUPPORT_FLOOR_VERSION` directly, `0 < 12`, takes the below-floor
  branch, prints the warning, and `return 0` without ever calling
  `migrate_config()`.

So the seed was misclassified as a two-year-old config, never stamped, and the
warning repeated forever. It is an upstream inconsistency between the two gates,
not a mistake in how the seed was written — but stamping the file sidesteps it
entirely.

### Was the hardening applied, or silently discarded?

**Applied.** This was the open question and it is now resolved from source, not
inference:

1. The below-floor branch is warn-and-continue by design.
   `hermes_cli/config_migrations.py` documents it: below-floor configs are
   *"left byte-for-byte untouched — the process continues with the config as-is
   (defaults deep-merged at read time…)"*.
2. `_load_config_impl()` deep-copies `DEFAULT_CONFIG` and `_deep_merge`s the raw
   user file over it on every read. There is **no reference to
   `_config_version` anywhere in the load path** — no version gate, no discard.
3. `hermes_cli/tools_config.py::_get_platform_tools()` reads
   `config["platform_toolsets"]` straight off that merged config, and an explicit
   list is authoritative. `_deep_merge` replaces lists wholesale rather than
   unioning them, which is precisely the behaviour the narrowed `cli` toolset
   depends on.
4. `apply_terminal_config_to_env()` gates on
   `isinstance(read_raw_config().get("terminal"), dict)` → true for this seed →
   "config.yaml is authoritative and overrides existing env values", so
   `terminal.cwd` and `terminal.backend` bridge through.

Hermes was **not** coming up with upstream defaults. The
`terminal`/`tool_loop_guardrails`/`platform_toolsets` containment vault#117 asked
for was in force the whole time. The warning was noise.

That said — the containment has never actually been *exercised*, because the
container has never stayed up. What is proven here is that the config is read and
merged. See "Still unverified" below.

### Why 33

`DEFAULT_CONFIG["_config_version"] = 33` in `hermes_cli/config_defaults.py` at
tag `v2026.7.30`. Not guessed, not inferred from the migration registry (whose
last entry is coincidentally also 33). It is what a fresh `hermes setup` on this
exact image writes.

Stamping it at latest means `docker_config_migrate.py` returns at its
`current_ver >= latest_ver` short-circuit: no warning, and no migration pass that
would rewrite the seed and strip every comment out of it. None of the 13
registered migration steps (v12→v33) would have done anything to this file
anyway — they all key off `custom_providers`, `stt.model`, `display.*`,
`compression.summary_*`, `plugins.enabled`, `curator`, `model_catalog`,
`memory/skills.write_mode`, `agent.verify_on_stop`, `delegation.max_async_children`,
none of which the seed sets.

The rationale is written into the file, including what happens when Renovate
bumps the image past schema 33.

---

## (a) `.env` said something false and called it verified

```
# Until a key is set the gateway still starts, the dashboard still serves, and
# the healthcheck still passes; the agent simply cannot infer. Verified.
```

All three clauses are wrong. The actual chain, at the pinned tag:

1. `Dockerfile`: `ENTRYPOINT ["/init", "/opt/hermes/docker/main-wrapper.sh"]`,
   `CMD []`. `main-wrapper.sh` execs `hermes` with no arguments as s6-overlay's
   **main program**.
   - Worth correcting a naming detail from the original diagnosis:
     `docker/s6-rc.d/main-hermes/run` is `exec sleep infinity`. It is a
     placeholder slot that exists only because s6-rc rejects an empty user
     bundle — it does not run the agent. The CMD does.
2. `hermes_cli/main.py` first-run guard: `_has_any_provider_configured()` is
   false → prints "It looks like Hermes isn't configured yet" → checks
   `is_interactive_stdin()` → Dockge starts detached, no TTY → `sys.exit(1)`.
3. Under the main-program model, the CMD exiting takes `/init` and the entire
   supervision tree with it — **including the `dashboard` longrun**. The
   dashboard never binds, `/api/health` never answers, the healthcheck cannot
   pass. `restart: unless-stopped` restarts it, it fails identically, and
   Docker's backoff walks up to its ~60s ceiling. 31 cycles observed.

Replaced with the above, stated as: a provider is **required for the container to
run at all**, not merely for inference to work.

No `op://` literal was added anywhere in a comment — that is the bug HO#636 just
fixed. Verified mechanically against the actual regex in
`components/store/index.ts` (`/op:\/\/Eris\/([\w| -]+)\/([\w| -]+)/g`): zero
matches in the edited file.

---

## (c) drive-by: `init.sh` migration aside

Said the ladder spans `v0 -> v33`. It does not — v12 is upstream's auto-migration
support floor, and the sub-v12 steps were deleted in July 2026. One-comment fix,
same defect family, corrected while I had the source open.

---

## For whoever makes the provider call

Not a recommendation, just a gotcha found while looking at the local-inference
route, so it does not have to be rediscovered:

`docker/_common/llama-vulkan/compose.yaml` declares **no `networks:` key**. It
therefore sits on its own compose project's default bridge network and publishes
`8080` on the **host**. Hermes is attached to the external `dockge_default`
network with no host networking and no `extra_hosts`, so **`http://localhost:8080/v1`
would not work as-is.** Three ways out, in rough order of least surprise:

1. `extra_hosts: ["host.docker.internal:host-gateway"]` on the hermes service,
   then point at `http://host.docker.internal:8080/v1`.
2. The celestia host IP directly.
3. Attach `llama-vulkan` to `dockge_default` too and use the service name — the
   cleanest, but it changes a `_common` file deployed to every dockge host, so it
   is the biggest blast radius of the three.

Also relevant to sequencing: `_has_any_provider_configured()` is satisfied by
`OPENAI_BASE_URL` **on its own** — local OpenAI-compatible servers frequently
need no key. So pointing Hermes at a local endpoint ends the boot loop without
any credential existing anywhere. That makes the local route viable as a
*stop-the-bleeding* step decoupled from the primary-model decision, even given
that gemma-3-4b-it is a poor primary driver for an agent holding a shell.

That is David's call, not mine. Nothing in this PR moves toward it.

---

## Still unverified

- **That the narrowed toolset takes effect at runtime.** I have proven the config
  is read and merged and that `platform_toolsets.cli` is the authoritative input
  to toolset resolution. I have not proven the resulting tool surface, because
  the container has never stayed up long enough to ask it. Once a provider is set
  and it boots, the check is:
  ```
  docker exec hermes hermes tools list
  ```
  Expect exactly `web, terminal, file, skills, todo, memory, session_search,
  clarify` — plus, per the existing note in the seed, possibly `bfl`, which
  appears to register outside `platform_toolsets` and is inert without its key.
  Cross-check `terminal.cwd` with
  `docker exec hermes printenv TERMINAL_CWD` → `/opt/data/workspace`.
- **That the migration warning is gone.** Only observable on a *fresh* data
  volume, since `init.sh` never overwrites an existing `config.yaml`. The live
  `/opt/stacks-data/hermes/config.yaml` on celestia still lacks the key and will
  keep warning until it is either hand-stamped or the volume is re-seeded. That
  is deliberate — this PR does not touch host state.

## Scope

Config-and-comment only. No provider set, no `pulumi up`, no host edits, no
1Password changes. `stacks/home` is converging on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- crew:agent=link -->
