### PR TITLE
feat(openbao): manage OIDC login in Pulumi instead of a bootstrap script

### DIFF
--- a/components/openbao/oidc.ts
+++ b/components/openbao/oidc.ts
@@ -1,0 +1,169 @@
+/**
+ * OpenBao human login: OIDC against Authentik.
+ *
+ * This replaces the `oidc` subcommand of the vault repo's
+ * `bootstrap/openbao/equestria-init.sh`. Everything here is barrier state —
+ * auth methods, their config and their roles live *inside* OpenBao and are
+ * written through its API, so unlike the seal and storage settings they can
+ * never come from the HCL config file or an environment variable. That left
+ * two options: a one-shot script, or a provider. A provider wins — the config
+ * is then reviewable in git, drift is detected on every preview, and the
+ * client credentials never have to be copied by hand, because the same Pulumi
+ * run that creates the Authentik application produces them.
+ *
+ * What stays in the bootstrap script, and why it has to:
+ *
+ *   - `bao operator init` and the recovery shares. Pulumi authenticates to
+ *     OpenBao with a token; init is what makes the first token exist. It
+ *     cannot be expressed as a resource in the thing it is bootstrapping.
+ *   - the `pulumi` AppRole itself, for the same reason — it is the credential
+ *     this code authenticates with.
+ *
+ * Everything after that first token is a candidate for this file. See
+ * `docs/openbao-pulumi-adoption.md` for the resources still held by the
+ * script (KV mounts, the other policies, the kubernetes/approle backends) and
+ * why adopting them needs `pulumi import` rather than a plain create.
+ */
+
+import * as pulumi from "@pulumi/pulumi";
+import * as vault from "@pulumi/vault";
+import type { GlobalResources } from "../globals.ts";
+
+/**
+ * The Authentik OAuth2 client for OpenBao, as the `applications` stack writes
+ * it to 1Password (`<cluster>-<app>-oidc-credentials`, created by
+ * `AuthentikApplicationManager.createProvider`).
+ *
+ * `issuer` is the discovery URL and NOT `openid_configuration_url`: OpenBao
+ * appends `/.well-known/openid-configuration` itself, so handing it the
+ * already-suffixed form yields a 404 at login. The Authentik slug embedded in
+ * it is a RandomPet, so this can never be hand-written either.
+ */
+interface OidcClientCredentials {
+  client_id: string;
+  client_secret: string;
+  issuer: string;
+}
+
+export interface OpenBaoOidcArgs {
+  globals: GlobalResources;
+  /**
+   * Title of the 1Password item holding the Authentik client credentials.
+   * Defaults to the item the equestria `applications` stack generates.
+   */
+  credentialTitle?: string;
+  /** Public URL of the OpenBao UI, used to build the login callback. */
+  publicUrl?: string;
+}
+
+/**
+ * Group → policy mapping. Deliberately small and explicit rather than derived:
+ * these two bindings are the whole authorization model for human access, and
+ * an accidental extra entry here is a privilege grant.
+ */
+const ROLE_BINDINGS = [
+  { role: "admin", group: "admins", policy: "admin" },
+  { role: "family", group: "family", policy: "viewer" },
+] as const;
+
+export class OpenBaoOidc extends pulumi.ComponentResource {
+  public readonly backendPath: pulumi.Output<string>;
+
+  constructor(name: string, args: OpenBaoOidcArgs, opts?: pulumi.ComponentResourceOptions) {
+    super("custom:openbao:oidc", name, args, opts);
+
+    const { globals } = args;
+    const credentialTitle = args.credentialTitle ?? "equestria-openbao-oidc-credentials";
+    const publicUrl = args.publicUrl ?? "https://bao.equestria.driscoll.tech";
+
+    // Resources here are provider-backed; without this they would target
+    // whatever ambient Vault config happened to be in the environment.
+    const cro = { parent: this, provider: globals.baoProvider };
+
+    const credentials = globals.store.getSecretByTitle<OidcClientCredentials>(credentialTitle);
+
+    // Read-only human access for the family group.
+    //
+    // SCOPE DECISION: `list` on secrets/metadata/* lets family browse the shape
+    // of the tree; there is deliberately NO capability on secrets/data/*, so no
+    // secret VALUE is readable. docs/ is fully readable because it holds
+    // reference material rather than credentials. Widening this to real secret
+    // reads should be a conscious, reviewed change — not a default.
+    const viewer = new vault.Policy(
+      "openbao-viewer",
+      {
+        name: "viewer",
+        policy: `# Read-only human access (Authentik group: family). Managed by Pulumi.
+# Browse the secret tree without reading any secret value.
+path "secrets/metadata/*" {
+  capabilities = ["list"]
+}
+
+# Reference documents are readable in full — docs/ carries no credentials.
+path "docs/data/*" {
+  capabilities = ["read"]
+}
+path "docs/metadata/*" {
+  capabilities = ["read", "list"]
+}
+`,
+      },
+      cro,
+    );
+
+    // The OIDC auth method. `defaultRole` is the least-privileged of the two on
+    // purpose: a login that does not match a more specific role gets `viewer`,
+    // never `admin`.
+    const backend = new vault.jwt.AuthBackend(
+      "openbao-oidc",
+      {
+        path: "oidc",
+        type: "oidc",
+        description: "Authentik OIDC — human login. Managed by Pulumi.",
+        oidcDiscoveryUrl: credentials.issuer,
+        oidcClientId: credentials.client_id,
+        oidcClientSecret: pulumi.secret(credentials.client_secret),
+        defaultRole: "family",
+      },
+      cro,
+    );
+
+    // Must match the Authentik client's allowed redirect URIs EXACTLY or the
+    // login fails with "unauthorized redirect_uri". Both are declared on the
+    // openbao ApplicationDefinition in the equestria-cluster repo.
+    //
+    // The UI path contains "oidc" twice by design: /auth/<mount-path>/oidc/callback,
+    // and the mount path here is itself "oidc". Port 8250 is the loopback
+    // listener `bao login -method=oidc` spins up for the CLI flow.
+    const allowedRedirectUris = [`${publicUrl}/ui/vault/auth/oidc/oidc/callback`, "http://localhost:8250/oidc/callback"];
+
+    for (const { role, group, policy } of ROLE_BINDINGS) {
+      new vault.jwt.AuthBackendRole(
+        `openbao-oidc-${role}`,
+        {
+          backend: backend.path,
+          roleName: role,
+          roleType: "oidc",
+          userClaim: "email",
+          groupsClaim: "groups",
+          // boundClaimsType defaults to "string" (exact match, no globbing).
+          // Authentik sends `groups` as a list, and a list matches when any
+          // element equals the bound value.
+          boundClaims: { groups: group },
+          tokenPolicies: [policy],
+          oidcScopes: ["openid", "profile", "email"],
+          allowedRedirectUris,
+          // 8h: one working day, so a session does not outlive it, and short
+          // enough that a group change in Authentik takes effect the same day.
+          tokenTtl: 8 * 60 * 60,
+        },
+        { ...cro, dependsOn: policy === "viewer" ? [viewer] : [] },
+      );
+    }
+
+    // The provider types `path` as optional because it defaults server-side;
+    // we set it explicitly above, so the fallback is unreachable in practice.
+    this.backendPath = backend.path.apply(p => p ?? "oidc");
+    this.registerOutputs({ backendPath: this.backendPath });
+  }
+}

--- a/docs/openbao-pulumi-adoption.md
+++ b/docs/openbao-pulumi-adoption.md
@@ -1,0 +1,72 @@
+# Moving OpenBao configuration from bootstrap scripts into Pulumi
+
+The vault repo's `bootstrap/openbao/*.sh` scripts were written before OpenBao had a Pulumi
+provider in this estate. Now that `components/globals.ts` exposes `baoProvider` (the
+official `@pulumi/vault` provider, adopted in home-operations#683), most of what those
+scripts do is better expressed as resources.
+
+This file records the split: what has moved, what is next, and the one category that can
+never move.
+
+## The dividing line
+
+**Pulumi authenticates to OpenBao with a token.** Anything required to *make that token
+exist* therefore cannot be a Pulumi resource — it would be a resource in the system it is
+bootstrapping. Everything after the first working token is fair game.
+
+## What can never move
+
+| Operation | Script | Why it stays |
+|---|---|---|
+| `bao operator init` | `bao-transit.sh`, `equestria-init.sh` | Creates the barrier and the first root token. Nothing can talk to OpenBao before it. |
+| Recovery-share handling | both | The shares come back once, from `init`, and go straight into SOPS. They are never re-derivable, so there is nothing for a provider to reconcile against. |
+| Root-token regeneration | `equestria-init.sh regen_root` | A break-glass path that runs when normal credentials do not work — i.e. exactly when Pulumi cannot run. |
+| The `pulumi` AppRole | `equestria-init.sh` | The credential this Pulumi code logs in with. Chicken-and-egg. |
+
+## What has moved
+
+| Resource | Was | Now |
+|---|---|---|
+| `viewer` policy | `equestria-init.sh oidc` | `vault.Policy` in `components/openbao/oidc.ts` |
+| `oidc` auth method + its config | `equestria-init.sh oidc` | `vault.jwt.AuthBackend` |
+| `admin` / `family` OIDC roles | `equestria-init.sh oidc` | `vault.jwt.AuthBackendRole` |
+
+Wired into `stacks/home`. The win is more than tidiness: the Authentik client credentials
+are produced by the `applications` stack, so a Pulumi-side consumer reads them directly
+instead of a human copying `client_id` / `client_secret` / `issuer` into environment
+variables for a one-shot script run.
+
+## What should move next, and the catch
+
+These are all portable in principle — the provider has a resource for each:
+
+| Operation | Provider resource |
+|---|---|
+| `bao secrets enable -path={secrets,docs,meta}` | `vault.Mount` |
+| `bao secrets enable transit` + `transit/keys/<name>` | `vault.Mount` + `vault.transit.SecretBackendKey` |
+| `bao auth enable {kubernetes,approle}` | `vault.AuthBackend` |
+| `bao write auth/kubernetes/config` | `vault.kubernetes.AuthBackendConfig` |
+| `admin`, `pulumi`, `eso-equestria`, `eso-sgc`, `equestria-unseal`, `restore-test` policies | `vault.Policy` |
+| `restore-test` AppRole | `vault.appRole.AuthBackendRole` |
+
+**The catch: they already exist.** A plain `pulumi up` would try to *create* them, and
+mounts and auth backends fail loudly on a path that is already in use (`path is already in
+use at secrets/`). So adopting them means `pulumi import`, one resource at a time, each
+verified against the live server before the next.
+
+Two cautions specific to this estate before anyone starts:
+
+1. **Do not reach for the `import` resource option as a shortcut.** The
+   `StandardDns`/Cloudflare incident (vault repo `docs/openbao-migration/STATUS.md`, and
+   the `standarddns-cloudflare-import-outage` note) is the precedent: an `import` that
+   cannot match the provider's ID format re-imports on every run, and combined with
+   `deleteBeforeReplace` it destroyed live records twice. Vault's IDs are stable and
+   path-shaped, which is a much better case than Cloudflare's — but verify with a real
+   `pulumi import` on one resource first, and confirm a follow-up `preview` is clean.
+2. **Policies are the safe place to start.** `vault.Policy` create is a PUT, so adopting
+   one is idempotent even without an import; the only consequence of Pulumi believing it
+   created the policy is that a `destroy` would remove it. Mounts and auth backends have
+   no such forgiveness.
+
+Until that adoption happens the scripts stay authoritative for those resources, and
+`equestria-init.sh status` remains the way to check them.

--- a/stacks/home/index.ts
+++ b/stacks/home/index.ts
@@ -9,6 +9,7 @@ import * as minio from "@pulumi/minio";
 import * as pulumi from "@pulumi/pulumi";
 import { DockgeLxc, getDockageProperties } from "../../components/DockgeLxc.ts";
 import { GlobalResources } from "../../components/globals.ts";
+import { OpenBaoOidc } from "../../components/openbao/oidc.ts";
 import { ProxmoxBackupServerLxc } from "../../components/ProxmoxBackupServerLxc.ts";
 import { getProxmoxProperties, ProxmoxHost } from "../../components/ProxmoxHost.ts";
 import { createGatusDnsUptime } from "../../components/StandardDns.ts";
@@ -325,3 +326,8 @@ export const celestia = {
   dockge: getDockageProperties(celestiaDockgeRuntime),
   backup: celestiaHost.backupVolumes!,
 };
+
+// OpenBao human login (Authentik OIDC): admins -> policy `admin`,
+// family -> read-only `viewer`. This is barrier state, so it cannot come from
+// the HelmRelease config or an env var — see components/openbao/oidc.ts.
+const _openbaoOidc = new OpenBaoOidc("openbao-oidc", { globals });


### PR DESCRIPTION
## Why

OpenBao's auth methods, their config and their roles are **barrier state** — written through the API after unseal. Unlike the seal and storage settings (which is why `VAULT_TRANSIT_SEAL_TOKEN` and `BAO_PG_CONNECTION_URL` work as env vars), they can never come from the HCL config or an environment variable. So the only choice was a one-shot script or a provider.

The provider wins, and by more than tidiness: the Authentik client credentials are produced by the **`applications` stack**, so a Pulumi-side consumer reads them directly instead of a human copying `client_id` / `client_secret` / `issuer` into a shell for a script run. Config becomes reviewable in git and drift shows up on every preview.

Replaces the `oidc` subcommand of `vault:bootstrap/openbao/equestria-init.sh`.

## What it creates

`components/openbao/oidc.ts`, wired into `stacks/home`:

- **`viewer` policy** — `list` on `secrets/metadata/*` (browse the tree), `read`+`list` on `docs/`, and deliberately **no capability on `secrets/data/*`** so no secret value is readable. Widening it should be a conscious, reviewed change.
- **`oidc` auth method** with `defaultRole: family` — an unmatched login lands on the *least* privileged role, never `admin`.
- **`admin` / `family` roles** bound on the `groups` claim, 8h tokens.

Two details that are easy to get wrong, commented in place:
- the discovery URL must be the item's **`issuer`** field, not `openid_configuration_url` — OpenBao appends `/.well-known/openid-configuration` itself
- the redirect URIs must match the Authentik client **exactly**; the UI one carries `oidc` twice because the mount path is itself `oidc`

## The wider survey

`docs/openbao-pulumi-adoption.md` answers "what else should move":

- **Can never move**: `operator init`, recovery shares, root regeneration, the `pulumi` AppRole — each of them is what *makes Pulumi's own credential exist*. A resource in the system it bootstraps is a contradiction.
- **Should move next**: KV mounts, the transit engine + key, the remaining policies, the kubernetes/approle backends and the restore-test AppRole.
- **The catch**: they already exist, so adoption needs `pulumi import` — a plain create fails with `path is already in use`. The doc flags the StandardDns/Cloudflare import outage as the precedent for doing that carefully, and notes policies are the safe place to start (`vault.Policy` create is a PUT, so it is idempotent even unimported).

## Verification

`npx tsc -p components/tsconfig.json --noEmit` — zero new errors (same 5 pre-existing `truenas-types.ts`); Biome clean.

Not yet applied: `pulumi up` on `stacks/home` needs `BAO_ADDR`/`BAO_TOKEN` from the `pulumi` AppRole, and the OpenBao pods still need their pending roll before OIDC login can be exercised end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)