### PR TITLE
fix(luna): complete the remote:false flip — internalIpAddress + host accept-routes

### DIFF
--- a/stacks/gulf-of-mexico/index.ts
+++ b/stacks/gulf-of-mexico/index.ts
@@ -39,13 +39,20 @@ const host = new ProxmoxHost("luna", {
   globals: globals,
   authentikOutputs: outputs,
   tailscaleIpAddress: "100.111.10.104",
+  // Required while remote: false (ProxmoxHost throws without it) and feeds the
+  // tailscale exports that local-dns.ts uses to pin the DHCP reservation.
+  internalIpAddress: "10.10.10.104",
   proxmox: mainProxmoxCredentials,
   remote: false, // once this gets shipped to the new location, flip this to true so that tailscale accepts routes from the LAN
   cluster: cluster,
   tailscaleArgs: {
     advertiseExitNode: true,
     acceptDns: true,
-    acceptRoutes: true,
+    // Same hazard as the dockge LXC below: accepting the tailnet-advertised
+    // 10.10.0.0/16 while sitting ON that subnet routes replies to LAN clients
+    // out tailscale0 and blackholes all LAN-inbound traffic. Flip to true
+    // together with `remote` at move time.
+    acceptRoutes: false,
   },
   tailscaleSubnetRoutes: [],
   vmIdRange: vmRange,


### PR DESCRIPTION
Completes a97a843c ("fixing luna accept-routes for now"): `remote: false` throws in ProxmoxHost without `internalIpAddress`, and the host's hardcoded `acceptRoutes: true` is the same LAN-inbound blackhole that was fixed live on the dockge LXC (accepting the tailnet's `10.10.0.0/16` while sitting on that subnet routes replies to LAN clients out tailscale0).

Pulumi preview (gulf-of-mexico, real backend): all in-place updates, no deletes/replaces — the `luna.host.driscoll.tech` records move to `10.10.10.104` (mirroring celestia's local-host pattern), and `luna-tailscale-set` gains `--accept-routes=false`.

**DNS for `dockge-luna.driscoll.tech` intentionally keeps the tailscale IP** — SGC-side reachability is being handled with tailscale-operator egress + CoreDNS rewrite in stargate-command-cluster instead of repointing records at the LAN.

Flip `remote`, `internalIpAddress` (remove), and both accept-routes back together at move time — comments in code say the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)