### PR TITLE
feat(alpha-site): bao-standby — break-glass standby + dump receiver (Phase 5)

### DIFF
--- a/docker/alpha-site/bao-standby/compose.yaml
+++ b/docker/alpha-site/bao-standby/compose.yaml
@@ -1,0 +1,136 @@
+services:
+  # ── Always running: the dump receiver ──────────────────────────────────────
+  # A second rclone SFTP server, separate from the estate-wide read-only
+  # rclone-sftp stack on 2022, because this one must accept WRITES into its
+  # dump directory — the nightly openbao-replica CronJob in equestria pushes
+  # the age-encrypted pg_dump here and prunes it to 30 days, and the monthly
+  # restore test pulls the newest dump back out. Auth reuses the keys DockgeLxc
+  # already seeds for rclone-sftp: same host key, same authorized client key,
+  # zero new key material.
+  dump-sftp:
+    user: "65534:65534"
+    container_name: bao-standby-dump-sftp
+    image: rclone/rclone:1.75.0@sha256:b06aed988cf5967de7c25be5925240983981c757f4ed1ac9d2fa659d51d60548
+    restart: unless-stopped
+    dns:
+      - 100.100.100.100
+    command: >-
+      serve sftp /data/dumps --addr :2023
+      --authorized-keys /config/ssh/authorized_keys
+      --key /config/ssh/host_key
+    ports:
+      # Bound to the tailnet address, NOT 0.0.0.0 — the only clients are the
+      # equestria cronjobs, arriving through the dockge-as egress Service
+      # (port 2023 is declared in equestria's tailscale-system/services).
+      - "${tailscaleIpAddress}:2023:2023"
+    volumes:
+      - /opt/stacks-data/${APP}/dumps:/data/dumps
+      - /opt/stacks-data/rclone-sftp/keys:/config/ssh:ro
+    tmpfs:
+      - /.cache:uid=65534,gid=65534
+    networks:
+      - dockge_default
+
+  # ── Stopped by default: the break-glass standby ────────────────────────────
+  # `profiles: [break-glass]` keeps both of these DOWN on a normal
+  # `docker compose up -d`. That is deliberate and load-bearing: this host also
+  # runs bao-transit, so a running standby would put the ciphertext and the key
+  # that decrypts it live on one machine. Start them only during an actual
+  # break-glass, via restore.sh (vault/bootstrap/RUNBOOK.md Scenario B).
+  standby-postgres:
+    profiles: ["break-glass"]
+    container_name: bao-standby-postgres
+    # Same major as the CNPG cluster the dumps come from (17.5).
+    image: docker.io/library/postgres:17.5-alpine@sha256:6567bca8d7bc8c82c5922425a0baee57be8402df92bae5eacad5f01ae9544daa
+    restart: unless-stopped
+    dns:
+      - 100.100.100.100
+    environment:
+      POSTGRES_USER: openbao
+      POSTGRES_DB: openbao
+      # Scratch credential for a database that only ever holds ciphertext
+      # OpenBao already encrypted, on a container network. Overridable from
+      # .env; not worth a secret store entry.
+      POSTGRES_PASSWORD: ${BAO_STANDBY_PG_PASSWORD:-break-glass}
+    volumes:
+      - /opt/stacks-data/${APP}/postgres:/var/lib/postgresql/data
+    networks:
+      - dockge_default
+
+  bao-standby:
+    profiles: ["break-glass"]
+    container_name: bao-standby
+    image: ghcr.io/openbao/openbao:2.6.1@sha256:5b2486ab0fb90bbc788cc345b0a08616dfb375873ee8be5df3a2fd4d378a67e0
+    restart: unless-stopped
+    depends_on:
+      - standby-postgres
+    dns:
+      - 100.100.100.100
+    command: server -config=/openbao/config/config.hcl
+    cap_add:
+      - IPC_LOCK
+    environment:
+      # Env beats config for both of these (confirmed against source, see
+      # vault docs/openbao-migration/STATUS.md "facts established the hard
+      # way"), so config.hcl deliberately omits them.
+      BAO_PG_CONNECTION_URL: postgres://openbao:${BAO_STANDBY_PG_PASSWORD:-break-glass}@standby-postgres:5432/openbao?sslmode=disable
+      # The SAME transit token equestria seals with — supplied by the operator
+      # at break-glass time from vault/bootstrap/openbao/transit-token.sops.yaml.
+      # Deliberately NOT resolved from a secret store here: at the moment this
+      # container matters, the secret stores are what's broken.
+      VAULT_TRANSIT_SEAL_TOKEN: ${BAO_STANDBY_TRANSIT_TOKEN:-}
+    ports:
+      # 8201 on the tailnet address; 8200 is bao-transit's.
+      - "${tailscaleIpAddress}:8201:8200"
+    volumes:
+      - ./config/config.hcl:/openbao/config/config.hcl:ro
+    labels:
+      traefik.enable: true
+      # Tailscale entrypoint only, mirroring bao-transit: the break-glass
+      # standby has even less business on the LAN than the seal root does.
+      traefik.http.routers.bao-standby.rule: Host(`bao-standby.${tailscaleDomain}`)
+      traefik.http.routers.bao-standby.entrypoints: tailscale
+      traefik.http.routers.bao-standby.service: bao-standby
+      traefik.http.services.bao-standby.loadbalancer.server.port: 8200
+    networks:
+      - dockge_default
+
+x-dockge:
+  notes: |
+    Break-glass standby for the equestria OpenBao cluster (migration Phase 5).
+    Three services, one running:
+
+      dump-sftp         ALWAYS UP. Receives the nightly age-encrypted pg_dump
+                        from the equestria openbao-replica CronJob into
+                        /opt/stacks-data/bao-standby/dumps (30-day retention,
+                        pruned by the sender).
+      standby-postgres  STOPPED (profile break-glass).
+      bao-standby       STOPPED (profile break-glass).
+
+    The dumps CANNOT be decrypted on this host: they are age-encrypted to the
+    estate recipients and no age identity lives here — deliberately, because
+    this host also runs bao-transit (the key that decrypts OpenBao's own
+    storage encryption). Keep it that way. Do not add an age key to this
+    host, and do not start the standby outside a break-glass.
+
+    Break-glass (full procedure: vault/bootstrap/RUNBOOK.md Scenario B):
+      1. On a machine with age.key: decrypt the newest dump
+      2. Copy the decrypted .sql here, then:
+           cd /opt/stacks/bao-standby
+           BAO_STANDBY_TRANSIT_TOKEN=<token> bash restore.sh /path/to/openbao.sql
+         (the token comes from vault/bootstrap/openbao/transit-token.sops.yaml)
+      3. Verify, then re-point consumers at
+         https://bao-standby.${tailscaleDomain} (or http://<tailnet-ip>:8201)
+
+    First-run: /opt/stacks-data/bao-standby/dumps must be writable by uid
+    65534 (rclone runs as nobody, same as the rclone-sftp stack):
+      mkdir -p /opt/stacks-data/bao-standby/dumps
+      chown 65534:65534 /opt/stacks-data/bao-standby/dumps
+    Like the bao-transit data chown, this is a host-side fix that belongs in
+    the Pulumi DockgeLxc definition eventually.
+  urls:
+    - https://bao-standby.${tailscaleDomain}
+
+networks:
+  dockge_default:
+    external: true

--- a/docker/alpha-site/bao-standby/config/config.hcl
+++ b/docker/alpha-site/bao-standby/config/config.hcl
@@ -1,0 +1,32 @@
+# bao-standby — break-glass single node, restored from the nightly dump.
+#
+# Deliberately NOT here (env beats config, confirmed against source — see
+# vault docs/openbao-migration/STATUS.md):
+#   connection_url  → BAO_PG_CONNECTION_URL   (compose environment)
+#   seal token      → VAULT_TRANSIT_SEAL_TOKEN (operator-supplied at start)
+ui = true
+
+listener "tcp" {
+  address = "0.0.0.0:8200"
+  # Only reachable over the tailnet (WireGuard) and the container network,
+  # same trade-off as bao-transit.
+  tls_disable = true
+}
+
+storage "postgresql" {
+  # Same logical table names as equestria's config. The restored tables live
+  # in the `openbao` schema and are found via the openbao role's search_path,
+  # exactly as they are in CNPG.
+  table      = "openbao_kv_store"
+  ha_enabled = "false"
+}
+
+seal "transit" {
+  # bao-transit runs on this same host; container-to-container over the
+  # shared dockge_default network. Same key the equestria cluster seals with,
+  # which is what makes the restored keyring usable at all.
+  address    = "http://bao-transit:8200"
+  key_name   = "openbao-equestria-unseal"
+  mount_path = "transit/"
+  disable_renewal = "false"
+}

--- a/docker/alpha-site/bao-standby/definition.yaml
+++ b/docker/alpha-site/bao-standby/definition.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: bao-standby
+spec:
+  name: OpenBao Standby (Alpha Site)
+  category: Infrastructure
+  description: Break-glass standby — stopped by default, restores the nightly dump
+  url: &url https://bao-standby.${tailscaleDomain}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/vault.svg
+  access_policy:
+    groups:
+      - admins
+  gatus:
+    # Only the dump RECEIVER is checked. The standby itself is stopped by
+    # default — an HTTP check against it would page forever about a state
+    # that is deliberate. Whether the dumps it receives are fresh and usable
+    # is covered separately by the "OpenBao Break Glass" heartbeat endpoints
+    # (uptime stack config), which the equestria cronjobs report into.
+    - name: bao-standby-dump-receiver
+      url: "tcp://${tailscaleIpAddress}:2023"
+      interval: 5m
+      conditions:
+        - "[CONNECTED] == true"

--- a/docker/alpha-site/bao-standby/restore.sh
+++ b/docker/alpha-site/bao-standby/restore.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# restore.sh — bring the break-glass standby up from a decrypted dump.
+# Run ON dockge-as, from this stack directory. Full procedure and the
+# decryption step (which happens on a machine with age.key, NOT here):
+# vault/bootstrap/RUNBOOK.md Scenario B.
+#
+#   BAO_STANDBY_TRANSIT_TOKEN=<token> bash restore.sh /path/to/openbao.sql
+#
+# The token is the transit seal token from
+# vault/bootstrap/openbao/transit-token.sops.yaml. Without it the standby
+# starts but can never unseal.
+#
+# Safe to re-run: the restore refuses a non-empty database rather than
+# silently merging two states — wipe /opt/stacks-data/bao-standby/postgres
+# first if you want a clean second attempt.
+set -Eeuo pipefail
+
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+dump="${1:-}"
+[[ -n "$dump" && -f "$dump" ]] || die "usage: restore.sh /path/to/openbao.sql (a DECRYPTED dump)"
+head -c 512 "$dump" | grep -qi 'age-encryption\|AGE ENCRYPTED' && die "$dump is still age-encrypted — decrypt it on a machine holding age.key first"
+grep -q 'CREATE SCHEMA' "$dump" || die "$dump does not look like a plain-format pg_dump"
+[[ -n "${BAO_STANDBY_TRANSIT_TOKEN:-}" ]] || die "BAO_STANDBY_TRANSIT_TOKEN is not set — the standby could start but never unseal. See header."
+
+compose() { docker compose --profile break-glass "$@"; }
+
+echo "starting standby-postgres..."
+compose up -d standby-postgres
+for _ in $(seq 1 60); do
+  docker exec bao-standby-postgres pg_isready -U openbao -d openbao >/dev/null 2>&1 && break
+  sleep 2
+done
+docker exec bao-standby-postgres pg_isready -U openbao -d openbao >/dev/null || die "standby-postgres never became ready"
+
+existing="$(docker exec bao-standby-postgres psql -U openbao -d openbao -tA \
+  -c "select count(*) from information_schema.tables where table_schema='openbao'")"
+[[ "$existing" == "0" ]] || die "database already has $existing openbao table(s) — refusing to restore over it (see header)"
+
+echo "restoring $dump..."
+docker exec -i bao-standby-postgres psql -U openbao -d openbao -q -v ON_ERROR_STOP=1 < "$dump"
+
+entries="$(docker exec bao-standby-postgres psql -U openbao -d openbao -tA -c 'select count(*) from openbao.openbao_kv_store')"
+[[ "$entries" -gt 0 ]] || die "restore left openbao_kv_store empty"
+echo "restored: openbao_kv_store has $entries rows"
+
+echo "starting bao-standby (unseals via bao-transit on this host)..."
+BAO_STANDBY_TRANSIT_TOKEN="$BAO_STANDBY_TRANSIT_TOKEN" compose up -d bao-standby
+
+for _ in $(seq 1 60); do
+  health="$(docker exec bao-standby wget -qO- http://127.0.0.1:8200/v1/sys/health 2>/dev/null || true)"
+  [[ "$health" == *'"sealed":false'* ]] && break
+  sleep 2
+done
+[[ "${health:-}" == *'"sealed":false'* ]] || die "standby never unsealed — is bao-transit healthy? (RUNBOOK Scenario A step 2)"
+
+cat <<'DONE'
+
+Standby is up and unsealed. Before trusting it, run the canary read
+(RUNBOOK Scenario B step 5):
+
+  export BAO_ADDR=https://bao-standby.<tailscale-domain>   # or http://<tailnet-ip>:8201
+  bao login   # or use an approle that lives in the restored data
+  bao kv get secrets/shared/cloudflare-driscoll-tech
+
+Then re-point consumers (Scenario B step 6). Remember: everything written to
+OpenBao after the dump's timestamp does not exist here — RPO is up to 24h.
+DONE

--- a/docker/alpha-site/uptime/compose.yaml
+++ b/docker/alpha-site/uptime/compose.yaml
@@ -25,6 +25,10 @@ services:
       - /opt/stacks-data/${APP}/data/:/data/
       - /opt/stacks-data/${APP}/config:/config:ro
       - ./config/default.yaml:/config/default.yaml:ro
+      # Heartbeat endpoints the equestria openbao-replica cronjobs report
+      # into — in-repo rather than Pulumi-written because the consumers are
+      # GitOps jobs, not Pulumi-managed backup plans.
+      - ./config/openbao-break-glass.yaml:/config/openbao-break-glass.yaml:ro
     networks:
       - dockge_default
 x-dockge:

--- a/docker/alpha-site/uptime/config/openbao-break-glass.yaml
+++ b/docker/alpha-site/uptime/config/openbao-break-glass.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/gatus.schema.json
+#
+# Heartbeats for the OpenBao break-glass pipeline (migration Phase 5).
+# Both endpoints are REPORTED INTO by the openbao-replica cronjobs in the
+# equestria cluster (kubernetes/apps/kube-system/openbao-replica/), which
+# POST success/failure through the dockge-as egress. Two failure modes, both
+# loud:
+#
+#   - a job reports success=false      → endpoint goes red immediately
+#   - a job stops reporting AT ALL     → the heartbeat interval lapses and
+#                                        the endpoint goes red anyway
+#
+# Silence is the dangerous one: RUNBOOK Scenario D says a backup that has not
+# proven itself in over a month is UNTRUSTED. These heartbeats are what makes
+# that statement enforceable.
+#
+# Token convention matches toGatusKey(group, name) in
+# home-operations/components/helpers.ts, like the Pulumi-generated backup
+# endpoints.
+external-endpoints:
+  - name: nightly-dump
+    group: "OpenBao Break Glass"
+    token: openbao-break-glass_nightly-dump
+    # Nightly at 03:00 — 26h of silence means a dump was missed.
+    heartbeat:
+      interval: 26h
+    alerts:
+      - type: pushover
+        enabled: true
+        success-threshold: 1
+        failure-threshold: 1
+        minimum-reminder-interval: 24h
+  - name: restore-test
+    group: "OpenBao Break Glass"
+    token: openbao-break-glass_restore-test
+    # Monthly on the 1st at 05:00. 33 days of headroom covers a 31-day month
+    # plus one retry window; past that the backup is formally untrusted
+    # (RUNBOOK Scenario D) and someone should hear about it every day.
+    heartbeat:
+      interval: 792h
+    alerts:
+      - type: pushover
+        enabled: true
+        success-threshold: 1
+        failure-threshold: 1
+        minimum-reminder-interval: 24h


### PR DESCRIPTION
## What

The alpha-site half of Phase 5 (PLAN §E). Pairs with equestria-cluster#3071 (the nightly dump + monthly restore-test CronJobs) and vault#151 (RUNBOOK Scenarios B and D).

### `docker/alpha-site/bao-standby/` — new dockge stack

- **`dump-sftp`** (always on): rclone serve sftp exposing a writable dumps dir, bound to `${tailscaleIpAddress}:2023`, reusing the rclone-sftp keys `DockgeLxc` already seeds. This is what the equestria CronJob ships to.
- **`standby-postgres` + `bao-standby`**: **stopped by default**, behind the `break-glass` compose profile. This is the container that exists for the day equestria is gone.
- **`restore.sh`**: refuses encrypted input (the age layer must be peeled deliberately, off-host) and refuses a non-empty DB; waits for transit unseal.
- Traefik tailscale-entrypoint route `bao-standby.${tailscaleDomain}`, direct API on `:8201`.

Standby-stopped-by-default and the independent age layer are the two mitigations for `bao-transit` and the standby sharing a host — the known trade-off documented in PLAN §E and STATUS.md.

### `docker/alpha-site/uptime/` — Gatus heartbeats

`OpenBao Break Glass` external-endpoints with pushover: the nightly dump lapses at **26h**, the restore test at **33 days**, both re-page daily. This enforces the RUNBOOK Scenario D rule — *an unverified backup is not a backup* — by failing loudly on **silence** as well as on failure.

## Manual step before first use

`chown 65534:65534 /opt/stacks-data/bao-standby/dumps` on dockge-as (the compose runs unprivileged; same class of first-run volume-ownership issue as bao-transit's uid 100:1000 chown).

## Verification

Compose configs validated with `docker compose config`; scripts shellcheck-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)