### PR TITLE
fix(proxmox-host): allow non-remote hosts to omit internalIpAddress (tailnet-primary)

### DIFF
--- a/components/ProxmoxHost.ts
+++ b/components/ProxmoxHost.ts
@@ -82,10 +82,13 @@ export class ProxmoxHost extends ComponentResource {
     if (args.remote) {
       this.internalIpAddress = args.tailscaleIpAddress;
     } else {
-      if (args.internalIpAddress === undefined) {
-        throw new Error("internalIpAddress must be provided for non-remote Proxmox hosts");
-      }
-      this.internalIpAddress = args.internalIpAddress;
+      // Tailnet-primary local hosts (e.g. luna, modeled remote:false while it
+      // is physically home but staged for an off-site move) may omit
+      // internalIpAddress: the tailscale IP then doubles as the internal
+      // address. DNS stays on the tailnet IP, and the LAN-side machinery
+      // (local-dns.ts reservations/DHCP DNS) correctly skips the host because
+      // 100.x is outside the Home subnet.
+      this.internalIpAddress = args.internalIpAddress ?? args.tailscaleIpAddress;
     }
     this.tailscaleIpAddress = args.tailscaleIpAddress;
     this.remote = args.remote;


### PR DESCRIPTION
Unbreaks gulf-of-mexico after a97a843c: `remote: false` threw without `internalIpAddress`. Luna is deliberately tailnet-primary while physically home (DNS keeps tailscale IPs — see closed #647 for the rejected LAN-DNS approach), so the tailscale IP now doubles as the internal address when none is provided. local-dns.ts reservations correctly skip 100.x as out-of-subnet.

Preview on the real backend: constructor passes, **zero DNS record changes**, only the expected authentik launch-URL updates from the remote flip (plus the documented phantom deletes this stack always previews).

SGC-side reachability for `dockge-luna.driscoll.tech` (voice pipeline ports for HA) follows separately in stargate-command-cluster via the existing operator-egress + CoreDNS rewrite pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)