### PR TITLE
fix(luna): pin dockge acceptRoutes=false while the LXC is still on the home LAN

### DIFF
--- a/stacks/gulf-of-mexico/index.ts
+++ b/stacks/gulf-of-mexico/index.ts
@@ -57,7 +57,17 @@ const dockgeRuntime = new DockgeLxc("luna-dockge", {
   host: host,
   vmId: dockgeId.result,
   cluster: cluster,
-  tailscaleArgs: { acceptDns: true, acceptRoutes: host.remote },
+  // acceptRoutes MUST stay false while this LXC physically sits on the home
+  // 10.10.0.0/16 LAN, even though the host is modeled `remote: true` for its
+  // eventual move. With accept-routes on, tailscale's table 52 carries the
+  // tailnet-advertised 10.10.0.0/16 and wins over the connected eth0 route, so
+  // replies to LAN clients leave via tailscale0 — LAN-inbound blackhole (SYNs
+  // arrive, no SYN-ACK; found 2026-08-03 when Home Assistant on SGC could not
+  // reach the wyoming/llama-voice ports; fixed live with
+  // `tailscale set --accept-routes=false`). Flip this back to `host.remote`
+  // as part of the physical move, when the LXC is no longer on the subnet it
+  // would be accepting.
+  tailscaleArgs: { acceptDns: true, acceptRoutes: false },
   sftpKey: sftpClientKey,
   createDockerLxc: true,
   monitor,


### PR DESCRIPTION
Reconciles IaC with the live fix applied 2026-08-03.

`luna-dockge` had `acceptRoutes: host.remote`, and the luna host is modeled `remote: true` for its eventual off-site move — so Tailscale accepted the tailnet-advertised `10.10.0.0/16` while the LXC is physically *on* that subnet. Table 52 shadows the connected eth0 route, replies to LAN clients leave via tailscale0, and every LAN-inbound connection blackholes (SYNs arrive on eth0; no SYN-ACK, no RST, no ICMP). Nobody noticed because all admin access rides the tailnet — it surfaced when Home Assistant on SGC (hostNetwork, not on the tailnet) couldn't reach the wyoming (10300/10200) and llama-voice (8080) ports.

The live LXC was fixed with `tailscale set --accept-routes=false` (verified: all voice ports now OPEN from the HA pod); this PR pins the stack so the next provision doesn't re-arm the blackhole.

**At move time:** flip back to `host.remote` (comment in code says the same). Also worth noting for the move: HA's voice pipeline currently targets luna by LAN IP, so the voice stacks (llama-voice + wyoming) will need to relocate to a machine local to HA — celestia can host them, but its GTT budget (7.7 GB) doesn't fit voice E2B alongside the 64K-context agent E4B; the agent context would need trimming to ~32K.

🤖 Generated with [Claude Code](https://claude.com/claude-code)