### PR TITLE
feat(itsaplan): deploy to celestia as compose on a shared per-node postgres

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -133,6 +133,21 @@
       matchPackageNames: ["nousresearch/hermes-agent"],
       versioning: "loose",
     },
+    {
+      // The repo extends "docker:enableMajor", so without this rule Renovate
+      // would happily open a postgres 17 -> 18 PR for docker/_common/postgres.
+      // Merging it would not be an upgrade, it would be an outage: PGDATA is
+      // bound to the major version that created it, and an 18 binary starting
+      // on a 17 data directory exits with "database files are incompatible
+      // with server" and crash-loops. A major move is a pg_upgrade or a
+      // dump/restore, planned alongside the CNPG decision in vault#114 — never
+      // an image bump. Minor, patch and digest updates still flow normally.
+      description: "Container Postgres majors are a data migration, not an image bump",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["postgres"],
+      matchUpdateTypes: ["major"],
+      enabled: false,
+    },
   ],
   customManagers: [
     {

--- a/docker/_common/postgres/.env
+++ b/docker/_common/postgres/.env
@@ -1,0 +1,48 @@
+# 1Password reference format: op://<vault>/<item-name>/<field-name>
+#
+# Everything below is resolved by GlobalResources.replaceOnePasswordPlaceholders
+# (components/store/index.ts:115) before this file is copied to the host. That
+# resolver is a plain regex over the raw file text with no notion of comments,
+# and a reference to a *missing item* throws an unhandled exception that aborts
+# the entire stacks/home program — not just this stack (HO#636). So: never
+# write a reference-shaped string in a comment here, even a disabled one, and
+# never reference an item before it exists in 1Password.
+#
+# --- superuser -------------------------------------------------------------
+# Item to create: a Password item titled "Docker Postgres" with a `password`
+# field. One item, reused by every node — the instances are independent and
+# never replicate to each other, so a shared superuser secret buys convenience
+# without creating a shared blast radius beyond what a Dockge host already has.
+POSTGRES_SUPERUSER_PASSWORD="op://Eris/Docker Postgres/password"
+
+TIMEZONE=${TIMEZONE}
+
+# --- dump schedule ---------------------------------------------------------
+# Consumed by backup.sh. Daily, two weeks of local history; restic keeps the
+# long tail. Both are read at container start, so changing them needs a restart.
+POSTGRES_DUMP_INTERVAL_SECONDS=86400
+POSTGRES_DUMP_KEEP_DAYS=14
+
+# --- application databases -------------------------------------------------
+# Declared per host, NOT here. Any variable named PGAPP_<NAME>_PASSWORD makes
+# provision.sh create a login role <name> and a database <name> owned by it.
+#
+# This base file deliberately declares none, which is the correct state for a
+# node with no consumers: postgres-provision reconciles nothing and exits 0.
+# A host that does have consumers overrides this whole file — DockgeLxc's
+# getStackFiles (components/DockgeLxc.ts:740) prefers docker/<host>/<stack>/
+# over docker/_common/<stack>/ per relative path, so the override is
+# whole-file, not merged. docker/celestia/postgres/.env is the worked example;
+# it necessarily repeats the lines above.
+#
+# --- exposure --------------------------------------------------------------
+# This service has no published ports and no traefik labels, but it does sit on
+# the host-wide dockge_default network, so every container on the node can open
+# a TCP connection to postgres-shared:5432. The password is the only boundary
+# between stacks. That is inherent to "one Postgres serving several stacks" —
+# they need a network in common, and dockge_default is the only host-wide one
+# the estate creates (components/DockgeLxc.ts:593). The alternative, a
+# dedicated external network that consumers opt into, would isolate better but
+# nothing creates it, and a consumer deployed before the network exists fails
+# at `docker compose up` with a confusing error. _common/neo4j already sits on
+# dockge_default on the same reasoning.

--- a/docker/_common/postgres/.ignore
+++ b/docker/_common/postgres/.ignore
@@ -1,0 +1,43 @@
+This stack is staged, not deployed. Delete this file to enable it on every
+Dockge host.
+
+WHY THE GATE IS HERE AND NOT A COMMENTED-OUT COMPOSE FILE
+---------------------------------------------------------
+components/DockgeLxc.ts:754 checks for a `.ignore` in either the _common or the
+host stack directory and returns null from getStackFiles *before any file in
+this directory is read*. That ordering is the point: no read means no
+`op://` resolution, so a reference to a 1Password item that does not exist yet
+cannot fire.
+
+That matters more than usual here. GlobalResources.replaceOnePasswordPlaceholders
+(components/store/index.ts:115) throws an unhandled exception on a missing item,
+and that aborts the entire stacks/home program — freezing Docker deploys on
+every host, which is exactly what happened for ~90 minutes in HO#636. `.env` in
+this directory references an item that has to be created by hand first, so
+merging this PR without the gate would be a live estate-wide outage risk rather
+than a theoretical one.
+
+BEFORE DELETING THIS FILE
+-------------------------
+1. Create a 1Password item in the Eris vault titled `Docker Postgres`, of
+   category Password, with a `password` field. Generate it with
+   `openssl rand -hex 32`.
+
+2. Decide whether every node should run this. It is a `_common` stack, so
+   deleting this file starts Postgres on celestia, alpha-site, luna AND
+   skystar. Only celestia has a consumer today (itsaplan), so the other three
+   would each run an idle instance: ~30-50MB RSS at rest plus the 2g mem_limit
+   headroom, provisioning zero databases, and producing a nightly globals-only
+   dump of an empty cluster. That is small but not nothing, and a database
+   nobody uses is still a thing that must be patched.
+
+   To run it on celestia only, delete this file and add an empty `.ignore` to
+   `docker/<host>/postgres/` for each host that should skip it — the same check
+   reads host directories too. Per-node was the ask, so the default here is all
+   four; the per-host opt-out is the escape hatch if the idle cost is not worth
+   it.
+
+3. Note that luna's stacks use `network_mode: host` (docker/AGENTS.md). This
+   compose file joins `dockge_default` instead and has been verified against
+   celestia conventions only. Deploying to luna is UNVERIFIED — check that the
+   host-networking pattern there does not conflict before enabling it.

--- a/docker/_common/postgres/backup.sh
+++ b/docker/_common/postgres/backup.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Periodic logical dumps of every application database on this node.
+#
+# WHY THIS EXISTS. The celestia dockge backrest plan (stacks/backups/index.ts)
+# rclone-pulls /opt/stacks-data/ from each Dockge host and restic-snapshots the
+# result. For almost every stack a file copy is a fine backup. For Postgres it
+# is not: copying a running cluster's data directory yields torn pages and a
+# WAL that does not match, so the snapshot may restore to nothing. The live
+# PGDATA is therefore excluded from that plan and these dumps are the real
+# backup source — each one a consistent snapshot taken inside a single
+# transaction, written to a path that IS in backup scope.
+#
+# NOTE FOR EDITORS: this file is run through the Pulumi variable substitution
+# in components/DockgeLxc.ts. Do not introduce shell variables named host,
+# hostname, ipAddress, searchDomain, APP, STACK_NAME, CLUSTER_*, TIMEZONE, or
+# UPTIME_API_URL — those tokens are rewritten in transit.
+set -eu
+
+interval="${POSTGRES_DUMP_INTERVAL_SECONDS:-86400}"
+keep_days="${POSTGRES_DUMP_KEEP_DAYS:-14}"
+out_dir=/dumps
+
+echo "[backup] every ${interval}s, keeping ${keep_days} days, into ${out_dir}"
+
+while true; do
+  stamp=$(date +%Y%m%dT%H%M%S)
+
+  # Roles and their passwords live outside any single database, so a per-database
+  # dump alone is not restorable on a fresh cluster. --globals-only captures them.
+  if pg_dumpall --globals-only >"${out_dir}/globals-${stamp}.sql.tmp"; then
+    mv "${out_dir}/globals-${stamp}.sql.tmp" "${out_dir}/globals-${stamp}.sql"
+  else
+    rm -f "${out_dir}/globals-${stamp}.sql.tmp"
+    echo "[backup] WARN: globals dump failed" >&2
+  fi
+
+  # Template databases and the maintenance database carry nothing worth keeping.
+  for db_name in $(psql -tA -d postgres \
+      -c "SELECT datname FROM pg_database WHERE datistemplate = false AND datname <> 'postgres'"); do
+    # -Fc is the custom format: compressed, and restorable selectively with
+    # pg_restore rather than only as a whole-file replay.
+    if pg_dump -Fc -d "$db_name" -f "${out_dir}/${db_name}-${stamp}.dump.tmp"; then
+      # Rename only after a clean exit, so a dump interrupted mid-write is never
+      # mistaken for a good one by the retention sweep or by a restore.
+      mv "${out_dir}/${db_name}-${stamp}.dump.tmp" "${out_dir}/${db_name}-${stamp}.dump"
+      echo "[backup] dumped ${db_name}"
+    else
+      rm -f "${out_dir}/${db_name}-${stamp}.dump.tmp"
+      echo "[backup] WARN: dump of ${db_name} failed" >&2
+    fi
+  done
+
+  # Retention. Restic keeps its own history of these files, so this only bounds
+  # what sits on the host between snapshots.
+  find "$out_dir" -maxdepth 1 -type f \( -name '*.dump' -o -name '*.sql' \) \
+    -mtime "+${keep_days}" -delete 2>/dev/null || true
+  find "$out_dir" -maxdepth 1 -type f -name '*.tmp' -mtime +1 -delete 2>/dev/null || true
+
+  sleep "$interval"
+done

--- a/docker/_common/postgres/compose.yaml
+++ b/docker/_common/postgres/compose.yaml
@@ -1,0 +1,168 @@
+services:
+  # Shared Postgres for this Docker node. One instance per host (this is a
+  # `_common` stack, so components/DockgeLxc.ts:641 deploys it to celestia,
+  # alpha-site, luna and skystar alike), serving every consumer stack on that
+  # host rather than each app shipping its own database container.
+  #
+  # NAMING — deliberate, and the single most important line in this file.
+  # The service, container and DNS name is `postgres-shared`, NOT `postgres`.
+  # This stack sits on the host-wide `dockge_default` network, where every
+  # container name is a DNS name every other container on the host resolves.
+  # `postgres` is the single most likely name for some future stack to claim:
+  # vendor compose files use it constantly — itsaplan's own upstream
+  # docker-compose.yml has a service called exactly `postgres`. Two containers
+  # answering to one name on one network is a round-robin coin flip on every
+  # connection, which is the hazard docker/celestia/homelable/compose.yaml
+  # documents for the name `backend`. A stack literally called `postgres` on a
+  # shared network is the sharpest possible version of that problem, so the
+  # generic name is left unclaimed on purpose. Consumers dial
+  # `postgres-shared:5432`.
+  postgres-shared:
+    # Postgres 17, chosen rather than inherited:
+    #   * upstream itsaplan pins `postgres:17-alpine` and runs its test suite
+    #     against it (docker-compose.test.yml), so 17 is the tested target;
+    #   * the estate's CNPG clusters are on 17 today, and vault#114 (the 17->18
+    #     conversation) is still open. Following the CNPG decision rather than
+    #     getting ahead of it keeps one Postgres major across the estate.
+    # When vault#114 lands on 18, this moves with it — deliberately second.
+    #
+    # A major bump here is NOT an image bump: PGDATA is major-version-bound and
+    # a 17->18 image swap crash-loops on "database files are incompatible".
+    # `.github/renovate.json5` disables major updates for this image for that
+    # reason; minor/patch/digest still flow normally.
+    image: postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193
+    container_name: postgres-shared
+    hostname: postgres-shared
+    env_file:
+      - .env
+    environment:
+      TZ: ${TIMEZONE}
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_SUPERUSER_PASSWORD}
+      # The maintenance database. Application databases are created by the
+      # postgres-provision service below, never here.
+      POSTGRES_DB: postgres
+      # First-init only. Checksums make torn pages loud instead of silent;
+      # they cannot be turned on later without a dump/restore, so the choice
+      # has to be made now.
+      POSTGRES_INITDB_ARGS: "--data-checksums"
+      PGDATA: /var/lib/postgresql/data/pgdata
+    # Runs as the image's own postgres user (uid/gid 70 on Alpine) rather than
+    # starting as root and stepping down. init.sh pre-creates and chowns the
+    # data directories, so the entrypoint's chown pass is unnecessary — which
+    # in turn means the container needs no capabilities at all.
+    user: "70:70"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      # Live data. NOT usable as a backup source — a file copy of a running
+      # cluster is torn, not crash-consistent. `stacks/backups/index.ts`
+      # excludes this path and backs up the dumps below instead.
+      - /opt/stacks-data/postgres/pgdata:/var/lib/postgresql/data
+    # Postgres uses POSIX shared memory for parallel query; Docker's 64m
+    # default is small enough to cause "could not resize shared memory segment".
+    shm_size: 256mb
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    # The image sets STOPSIGNAL SIGINT (fast shutdown). The grace period is
+    # headroom for the resulting checkpoint on a busy cluster.
+    stop_grace_period: 1m
+    restart: unless-stopped
+    dns:
+      - 100.100.100.100
+    # Deliberately NOT autoheal-labelled. autoheal restarts unhealthy
+    # containers, and a database that is slow to answer pg_isready is usually
+    # in crash recovery — the one moment when restarting it repeatedly is the
+    # worst available action.
+    #
+    # No traefik labels and no published ports. Reachable only from
+    # dockge_default by name. See the exposure note in .env.
+    mem_limit: 2g
+    cpus: 2
+    networks:
+      - dockge_default
+
+  # Idempotent provisioner. Runs to completion on every stack start and
+  # reconciles roles + databases to whatever the .env declares.
+  #
+  # This exists because the postgres image's own /docker-entrypoint-initdb.d
+  # hook runs ONCE, on first init of an empty PGDATA. Adding a second consumer
+  # six months from now would never re-run it, and the failure would be silent.
+  # A provisioner that runs every time makes "add a consumer" a git edit.
+  #
+  # Convention: any variable named PGAPP_<NAME>_PASSWORD provisions a login
+  # role <name> and a database <name> owned by it. Nothing else is read, so a
+  # host with no consumers provisions nothing and this container exits 0.
+  postgres-provision:
+    image: postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193
+    container_name: postgres-shared-provision
+    depends_on:
+      postgres-shared:
+        condition: service_healthy
+    env_file:
+      - .env
+    environment:
+      TZ: ${TIMEZONE}
+      PGHOST: postgres-shared
+      PGUSER: postgres
+      PGPASSWORD: ${POSTGRES_SUPERUSER_PASSWORD}
+    user: "70:70"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - ./provision.sh:/provision.sh:ro
+    entrypoint: ["/bin/sh", "/provision.sh"]
+    # One-shot. `no` rather than `on-failure` so a persistently broken
+    # declaration is visible in `docker compose ps` instead of looping.
+    restart: "no"
+    dns:
+      - 100.100.100.100
+    networks:
+      - dockge_default
+
+  # Periodic logical dumps — the actual backup source for this database.
+  #
+  # The celestia dockge backrest plan (stacks/backups/index.ts) rclone-pulls
+  # /opt/stacks-data/ from each host and restic-snapshots it. That is a file
+  # copy of a live cluster, which for Postgres is not a restorable artifact.
+  # pg_dump produces one that is: each dump is a consistent snapshot taken
+  # inside a single transaction.
+  postgres-backup:
+    image: postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193
+    container_name: postgres-shared-backup
+    depends_on:
+      postgres-shared:
+        condition: service_healthy
+    env_file:
+      - .env
+    environment:
+      TZ: ${TIMEZONE}
+      PGHOST: postgres-shared
+      PGUSER: postgres
+      PGPASSWORD: ${POSTGRES_SUPERUSER_PASSWORD}
+    user: "70:70"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - ./backup.sh:/backup.sh:ro
+      - /opt/stacks-data/postgres/dumps:/dumps
+    entrypoint: ["/bin/sh", "/backup.sh"]
+    restart: unless-stopped
+    dns:
+      - 100.100.100.100
+    networks:
+      - dockge_default
+
+networks:
+  dockge_default:
+    external: true

--- a/docker/_common/postgres/init.sh
+++ b/docker/_common/postgres/init.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Pre-create the data directories with the ownership the Postgres containers
+# need. All three services run as uid/gid 70 (the postgres user in the Alpine
+# image) with cap_drop: ALL, so they cannot chown anything themselves — the
+# directories have to be right before the containers start.
+#
+# components/DockgeLxc.ts runs this on every deploy, so it must stay idempotent.
+set -euo pipefail
+
+for dir in /opt/stacks-data/postgres/pgdata /opt/stacks-data/postgres/dumps; do
+  mkdir -p "$dir"
+  chown 70:70 "$dir"
+done
+
+# initdb refuses to run in a directory with group/world permissions.
+chmod 700 /opt/stacks-data/postgres/pgdata
+chmod 750 /opt/stacks-data/postgres/dumps
+
+echo "Shared Postgres data directories ready."

--- a/docker/_common/postgres/provision.sh
+++ b/docker/_common/postgres/provision.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+# Idempotent role + database provisioner for the shared Postgres on this node.
+#
+# Runs to completion on every stack start. It is intentionally NOT the image's
+# /docker-entrypoint-initdb.d hook: that hook fires once, on first init of an
+# empty PGDATA, so a consumer added later would never be provisioned and the
+# failure would be silent until the app tried to connect.
+#
+# Declaration format, in this stack's .env:
+#
+#   PGAPP_<NAME>_PASSWORD=<password>
+#
+# provisions a login role <name> and a database <name> owned by it, where
+# <name> is <NAME> lowercased. Nothing else in the environment is read, so a
+# host with no consumers provisions nothing and exits 0. To add a consumer,
+# add one variable to the host's .env override; to remove one, delete the
+# variable — note that this script never DROPs anything, on purpose.
+#
+# NOTE FOR EDITORS: this file is run through the Pulumi variable substitution
+# in components/DockgeLxc.ts before it lands on the host. Do not introduce
+# shell variables named host, hostname, ipAddress, searchDomain, APP,
+# STACK_NAME, CLUSTER_*, TIMEZONE, or UPTIME_API_URL — those tokens are
+# rewritten in transit.
+set -eu
+
+echo "[provision] reconciling roles and databases on ${PGHOST}"
+
+provisioned=0
+
+for var_name in $(env | sed -n 's/^\(PGAPP_[A-Za-z0-9_]*_PASSWORD\)=.*/\1/p'); do
+  # PGAPP_ITSAPLAN_PASSWORD -> itsaplan
+  db_name=$(printf '%s' "$var_name" | sed 's/^PGAPP_//; s/_PASSWORD$//' | tr '[:upper:]' '[:lower:]')
+
+  # Constrain to a safe identifier. Everything downstream relies on this.
+  case "$db_name" in
+    *[!a-z0-9_]* | "")
+      echo "[provision] SKIP ${var_name}: '${db_name}' is not a valid identifier ([a-z0-9_])" >&2
+      continue
+      ;;
+  esac
+
+  app_pw=$(printenv "$var_name" || true)
+  if [ -z "$app_pw" ]; then
+    echo "[provision] SKIP ${var_name}: empty value" >&2
+    continue
+  fi
+
+  # An unresolved 1Password reference means the item or field is missing and
+  # the placeholder was passed through verbatim. Creating a role whose password
+  # is the literal string "op://..." would be worse than failing loudly.
+  case "$app_pw" in
+    op://*)
+      echo "[provision] SKIP ${var_name}: 1Password reference did not resolve" >&2
+      continue
+      ;;
+  esac
+
+  # Role and database, both create-if-missing then reconcile.
+  #
+  # These use `\gexec` — a SELECT that BUILDS the DDL as text, which psql then
+  # executes — rather than a DO block. Two reasons, one of them a trap:
+  #
+  #   * psql does NOT substitute :'var' inside a dollar-quoted body ($do$...$do$).
+  #     It treats the whole block as an opaque literal, so a DO block containing
+  #     :'db_name' reaches the server with the colon-form intact and fails with
+  #     `syntax error at or near ":"`. Verified against postgres:17-alpine.
+  #   * CREATE DATABASE cannot run inside a transaction block, so it could not
+  #     live in a DO block anyway.
+  #
+  # format() with %I/%L does the quoting server-side, so neither an identifier
+  # nor a password containing quotes can break out of its context.
+  psql -q -v ON_ERROR_STOP=1 -d postgres \
+    --set=db_name="$db_name" --set=app_pw="$app_pw" <<'SQL'
+SELECT format('CREATE ROLE %I LOGIN', :'db_name')
+WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'db_name')
+\gexec
+
+SELECT format('ALTER ROLE %I WITH LOGIN PASSWORD %L', :'db_name', :'app_pw')
+\gexec
+
+SELECT format('CREATE DATABASE %I OWNER %I', :'db_name', :'db_name')
+WHERE NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = :'db_name')
+\gexec
+
+-- Pin search_path to public for this role in this database.
+--
+-- Belt-and-braces, and the reason is worth keeping: ORMs that ship unqualified
+-- DDL (drizzle, which is what itsaplan uses) resolve CREATE TABLE against the
+-- default search_path of "$user", public. Today no schema named after the role
+-- exists, so everything lands in public and this changes nothing. The day
+-- someone creates a role-named schema, every later migration would silently
+-- retarget it — the shape that stalled the windmill 1.722 upgrade on the
+-- Kubernetes side. Pinning it now costs nothing and removes the failure mode.
+-- Role-level settings also apply to the migration runner, which a connection
+-- string parameter would only cover if every consumer remembered to add it.
+SELECT format('ALTER ROLE %I IN DATABASE %I SET search_path = public', :'db_name', :'db_name')
+\gexec
+SQL
+
+  # PG15+ no longer grants CREATE on the public schema to PUBLIC. The database
+  # owner reaches it through pg_database_owner anyway, so this is explicit
+  # rather than strictly required — and idempotent. It needs a connection to
+  # the application database itself, hence the separate invocation.
+  #
+  # Note this is a heredoc, not `psql -c`: psql performs variable interpolation
+  # only on input it parses itself (files and stdin), never on a -c string, so
+  # a -c containing :"db_name" reaches the server verbatim and fails. Verified.
+  psql -q -v ON_ERROR_STOP=1 -d "$db_name" --set=db_name="$db_name" <<'SQL'
+SELECT format('GRANT ALL ON SCHEMA public TO %I', :'db_name')
+\gexec
+SQL
+
+  provisioned=$((provisioned + 1))
+  echo "[provision] ok: ${db_name}"
+done
+
+echo "[provision] done — ${provisioned} database(s) reconciled"

--- a/docker/celestia/itsaplan/.env
+++ b/docker/celestia/itsaplan/.env
@@ -1,0 +1,92 @@
+# 1Password reference format: op://<vault>/<item-name>/<field-name>
+#
+# These are resolved by GlobalResources.replaceOnePasswordPlaceholders
+# (components/store/index.ts:115) before the file is copied to the host. That
+# resolver is a plain regex over raw file text with no notion of comments, and
+# a reference to a *missing item* throws an unhandled exception that aborts the
+# entire stacks/home program — every Docker deploy on every host, not just this
+# stack (HO#636). So: never write a reference-shaped string in a comment here,
+# even a disabled one, and never reference an item before creating it.
+#
+# Item to create: "Itsaplan", with the six fields referenced below.
+# Generate every one with `openssl rand -hex 32`.
+#
+#   HEX, NOT BASE64, AND THIS MATTERS FOR db_password. It is interpolated into
+#   DATABASE_URL as URI userinfo, where base64's `/` and `+` change how the URI
+#   parses — a password containing `/` truncates the host. Hex is URL-safe, so
+#   no encoding step is needed and none can be forgotten. The other five are
+#   opaque strings where any alphabet would do; keeping them all hex removes
+#   the question of which is which.
+
+# --- database ---------------------------------------------------------------
+# The shared per-node Postgres from docker/_common/postgres. Role and database
+# `itsaplan` are provisioned there by provision.sh, from this same 1Password
+# field (docker/celestia/postgres/.env) — one source of truth, so the two
+# cannot drift.
+#
+# No search_path override is needed in this URL: provision.sh runs
+# `ALTER ROLE itsaplan IN DATABASE itsaplan SET search_path = public`, which
+# also covers the migration runner. itsaplan's drizzle migrations are written
+# unqualified, so where they land is a real question, not a theoretical one —
+# see the comment in provision.sh.
+DATABASE_URL="postgres://itsaplan:op://Eris/Itsaplan/db_password@postgres-shared:5432/itsaplan"
+
+# --- auth and encryption ----------------------------------------------------
+BETTER_AUTH_SECRET="op://Eris/Itsaplan/better_auth_secret"
+
+# WRITE-ONCE IN PRACTICE. This key encrypts stored AI-provider credentials at
+# rest with AES-256-GCM and the app has no re-wrap path: changing it makes every
+# stored credential permanently undecryptable. Rotating it is a data migration,
+# not a config change.
+APP_ENCRYPTION_KEY="op://Eris/Itsaplan/app_encryption_key"
+
+# Shared by api, worker and bot; authenticates the /internal/* routes.
+WORKER_INTERNAL_TOKEN="op://Eris/Itsaplan/worker_internal_token"
+
+# --- public origins ---------------------------------------------------------
+# API_URL is the api origin (auth handler, email links, and the browser bundle);
+# APP_URL is the web origin (CORS trusted origins, passkey relying party, email
+# links). API_URL is ALSO a build arg for the web image — changing it requires
+# rebuilding web, not just restarting it.
+#
+# INTERNAL ONLY, deliberately. Both hostnames resolve on the LAN through
+# Technitium split-horizon and over the tailnet; neither is internet-reachable.
+# The reason is specific rather than a default posture: itsaplan's registration
+# mode defaults to `open` and can only be closed afterwards from god mode, so an
+# internet-reachable instance accepts self-signup until someone logs in and turns
+# it off. It also holds project data plus AI-provider credentials. And nothing
+# about it needs inbound reachability — the Telegram bot is outbound long-poll
+# and webhook delivery is outbound from the worker.
+API_URL="https://itsaplan-api.${CLUSTER_DOMAIN}"
+APP_URL="https://itsaplan.${CLUSTER_DOMAIN}"
+
+# Passkey relying party. Defaults to the APP_URL hostname, set explicitly so a
+# later APP_URL edit cannot silently invalidate every registered passkey.
+PASSKEY_RP_ID="itsaplan.${CLUSTER_DOMAIN}"
+PASSKEY_RP_NAME="Its a Plan"
+
+# --- object store -----------------------------------------------------------
+# These double as the MinIO root credentials (upstream's design). MinIO is not
+# on any shared network and publishes no ports.
+S3_BUCKET=planner-attachments
+S3_ACCESS_KEY_ID="op://Eris/Itsaplan/s3_access_key_id"
+S3_SECRET_ACCESS_KEY="op://Eris/Itsaplan/s3_secret_access_key"
+# Required by the AWS SDK, ignored by MinIO.
+S3_REGION=us-east-1
+
+# --- telemetry --------------------------------------------------------------
+# Anonymous telemetry ships from the worker and is on by default (TELEMETRY.md).
+# Off here: this is a private instance and its usage shape is not upstream's to
+# collect. Both variables are set because either one alone would do it, and the
+# pair is self-documenting.
+TELEMETRY_DISABLED=1
+DO_NOT_TRACK=1
+
+# --- deliberately not set ---------------------------------------------------
+# EMAIL_FROM / SMTP — no mailer is wired up, so notification email is inert.
+#   Passkeys and password login both work without it; only email-based flows
+#   (invites, notification digests) are affected. Staged to a follow-up.
+# COOKIE_DOMAIN — the default parent domain derived from APP_URL is correct for
+#   a single-label subdomain of the cluster domain.
+# PRIVACY_URL / TERMS_URL — build args for the logged-out screens; empty hides
+#   the legal notice, which is right for a private instance.

--- a/docker/celestia/itsaplan/.ignore
+++ b/docker/celestia/itsaplan/.ignore
@@ -1,0 +1,46 @@
+This stack is staged, not deployed. Delete this file to enable it on celestia.
+
+components/DockgeLxc.ts:754 makes getStackFiles return null before any file
+here is read, so none of the `op://` references in .env resolve and none of the
+source fetching or image building in init.sh runs. Nothing about this directory
+touches the estate while this file exists.
+
+BEFORE DELETING THIS FILE
+-------------------------
+1. Enable the shared database first. `docker/_common/postgres/.ignore` must be
+   gone and that stack must have run at least once on celestia, so that the
+   `itsaplan` role and database exist. The api applies its migrations on start
+   and will crash-loop against a database that is not there.
+
+2. Create a 1Password item in the Eris vault titled `Itsaplan` with six fields,
+   each generated with `openssl rand -hex 32`:
+
+     db_password            also read by docker/celestia/postgres/.env
+     better_auth_secret
+     app_encryption_key     write-once in practice — see .env
+     worker_internal_token
+     s3_access_key_id
+     s3_secret_access_key
+
+   A missing item aborts the whole stacks/home run (HO#636), so create it
+   before deleting this file, not after.
+
+3. Confirm the two hostnames are what you want:
+     itsaplan.<cluster domain>       web
+     itsaplan-api.<cluster domain>   api
+   The api origin is compiled into the web browser bundle at build time, so
+   changing it later is a rebuild rather than an edit. Settle it first.
+
+4. Accept the build. There is no upstream image to pull (see init.sh), so the
+   first deploy runs `bun install` and a Next.js production build for four
+   images on celestia. Expect that to be slow the first time and effectively
+   free afterwards, since init.sh no-ops on an unchanged version and Docker's
+   layer cache covers the rest. The duration is UNVERIFIED — nothing has been
+   built on the host.
+
+IMMEDIATELY AFTER THE FIRST DEPLOY
+----------------------------------
+Log in, then close registration from god mode. itsaplan's registration mode
+defaults to `open`, so until that is done anyone who can reach the hostnames
+can create an account. Both origins are internal-only for this reason, but
+internal-only is a smaller boundary than closed.

--- a/docker/celestia/itsaplan/compose.yaml
+++ b/docker/celestia/itsaplan/compose.yaml
@@ -1,0 +1,296 @@
+# itsaplan — self-hosted issue tracker / planning tool (AGPL-3.0).
+# Upstream: https://github.com/croffasia/itsaplan
+#
+# Migrated from upstream's docker-compose.yml with three estate-shaped changes:
+#
+#   1. No postgres service. The database comes from docker/_common/postgres,
+#      the per-node shared instance, where role and database `itsaplan` are
+#      provisioned by that stack's provision.sh.
+#   2. Every service is renamed with an `itsaplan-` prefix. Four of them join
+#      the host-wide dockge_default network, where the container name is a DNS
+#      name every container on the node resolves — and upstream's names (`api`,
+#      `web`, `worker`, `bot`, `minio`) are exactly the generic names that
+#      collide, the hazard docker/celestia/homelable/compose.yaml documents.
+#   3. No published ports. Traefik fronts web and api; MinIO stays off the
+#      network entirely, as upstream intends.
+#
+# BUILDS FROM SOURCE, deliberately and unavoidably: upstream publishes no
+# images (see init.sh). `./src` is populated by init.sh at the pinned release
+# and components/DockgeLxc.ts:1012 runs `docker compose build` before `up -d`.
+# These four images are therefore the estate's only non-digest-pinned images.
+# What Renovate tracks instead is the source revision, via the annotation on
+# ITSAPLAN_VERSION in init.sh (the "Process annotated dependencies" custom
+# manager in .github/renovate.json5 covers *.sh). The two supporting images
+# below are ordinary pinned images.
+
+x-itsaplan-build: &itsaplan-build
+  context: ./src
+
+services:
+  # Applies database migrations on startup, then serves the API.
+  itsaplan-api:
+    build:
+      <<: *itsaplan-build
+      dockerfile: apps/api/Dockerfile
+    image: itsaplan-api:local
+    container_name: itsaplan-api
+    hostname: itsaplan-api
+    env_file:
+      - .env
+    environment:
+      NODE_ENV: production
+      API_PORT: 3000
+      S3_ENDPOINT: http://itsaplan-minio:9000
+    depends_on:
+      itsaplan-minio-init:
+        condition: service_completed_successfully
+    # The image's CMD is `bun run packages/db/src/migrate.ts && bun run
+    # apps/api/src/index.ts` — it does not listen until migrations finish.
+    # Upstream allows 90s; this is 180s because upstream's number assumes an
+    # already-migrated database and the first boot here replays the entire
+    # migration chain against an empty one. Nothing kills the container during
+    # start_period, so the cost of being generous is only a later first alert.
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:3000/"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 180s
+    restart: unless-stopped
+    dns:
+      - 100.100.100.100
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      # dockge_default to reach postgres-shared and to be routable by traefik;
+      # itsaplan for MinIO and the internal worker/bot hops.
+      - itsaplan
+      - dockge_default
+    labels:
+      traefik.enable: true
+      traefik.docker.network: dockge_default
+
+      # The browser talks to this origin directly — NEXT_PUBLIC_API_URL is
+      # inlined into the web bundle — so it needs a real router, not just
+      # in-network access.
+      traefik.http.routers.itsaplan-api.rule: Host(`itsaplan-api.${CLUSTER_DOMAIN}`)
+      traefik.http.routers.itsaplan-api.entrypoints: websecure
+      traefik.http.routers.itsaplan-api.tls.certresolver: le
+      traefik.http.routers.itsaplan-api.service: itsaplan-api
+
+      traefik.http.routers.itsaplan-api-tailscale.rule: Host(`itsaplan-api.${tailscaleDomain}`)
+      traefik.http.routers.itsaplan-api-tailscale.entrypoints: tailscale
+      traefik.http.routers.itsaplan-api-tailscale.service: itsaplan-api
+
+      traefik.http.services.itsaplan-api.loadbalancer.server.port: 3000
+
+  # Webhook delivery, notification delivery, agent schedules and agent runs.
+  # Shares the database with the api. No ports, no router.
+  itsaplan-worker:
+    build:
+      <<: *itsaplan-build
+      dockerfile: apps/worker/Dockerfile
+    image: itsaplan-worker:local
+    container_name: itsaplan-worker
+    hostname: itsaplan-worker
+    env_file:
+      - .env
+    environment:
+      NODE_ENV: production
+      SERVICE_URL_API: http://itsaplan-api:3000
+    depends_on:
+      itsaplan-api:
+        condition: service_started
+    restart: unless-stopped
+    dns:
+      - 100.100.100.100
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      # dockge_default only for postgres-shared; no traefik labels.
+      - itsaplan
+      - dockge_default
+
+  # Telegram bot: long-polls getUpdates. The bot token lives in the database
+  # and is edited in god mode, so it is not an environment variable.
+  #
+  # MUST STAY AT EXACTLY ONE INSTANCE. Telegram hands each getUpdates call to a
+  # single caller, so a second instance silently steals updates from the first.
+  # `container_name` is the structural guarantee rather than a comment: Docker
+  # requires container names to be unique, so `docker compose up --scale
+  # itsaplan-bot=2` fails outright instead of half-working.
+  itsaplan-bot:
+    build:
+      <<: *itsaplan-build
+      dockerfile: apps/bot/Dockerfile
+    image: itsaplan-bot:local
+    container_name: itsaplan-bot
+    hostname: itsaplan-bot
+    env_file:
+      - .env
+    environment:
+      NODE_ENV: production
+      SERVICE_URL_API: http://itsaplan-api:3000
+    depends_on:
+      itsaplan-api:
+        condition: service_started
+    restart: unless-stopped
+    dns:
+      - 100.100.100.100
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    # No database access at all, so it never needs dockge_default.
+    networks:
+      - itsaplan
+
+  # Next.js frontend. NEXT_PUBLIC_API_URL is inlined into the browser bundle at
+  # BUILD time, so this image is bound to the api origin it was built for.
+  # Changing API_URL in .env means a rebuild, not a restart — that is why the
+  # hostnames have to be settled before the first build rather than after.
+  itsaplan-web:
+    build:
+      <<: *itsaplan-build
+      dockerfile: apps/web/Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: ${API_URL}
+    image: itsaplan-web:local
+    container_name: itsaplan-web
+    hostname: itsaplan-web
+    environment:
+      NODE_ENV: production
+      PORT: 3001
+      HOSTNAME: 0.0.0.0
+    depends_on:
+      itsaplan-api:
+        condition: service_started
+    # /login renders without a session and without reaching the api.
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:3001/login"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+    dns:
+      - 100.100.100.100
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - itsaplan
+      - dockge_default
+    labels:
+      traefik.enable: true
+      traefik.docker.network: dockge_default
+
+      traefik.http.routers.itsaplan.rule: Host(`itsaplan.${CLUSTER_DOMAIN}`)
+      traefik.http.routers.itsaplan.entrypoints: websecure
+      traefik.http.routers.itsaplan.tls.certresolver: le
+      traefik.http.routers.itsaplan.service: itsaplan
+
+      traefik.http.routers.itsaplan-tailscale.rule: Host(`itsaplan.${tailscaleDomain}`)
+      traefik.http.routers.itsaplan-tailscale.entrypoints: tailscale
+      traefik.http.routers.itsaplan-tailscale.service: itsaplan
+
+      traefik.http.services.itsaplan.loadbalancer.server.port: 3001
+
+  # S3-compatible object store for issue attachments.
+  #
+  # Stays in-stack and stays OFF the network: no published ports, no traefik
+  # labels, not on dockge_default, and the console is disabled outright. The
+  # api streams attachment bytes through itself, so nothing else needs to reach
+  # :9000, and upstream's own comment makes the same choice. Administer with mc
+  # from inside the stack network.
+  #
+  # NOTE: minio/minio on Docker Hub has not shipped since RELEASE.2025-09-07
+  # (verified — `latest` still resolves to that same digest), so this image is
+  # ~11 months stale and is not receiving security updates. Keeping it entirely
+  # off the network is part of why that is tolerable here; it is still the
+  # weakest component in this stack and a long-term home for attachments is
+  # worth revisiting.
+  itsaplan-minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
+    container_name: itsaplan-minio
+    hostname: itsaplan-minio
+    command: server /data
+    env_file:
+      - .env
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY_ID}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_ACCESS_KEY}
+      # No console. Upstream leaves it listening on :9001 unpublished; off is
+      # strictly better than unpublished-but-listening.
+      MINIO_BROWSER: "off"
+    volumes:
+      # Attachment blobs — not reproducible from git, and the database holds
+      # only their metadata. Covered by the celestia dockge backrest plan,
+      # which syncs /opt/stacks-data minus an explicit exclude list
+      # (stacks/backups/index.ts).
+      - /opt/stacks-data/itsaplan/minio:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    restart: unless-stopped
+    dns:
+      - 100.100.100.100
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - itsaplan
+
+  # One-shot: waits for MinIO, creates the attachments bucket, exits.
+  # `service_completed_successfully` on the api is what guarantees the bucket
+  # exists before the first upload, and `service_healthy` here is what
+  # guarantees mc is talking to a MinIO that is actually listening.
+  itsaplan-minio-init:
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
+    container_name: itsaplan-minio-init
+    depends_on:
+      itsaplan-minio:
+        condition: service_healthy
+    env_file:
+      - .env
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY_ID}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_ACCESS_KEY}
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        mc alias set local http://itsaplan-minio:9000 "$$MINIO_ROOT_USER" "$$MINIO_ROOT_PASSWORD"
+        mc mb --ignore-existing local/"$$S3_BUCKET"
+        echo "bucket ready: $$S3_BUCKET"
+    restart: "no"
+    dns:
+      - 100.100.100.100
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - itsaplan
+
+networks:
+  # Stack-private: MinIO, and the worker/bot -> api hops. Keeps the generic
+  # service names off the host-wide network.
+  itsaplan: {}
+  dockge_default:
+    external: true
+
+x-dockge:
+  urls:
+    - https://itsaplan.${CLUSTER_DOMAIN}
+    - https://itsaplan.${tailscaleDomain}

--- a/docker/celestia/itsaplan/definition.yaml
+++ b/docker/celestia/itsaplan/definition.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: itsaplan
+spec:
+  name: Its a Plan
+  category: ${CLUSTER_TITLE}
+  description: Self-hosted issue tracking and project planning
+  url: &url https://itsaplan.${CLUSTER_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/planka.svg
+  access_policy:
+    groups:
+      - admins
+  # No `authentik:` block, deliberately.
+  #
+  # itsaplan authenticates natively (better-auth: password, passkeys, optional
+  # Google OAuth) and does not speak OIDC to an external provider, so there is
+  # no oauth2 client to create. A forward-auth proxy would not help either: the
+  # browser calls the api origin directly with NEXT_PUBLIC_API_URL baked into
+  # its bundle, so gating only the web origin would leave registration reachable
+  # on the api origin — the gate would look real without being one.
+  #
+  # Registration mode therefore has to be closed IN THE APP, from god mode,
+  # immediately after the first account is created. Until that is done, anyone
+  # who can reach these hostnames can self-register. That is the reason both
+  # origins are internal-only; see the routing note in .env.
+  gatus:
+    - group: ${CLUSTER_TITLE}
+      url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 200"
+    # The api is a separate origin and a separate container; the web app
+    # rendering fine says nothing about it. This is also the check that fails
+    # if the shared Postgres is down, since the api will not serve without it.
+    - name: API
+      group: ${CLUSTER_TITLE}
+      url: https://itsaplan-api.${CLUSTER_DOMAIN}/
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/docker/celestia/itsaplan/init.sh
+++ b/docker/celestia/itsaplan/init.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Fetch the itsaplan source tree that compose.yaml builds from.
+#
+# WHY A FETCH AND NOT AN IMAGE PIN. itsaplan publishes no container images.
+# Its AGENTS.md says so in as many words — "Images are not published to a
+# registry: every deploy builds from source (docker compose up -d --build)" —
+# and .github/workflows/ (ci, cla, codeql, pr-title, release) contains no build
+# or push job; `ghcr.io` appears nowhere in the repository. There is no tag to
+# pin, so the pinned thing is the *source revision* instead.
+#
+# The estate's Dockge flow copies files from git to the host rather than
+# cloning anything, so there is no source tree on celestia to build against —
+# this script is what puts one there. Both halves of that already exist as
+# estate practice: components/DockgeLxc.ts:1012 runs `docker compose build`
+# before `up -d` on every stack, and docker/_common/backups/init.sh already
+# downloads a release artifact from the internet at deploy time.
+#
+# components/DockgeLxc.ts:995 runs init.sh with `triggers: [Date.now()]`, i.e.
+# on EVERY apply. It must therefore be cheap when nothing changed — hence the
+# version stamp, which turns a re-apply into a no-op and lets Docker's layer
+# cache make the subsequent `compose build` a no-op too.
+set -euo pipefail
+
+# renovate: datasource=github-releases depName=croffasia/itsaplan
+ITSAPLAN_VERSION=v0.6.0
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+src_dir="${script_dir}/src"
+stamp_file="${src_dir}/.itsaplan-version"
+
+if [[ -f "$stamp_file" && "$(cat "$stamp_file")" == "$ITSAPLAN_VERSION" ]]; then
+  echo "itsaplan source already at ${ITSAPLAN_VERSION}"
+  exit 0
+fi
+
+echo "Fetching itsaplan ${ITSAPLAN_VERSION} ..."
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+curl -fsSL "https://github.com/croffasia/itsaplan/archive/refs/tags/${ITSAPLAN_VERSION}.tar.gz" \
+  -o "${tmp_dir}/itsaplan.tar.gz"
+
+# Extract to a staging path first so a failed download never leaves a
+# half-populated src/ that the next build would happily compile.
+mkdir -p "${tmp_dir}/extract"
+tar -xzf "${tmp_dir}/itsaplan.tar.gz" -C "${tmp_dir}/extract" --strip-components=1
+
+rm -rf "$src_dir"
+mv "${tmp_dir}/extract" "$src_dir"
+echo "$ITSAPLAN_VERSION" >"$stamp_file"
+
+echo "itsaplan source ready at ${ITSAPLAN_VERSION}"

--- a/docker/celestia/postgres/.env
+++ b/docker/celestia/postgres/.env
@@ -1,0 +1,31 @@
+# celestia's override of docker/_common/postgres/.env.
+#
+# getStackFiles (components/DockgeLxc.ts:740) resolves each relative path
+# against docker/<host>/<stack>/ first and falls back to docker/_common/<stack>/,
+# so this file REPLACES the common .env on celestia rather than extending it.
+# Everything the common file declares has to be repeated here — that duplication
+# is the cost of per-host consumer lists, and it is why the compose file itself
+# is not overridden.
+#
+# 1Password reference format: op://<vault>/<item-name>/<field-name>
+# The resolver is a plain regex with no notion of comments, and a reference to a
+# missing item aborts the entire stacks/home run (HO#636). Never write a
+# reference-shaped string in a comment, and create the item before referencing it.
+
+# --- superuser (same as _common) -------------------------------------------
+POSTGRES_SUPERUSER_PASSWORD="op://Eris/Docker Postgres/password"
+
+TIMEZONE=${TIMEZONE}
+
+# --- dump schedule (same as _common) ---------------------------------------
+POSTGRES_DUMP_INTERVAL_SECONDS=86400
+POSTGRES_DUMP_KEEP_DAYS=14
+
+# --- application databases on celestia -------------------------------------
+# PGAPP_<NAME>_PASSWORD provisions login role <name> + database <name> owned by
+# it. See docker/_common/postgres/provision.sh.
+#
+# itsaplan (docker/celestia/itsaplan). The same value is read by the app itself
+# from that stack's own .env, where it is assembled into DATABASE_URL — both
+# sides reference the identical 1Password field, so they cannot drift.
+PGAPP_ITSAPLAN_PASSWORD="op://Eris/Itsaplan/db_password"

--- a/stacks/backups/index.ts
+++ b/stacks/backups/index.ts
@@ -25,6 +25,16 @@ const dockgeInstances = dockgeDetails.apply(details => {
           sourcePath: "/stacks/",
           exclude: [
             // "/adguard/confdir/AdGuardHome.yaml*",
+            // The shared Postgres live data directory (docker/_common/postgres).
+            // A file-level copy of a running cluster is torn, not
+            // crash-consistent: the data files and the WAL are captured at
+            // different instants, so the snapshot can restore to nothing while
+            // still looking like a successful backup. That failure is silent
+            // until someone needs it. The restorable artifact is the nightly
+            // pg_dump output in /postgres/dumps, which is NOT excluded and is
+            // what this plan actually protects. Do not remove this line without
+            // replacing it with a proper WAL-archiving setup.
+            "/postgres/pgdata",
             "/authentik-outpost",
             "/backrest",
             "/autoheal",


### PR DESCRIPTION
Moves itsaplan off Kubernetes and onto celestia as a Docker Compose stack, per your pivot. **equestria-cluster#3000 is closed as superseded.**

**Merging this deploys nothing.** Both stacks carry a `.ignore` file, which makes `getStackFiles` (`components/DockgeLxc.ts:754`) return null *before any file in the directory is read*. That ordering is deliberate: no read means no `op://` resolution, so the missing-1Password-item crash that froze every Docker deploy for ~90 minutes in HO#636 cannot fire from these files. Enabling each stack is one file deletion, after the prerequisites listed inside each `.ignore`.

## The image blocker — my recommendation changed

In eq#3000 I proposed a separate `itsaplan-images` repo publishing to ghcr.io with a Renovate-driven rebuild chain. **I no longer recommend that.** Two things I verified in this repo overturned it:

1. **The estate already builds images on the host.** `components/DockgeLxc.ts:1012` runs `docker compose -f compose.yaml build && docker compose up -d && docker compose start` for *every* stack. The build step is not something I need to add — it is already there and already runs.
2. **`init.sh` already fetches from the internet at deploy time.** `docker/_common/backups/init.sh` downloads an rclone release and unpacks it before compose runs. Fetching a pinned source tarball is the same move, not a new pattern.

So the objection that killed on-host building — "the Dockge flow copies files from git, there is no source tree to build from" — is answered by the mechanism the estate already has: `init.sh` puts the source tree there, then the existing build step consumes it.

The blocker itself has not gone away and is now stated by upstream in its own words. `AGENTS.md:164`: *"Images are not published to a registry: every deploy builds from source."* The workflows are `ci`, `cla`, `codeql`, `pr-title`, `release` — no build, no push; `ghcr.io` appears nowhere in the repository. Upstream is at **v0.6.0** (published today), up from v0.5.0 when eq#3000 was written.

**Why building on the host is now the better answer:**

- No second repo, no second workflow, no second Renovate hop that silently stops producing tags if it breaks.
- It **structurally solves** the `NEXT_PUBLIC_API_URL` problem. That value is inlined into the web bundle at build time, so an image is bound to the origin it was built for. Building where we know the origin means the binding is correct by construction rather than by coordination.
- It stays Renovate-managed. The annotation on `ITSAPLAN_VERSION` in `init.sh` is matched by the existing "Process annotated dependencies" custom manager, which covers `*.sh` — verified against the actual regex in `.github/renovate.json5`: `datasource=github-releases depName=croffasia/itsaplan currentValue=v0.6.0`.

**The honest cost:** these four images are the estate's only ones not pinned by digest. What is pinned is the *source revision*, which for a build-from-source project is arguably the more meaningful artifact — but it is a real deviation from the convention and it is the reason to say no if you want to. First build on celestia will be slow (`bun install` plus a Next.js production build, four images); afterwards `init.sh` no-ops on an unchanged version and Docker's layer cache covers the rest. **Build duration is UNVERIFIED** — nothing has been built on the host.

## `docker/_common/postgres`

One Postgres per Docker node. Because `_common` is read for every host (`DockgeLxc.ts:641`), enabling it starts an instance on celestia, alpha-site, luna and skystar.

**Service name is `postgres-shared`, not `postgres`** — the most important line in the file. The stack sits on the host-wide `dockge_default` network, where each container name is a DNS name every container on the node resolves. `postgres` is the single likeliest name for a future stack to claim; itsaplan's own upstream compose has a service called exactly that. Two containers answering one name is a round-robin coin flip per connection — the hazard `docker/celestia/homelable/compose.yaml` documents for `backend`, in its sharpest form. The generic name is left unclaimed.

**How consumers reach it, and who owns credentials.** Consumers dial `postgres-shared:5432` over `dockge_default`. Per-app roles and databases are created by `provision.sh`, which runs to completion on **every** stack start rather than as the image's `/docker-entrypoint-initdb.d` hook — that hook fires once, on first init of an empty PGDATA, so a consumer added six months later would never be provisioned and would fail silently. The declaration is one variable: `PGAPP_<NAME>_PASSWORD` creates login role `<name>` and database `<name>` owned by it. Adding a consumer is a one-line git edit. Nothing is ever dropped automatically.

Credentials are `op://` references only. The app password lives in exactly one 1Password field, referenced by both the provisioner and the app, so the two cannot drift.

**Is deploying to all four hosts right?** You asked for per-node, so that is the default. The cost where there are no consumers is real but small: the provisioner reconciles nothing and exits 0, and the instance idles at roughly 30–50 MB RSS producing a nightly globals-only dump of an empty cluster. It is still a database that has to be patched. The opt-out is documented in the `.ignore`: an empty `.ignore` under `docker/<host>/postgres/` skips that host, since the same check reads host directories too. **Deploying to luna is UNVERIFIED** — luna's stacks use `network_mode: host` per `docker/AGENTS.md`, and this compose joins `dockge_default`; that needs checking before luna is enabled.

**Persistence and backup — the part that mattered most.** Data lives under `/opt/stacks-data/postgres/`, which is in the celestia dockge backrest plan's scope (`rclone-sftp` maps `/opt/stacks-data/` to `/data/stacks/`, and the plan's `preSync.sourcePath` is `/stacks/`). But a file-level copy of a running Postgres is **not a restorable artifact** — data files and WAL are captured at different instants, and the failure is silent until someone needs it. So:

- `/postgres/pgdata` is **excluded** from the plan (`stacks/backups/index.ts`).
- A `postgres-backup` loop writes `pg_dump -Fc` per database plus `pg_dumpall --globals-only` to `/opt/stacks-data/postgres/dumps`, which is **not** excluded. Dumps are written to `.tmp` and renamed only on clean exit, so an interrupted dump is never mistaken for a good one.

**Version: Postgres 17, chosen rather than inherited.** Upstream itsaplan pins `postgres:17-alpine` and runs its test suite against it, and the estate's CNPG clusters are on 17 today with vault#114 (17→18) still open. Following that decision rather than getting ahead of it keeps one major across the estate. A major bump here is **not** an image bump — PGDATA is major-version-bound and an 18 binary on a 17 data directory crash-loops on "database files are incompatible" — so `.github/renovate.json5` now disables major updates for this image. Minor, patch and digest still flow.

Hardening: runs as uid/gid 70 with `cap_drop: [ALL]` and `no-new-privileges` (the entrypoint's chown pass is unnecessary because `init.sh` pre-owns the directories), `--data-checksums` at initdb, no published ports, no Traefik labels, and deliberately **no** autoheal label — a database slow to answer `pg_isready` is usually in crash recovery, the worst moment to restart it repeatedly.

**Exposure, stated plainly:** it has no ports and no router, but it is on `dockge_default`, so any container on the node can open a connection and the password is the only boundary. That is inherent to one Postgres serving several stacks — they need a network in common, and `dockge_default` is the only host-wide one the estate creates. A dedicated opt-in network would isolate better, but nothing creates it and a consumer deployed before it exists fails confusingly. `_common/neo4j` already sits on `dockge_default` on the same reasoning.

## `docker/celestia/itsaplan`

Upstream's compose with three estate-shaped changes: no `postgres` service (it comes from `_common/postgres`), every service renamed with an `itsaplan-` prefix so the four that join `dockge_default` do not claim `api`/`web`/`worker`/`minio`, and no published ports.

Carried over from eq#3000:

- **The bot is exactly one instance, structurally.** Telegram hands each `getUpdates` to a single caller. `container_name` is the guarantee, not a comment — Docker requires unique container names, so `--scale itsaplan-bot=2` fails outright instead of half-working.
- **The api runs migrations before it listens** (`bun run packages/db/src/migrate.ts && bun run apps/api/src/index.ts`). `start_period: 180s`, above upstream's 90s, because upstream's number assumes an already-migrated database and first boot replays the whole chain against an empty one.
- **MinIO stays in-stack and off the network** — stack-private network only, no ports, no router, and `MINIO_BROWSER: off` (upstream leaves the console listening but unpublished; off is strictly better). `itsaplan-minio-init` is the one-shot bucket create, ordered behind `service_healthy` so `mc` talks to a MinIO that is actually listening. Noted inline: minio/minio has not shipped since `RELEASE.2025-09-07` — verified, `latest` still resolves to that same digest — so it is ~11 months stale and is the weakest component here.
- **The `search_path` finding.** itsaplan's drizzle migrations are unqualified. `provision.sh` runs `ALTER ROLE ... IN DATABASE ... SET search_path = public`, which also covers the migration runner — a role-level setting rather than a connection-string parameter every consumer must remember. Today it changes nothing; the day a role-named schema exists it prevents the shape that stalled the windmill 1.722 upgrade.
- **Internal only, and the reason still holds.** Registration mode defaults to `open` and can only be closed from god mode afterwards, so an internet-reachable instance accepts self-signup until someone logs in and turns it off. It also holds project data and AI-provider credentials, and nothing about it needs inbound reachability — the bot is outbound long-poll, webhook delivery is outbound from the worker. Both origins resolve on the LAN via split-horizon and over the tailnet; neither is internet-facing.

**No `authentik:` block, deliberately.** itsaplan authenticates natively (better-auth, passkeys) and speaks no OIDC, so there is no client to create. Forward-auth would not help either: the browser calls the api origin directly with `NEXT_PUBLIC_API_URL` baked into its bundle, so gating only the web origin would leave registration reachable on the api origin — a gate that looks real without being one. Closing registration in god mode right after first login is therefore a required step, and it is written into the `.ignore`.

## Validation

Verified against real infrastructure, not just parsed:

- **`docker compose config` — VALID** for both stacks, with Pulumi substitutions and secrets simulated.
- **`provision.sh` run against a real `postgres:17-alpine`**, twice, to prove idempotency. This found **two genuine bugs**, both now fixed and re-verified:
  - psql does **not** interpolate `:'var'` inside a dollar-quoted `DO $$...$$` body — it reaches the server with the colon-form intact and fails with `syntax error at or near ":"`. Rewritten to `format()` + `\gexec`.
  - psql does **not** interpolate variables in a `-c` string either, only in input it parses itself. Those statements moved to heredocs.
- **End state confirmed:** role created and able to log in with a password containing `'`, `"`, `$` and `;`; database owned by the role; `search_path=public` set at role-in-database level; an unqualified `CREATE TABLE` verified to land in `public`.
- **Guards confirmed:** an unresolved `op://` value is skipped rather than becoming a literal password; empty values and invalid identifiers are skipped.
- **Backup verified as restorable, not merely produced:** `pg_dump -Fc` output restored into a fresh database with `pg_restore` exit 0 and the table present; `globals` dump contains the role.
- **Renovate custom-manager match confirmed** against the actual regex.
- **No reference-shaped string in any comment** — checked programmatically; the only unmatched `op://` occurrences are the `<vault>/<item-name>/<field-name>` prose form, identical to `docker/_common/neo4j/.env:1`.
- `hk check` clean; `tsc --noEmit` produces the same 6 pre-existing errors as `main` (diff empty).
- All test containers and networks removed.

## What you must decide

1. **Approve building on the host**, or tell me to go back to the `itsaplan-images` repo. This is the one real decision, and it is the reason I re-opened the question rather than reusing my previous answer. Nothing else in this PR depends on the outcome — `_common/postgres` stands either way.
2. **Create the two 1Password items before deleting either `.ignore`** — `Docker Postgres` (`password`) and `Itsaplan` (six fields). Generate every value with `openssl rand -hex 32`: hex rather than base64 matters for `db_password`, which is interpolated into `DATABASE_URL` as URI userinfo where base64's `/` would truncate the host. I do not write to 1Password.
3. **Confirm the hostnames** — `itsaplan.${CLUSTER_DOMAIN}` and `itsaplan-api.${CLUSTER_DOMAIN}`. The api origin is compiled into the web bundle, so changing it later is a rebuild, not an edit.
4. **Decide whether all four nodes should run Postgres.** Per-node was the ask and is what this does; only celestia has a consumer today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
