### PR TITLE
fix(postgres): restore PGDATA to /opt/stacks-data and make the stack coherent at 18

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -135,13 +135,23 @@
     },
     {
       // The repo extends "docker:enableMajor", so without this rule Renovate
-      // would happily open a postgres 17 -> 18 PR for docker/_common/postgres.
+      // would happily open a postgres 18 -> 19 PR for docker/_common/postgres.
       // Merging it would not be an upgrade, it would be an outage: PGDATA is
-      // bound to the major version that created it, and an 18 binary starting
-      // on a 17 data directory exits with "database files are incompatible
+      // bound to the major version that created it, and a 19 binary starting
+      // on an 18 data directory exits with "database files are incompatible
       // with server" and crash-loops. A major move is a pg_upgrade or a
-      // dump/restore, planned alongside the CNPG decision in vault#114 — never
-      // an image bump. Minor, patch and digest updates still flow normally.
+      // dump/restore — never an image bump. Minor, patch and digest updates
+      // still flow normally.
+      //
+      // The stack was authored on 17 and moved to 18 by hand in 2b99cb93. That
+      // was free precisely because no host had ever completed a first init —
+      // there was no 17 PGDATA on disk anywhere to be incompatible with, on any
+      // of the four Dockge hosts. That will NOT be true of the next major, which
+      // is the whole point of this rule. It also bounds a subtler failure: all
+      // three services in that compose file share one major, and pg_dump refuses
+      // to dump a server newer than itself while backup.sh only warns — so a
+      // partial major bump silently stops every backup, without ever failing a
+      // container. Bump all three together or none.
       description: "Container Postgres majors are a data migration, not an image bump",
       matchDatasources: ["docker"],
       matchPackageNames: ["postgres"],

--- a/docker/_common/postgres/.env
+++ b/docker/_common/postgres/.env
@@ -38,7 +38,7 @@ POSTGRES_DUMP_KEEP_DAYS=14
 # --- exposure --------------------------------------------------------------
 # This service has no published ports and no traefik labels, but it does sit on
 # the host-wide dockge_default network, so every container on the node can open
-# a TCP connection to postgres-shared:5432. The password is the only boundary
+# a TCP connection to postgres:5432. The password is the only boundary
 # between stacks. That is inherent to "one Postgres serving several stacks" —
 # they need a network in common, and dockge_default is the only host-wide one
 # the estate creates (components/DockgeLxc.ts:593). The alternative, a

--- a/docker/_common/postgres/compose.yaml
+++ b/docker/_common/postgres/compose.yaml
@@ -1,6 +1,17 @@
 services:
   postgres:
-    image: postgres:18-alpine
+    # Postgres 18. All three services in this file MUST stay on the same major:
+    # pg_dump refuses to dump a server newer than itself ("aborting because of
+    # server version mismatch"), and backup.sh treats a failed dump as a warning
+    # and keeps looping — so a skew here is a permanently silent backup failure,
+    # not a visible one. Verified against 18.4: pg_dump/pg_dumpall 17.10 exit 1,
+    # the matching 18 client exits 0. (psql 17 -> 18 does work, so provision.sh
+    # would have survived the skew; the backups would not have.)
+    #
+    # A major bump is NOT an image bump: PGDATA is bound to the major that
+    # created it, so 18 -> 19 is a pg_upgrade or dump/restore. renovate.json5
+    # disables major updates for this image; minor/patch/digest still flow.
+    image: postgres:18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
     container_name: postgres
     hostname: postgres
     env_file:
@@ -30,7 +41,26 @@ services:
     security_opt:
       - no-new-privileges:true
     volumes:
-      - /opt/stacks/postgres/pgdata:/var/lib/postgresql/data
+      # MUST be under /opt/stacks-data, never /opt/stacks. Two reasons, both
+      # load-bearing:
+      #
+      #   * /opt/stacks/<stack> is the Dockge *definition* directory — Pulumi
+      #     copies compose.yaml/.env/init.sh there, and DockgeLxc.ts:810 runs
+      #     `rm -rf /opt/stacks/<stack>` when the stack is deleted. PGDATA
+      #     there means removing the stack silently destroys the database.
+      #   * init.sh only prepares paths under /opt/stacks-data. Point this
+      #     elsewhere and Docker auto-creates the bind source as root:root
+      #     0755 at `up` time; the container runs as uid 70 with cap_drop ALL,
+      #     cannot mkdir $PGDATA inside it, and crash-loops on
+      #     "mkdir: can't create directory '.../pgdata': Permission denied".
+      #     Commit 2b99cb93 retargeted this line to /opt/stacks and that is
+      #     exactly what happened on celestia and skystar — 14 restarts, no
+      #     cluster ever initialised. Keep this path and init.sh in lockstep.
+      #
+      # It is also NOT usable as a backup source — a file copy of a running
+      # cluster is torn, not crash-consistent. stacks/backups/index.ts excludes
+      # this path and backs up the pg_dump output below instead.
+      - /opt/stacks-data/postgres/pgdata:/var/lib/postgresql/data
     # Postgres uses POSIX shared memory for parallel query; Docker's 64m
     # default is small enough to cause "could not resize shared memory segment".
     shm_size: 256mb
@@ -70,7 +100,8 @@ services:
   # role <name> and a database <name> owned by it. Nothing else is read, so a
   # host with no consumers provisions nothing and this container exits 0.
   postgres-provision:
-    image: postgres:18-alpine
+    # Same major + digest as the server above. See the note there.
+    image: postgres:18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
     container_name: postgres-provision
     depends_on:
       postgres:
@@ -109,7 +140,10 @@ services:
   # pg_dump produces one that is: each dump is a consistent snapshot taken
   # inside a single transaction.
   postgres-backup:
-    image: postgres:18-alpine
+    # Same major + digest as the server above — this is the one that MUST match.
+    # pg_dump aborts against a newer server and backup.sh only warns, so a skew
+    # here fails every dump forever without ever failing the container.
+    image: postgres:18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
     container_name: postgres-backup
     depends_on:
       postgres:

--- a/docker/_common/postgres/init.sh
+++ b/docker/_common/postgres/init.sh
@@ -4,16 +4,40 @@
 # image) with cap_drop: ALL, so they cannot chown anything themselves — the
 # directories have to be right before the containers start.
 #
+# uid/gid 70 is `postgres` in postgres:18-alpine — verified directly against the
+# image, not inherited from 17 (`id postgres` -> uid=70(postgres) gid=70(postgres)
+# on both 17.10 and 18.4), so the 17 -> 18 move did not shift it.
+#
+# Every path here must match the bind mounts in compose.yaml exactly. Docker
+# auto-creates a missing bind source as root:root 0755 at `up` time, which uid 70
+# cannot write, so a path that is mounted but not prepared here crash-loops the
+# container on "mkdir: can't create directory ...: Permission denied".
+#
 # components/DockgeLxc.ts runs this on every deploy, so it must stay idempotent.
 set -euo pipefail
 
-for dir in /opt/stacks-data/postgres/pgdata /opt/stacks-data/postgres/dumps; do
+data_root=/opt/stacks-data/postgres
+
+# pgdata is the bind *mount root* (/var/lib/postgresql/data). PGDATA itself is
+# the `pgdata` subdirectory inside it, which the container creates on first init
+# — it can only do that if the mount root is owned by 70. Pre-creating the inner
+# directory too makes that independent of the parent's mode.
+for dir in "$data_root/pgdata" "$data_root/pgdata/pgdata" "$data_root/dumps"; do
   mkdir -p "$dir"
   chown 70:70 "$dir"
 done
 
 # initdb refuses to run in a directory with group/world permissions.
-chmod 700 /opt/stacks-data/postgres/pgdata
-chmod 750 /opt/stacks-data/postgres/dumps
+chmod 700 "$data_root/pgdata" "$data_root/pgdata/pgdata"
+chmod 750 "$data_root/dumps"
+
+# Commit 2b99cb93 briefly mounted PGDATA from /opt/stacks/postgres/pgdata — the
+# Dockge *definition* directory, which DockgeLxc.ts:810 `rm -rf`s on stack delete.
+# Clear the empty husk Docker left behind on the hosts that ran that revision.
+# rmdir, never rm -rf: if anything is actually in there it is a real data
+# directory from that revision and must be looked at by a human, not deleted.
+rmdir /opt/stacks/postgres/pgdata 2>/dev/null \
+  && echo "Removed stray PGDATA directory from the Dockge definition dir." \
+  || true
 
 echo "Shared Postgres data directories ready."


### PR DESCRIPTION
## The actual error

`_common/postgres` crash-loops on **celestia** and **skystar** (14 restarts and counting):

```
mkdir: can't create directory '/var/lib/postgresql/data/pgdata': Permission denied
```

## Root cause — the bind-mount path, not the version

`2b99cb93` retargeted the data volume:

```
- /opt/stacks-data/postgres/pgdata:/var/lib/postgresql/data
+ /opt/stacks/postgres/pgdata:/var/lib/postgresql/data
```

`init.sh` only prepares paths under `/opt/stacks-data`, so Docker auto-created the new bind source at `up` time as **root:root 0755**. The container runs as uid 70 with `cap_drop: ALL` by design, so it can neither chown it nor `mkdir $PGDATA` inside it. On-host evidence:

```
/opt/stacks/postgres/pgdata        drwxr-xr-x  0  0    <- mounted, root-owned, unusable
/opt/stacks-data/postgres/pgdata   drwx------ 70 70    <- prepared by init.sh, mounted by nothing
```

**The uid-70 hypothesis is disproved.** `id postgres` is `uid=70(postgres) gid=70(postgres)` in *both* `17.10` and `18.4`, checked against the images directly. The crash-loop also persisted after all three services were aligned at 18, which rules the version skew out as the startup cause independently.

`/opt/stacks/<stack>` is also simply the wrong home for a database: it is the Dockge **definition** directory, and `DockgeLxc.ts:810` runs `rm -rf` on it when a stack is deleted. PGDATA there means deleting the stack silently destroys the database.

## The version decision: 18 stays

**18 was free, and it is only free right now.** No host has ever completed a first init — there is no `PG_VERSION` on celestia, luna or skystar, so there is no 17 PGDATA anywhere to be incompatible with. The Renovate rule's warning is real but had nothing to bite on yet. Reverting to 17 would buy nothing and discard a deliberate change; the right move is to make the stack *coherent* at 18.

## What the skew would have broken (verified, not assumed)

| client → server 18.4 | result |
|---|---|
| `pg_dump` 17.10 | **exit 1** — `aborting because of server version mismatch` |
| `pg_dumpall --globals-only` 17.10 | **exit 1** — same |
| `psql` 17.10 | exit 0 — works |
| `pg_dump` / `pg_dumpall` 18 | exit 0 |

The backup service was pinned to 17 against an 18 server. Critically, `backup.sh` treats a failed dump as `echo "[backup] WARN..." >&2` and **keeps looping** — so this would not have failed a container or raised an alert. Every backup on every host would have failed silently, forever. That was the most serious consequence of the skew, worse than the visible crash-loop. `provision.sh` uses only `psql` and would have survived it.

## Changes

- **`compose.yaml`** — volume restored to `/opt/stacks-data/postgres/pgdata`; all three services pinned to the same 18 digest (the server was unpinned while the others were digest-pinned, breaking the estate convention and letting the running version drift); comments record why the path and the shared major are load-bearing.
- **`init.sh`** — pre-creates the inner PGDATA dir, records that its paths and the compose mounts must move together, and `rmdir`s the empty husk left under `/opt/stacks/postgres/pgdata` on hosts that ran the broken revision. `rmdir`, never `rm -rf`: a non-empty directory there is real data and gets left for a human.
- **`renovate.json5`** — major-block rule kept and rebased onto the 18 baseline, extended to cover the partial-bump backup hazard.
- **`.env`** — one stale `postgres-shared:5432` reference updated after the rename.

## Verification

Replicated the new `init.sh` on dockge-celestia and ran the image with the exact compose security posture (`--user 70:70 --cap-drop ALL --security-opt no-new-privileges`):

```
status=running restarts=0 exit=0
/var/run/postgresql:5432 - accepting connections
PG_VERSION = 18
data_checksums = on
```

Then ran the **real `backup.sh`** against an 18 server: `[backup] dumped demo`, a globals dump containing `CREATE ROLE demo`, and a custom-format archive that `pg_restore --list` reads back correctly. Test rig fully removed; the live stack was not touched.

## Deployment notes

- **celestia / skystar** — crash-looping now; this fixes them on next deploy.
- **luna** — currently has *no* postgres stack deployed (empty root-owned `/opt/stacks/postgres`, no containers). Its deploy landed during the vault#135 OOM window. Now restored and healthy (28 containers, 6.6 GB available, swap 74/1024 MB), so it is safe to deploy to.
- **alpha-site** — **unverified**. Pings on tailscale but SSH refuses on port 22; a pre-existing access issue unrelated to this change.

## Memory cost (for vault#135 / vault#124)

Measured on an initialised 18 instance, idle after doing real init + dump work:

```
total   ~86 MiB   (peak 89 MiB)
anon      6.9 MiB   <- the only part that pressures swap
shmem    72.2 MiB   <- shared_buffers
```

The one-shot `pg_dump` client peaked at **912 kB**; the provision container exits. So `_common/postgres` costs roughly **~100 MiB steady state per host**, and its *anonymous* footprint is single-digit MiB. Since luna OOMed on its **1 GiB swap ceiling** rather than RAM, this stack is not a meaningful contributor to that failure mode. Measured at idle on an empty database — real workloads add per-connection `work_mem`, so treat it as a floor.

## Not foreclosing consolidation

Per "each machine needs a local db **at least for now**" — the cheap thing that keeps consolidation open is for consumers to reach the database through a variable in their own `.env` rather than hardcoding the literal hostname `postgres`. Then consolidating later is a per-host `.env` edit instead of a compose rewrite across every consumer. This costs nothing to adopt right now because **there are currently no consumers** (`itsaplan` was removed in `2b99cb93` and no `PGAPP_*` is declared on any host). No change made here — just flagging the moment it is free.

One related note, not changed: `2b99cb93` renamed `postgres-shared` → `postgres`. The original name existed to avoid a DNS collision on the host-wide `dockge_default` network, where vendor compose files very commonly ship a service called exactly `postgres`. That collision is not active today (the stack that motivated it, `itsaplan`, is gone) so the rename is defensible, but it is worth knowing it is the generic name on a shared network — and a name collision is precisely the kind of thing that would bite during a consolidation transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- crew:agent=tank -->
