### PR TITLE
fix(openbao): make the Phase 8a dual-write conditional on BAO_TOKEN

### DIFF
--- a/components/ProxmoxBackupServerLxc.ts
+++ b/components/ProxmoxBackupServerLxc.ts
@@ -566,37 +566,41 @@ systemctl reload proxmox-backup-proxy.service
     // 1Password stays authoritative until Phase 11 — this is written
     // ALONGSIDE the item, never instead of it; rollback is a plain
     // `git revert` of this block.
-    baoKvSecret(
-      `${args.host.name}-pbs-bao`,
-      {
-        mount: "secrets",
-        path: args.host.title.apply(title => pbsBaoPath(`Proxmox Backup Server LXC: ${title}`)),
-        data: {
-          name: name,
-          username: "root",
-          password: rootPassword.result,
-          cluster: cluster.meta.title,
-          dockge: interpolate`DockgeLxc: ${args.dockge.cluster.title}`,
-          hostname: this.tailscaleHostname,
-          webUrl: interpolate`https://${name}.${args.globals.tailscaleDomain}`,
-          ssh: {
-            hostname: this.tailscaleHostname,
+    if (args.globals.baoDualWriteEnabled) {
+      baoKvSecret(
+        `${args.host.name}-pbs-bao`,
+        {
+          mount: "secrets",
+          path: args.host.title.apply(title => pbsBaoPath(`Proxmox Backup Server LXC: ${title}`)),
+          data: {
+            name: name,
             username: "root",
             password: rootPassword.result,
+            cluster: cluster.meta.title,
+            dockge: interpolate`DockgeLxc: ${args.dockge.cluster.title}`,
+            hostname: this.tailscaleHostname,
+            webUrl: interpolate`https://${name}.${args.globals.tailscaleDomain}`,
+            ssh: {
+              hostname: this.tailscaleHostname,
+              username: "root",
+              password: rootPassword.result,
+            },
+            backrest: {
+              publicKey: backrestPrivateKey.publicKeyPem,
+              privateKey: backrestPrivateKey.privateKeyPem,
+              privateKeyId: backrestPrivateKey.id,
+            },
           },
-          backrest: {
-            publicKey: backrestPrivateKey.publicKeyPem,
-            privateKey: backrestPrivateKey.privateKeyPem,
-            privateKeyId: backrestPrivateKey.id,
-          },
+          customMetadata: baoProvenance({
+            source_title: interpolate`Proxmox Backup Server LXC: ${args.host.title}`,
+            source_tags: output(args.tags).apply(tags => [...tags, "pbs", "lxc", "backup"].join(",")),
+          }),
         },
-        customMetadata: baoProvenance({
-          source_title: interpolate`Proxmox Backup Server LXC: ${args.host.title}`,
-          source_tags: output(args.tags).apply(tags => [...tags, "pbs", "lxc", "backup"].join(",")),
-        }),
-      },
-      mergeOptions(cro, { dependsOn: [...(args.dependsOn ?? [])], provider: args.globals.baoProvider }),
-    );
+        mergeOptions(cro, { dependsOn: [...(args.dependsOn ?? [])], provider: args.globals.baoProvider }),
+      );
+    } else {
+      pulumi.log.warn(`BAO_TOKEN is not set — skipping the OpenBao dual-write for ${args.host.name}. 1Password stays authoritative; the canonical OpenBao path will be empty until a tokened run.`, this);
+    }
 
     this.tailscaleIpAddress = deviceInfo.deviceInfo.addresses.apply(z => z[0]);
     this.provider = new pbs.Provider(

--- a/components/authentik.ts
+++ b/components/authentik.ts
@@ -254,28 +254,32 @@ export class AuthentikApplicationManager extends pulumi.ComponentResource {
       // authoritative until Phase 11 — this is written ALONGSIDE the
       // OnePasswordItem above, never instead of it; rollback is a plain
       // `git revert` of this block.
-      baoKvSecret(
-        `${resourceName}-oidc-bao`,
-        {
-          mount: "secrets",
-          path: oidcBaoPath(this.args.clusterKey, definition.metadata.name),
-          data: {
-            client_id: clientId,
-            client_secret: clientSecret,
-            authorization_url: providerConfig.authorizeUrl,
-            token_url: providerConfig.tokenUrl,
-            userinfo_url: providerConfig.userInfoUrl,
-            issuer: providerConfig.issuerUrl,
-            end_session_url: providerConfig.logoutUrl,
-            jwks_url: providerConfig.jwksUrl,
-            openid_configuration_url: pulumi.interpolate`${providerConfig.issuerUrl}.well-known/openid-configuration`,
+      if (this.args.globals.baoDualWriteEnabled) {
+        baoKvSecret(
+          `${resourceName}-oidc-bao`,
+          {
+            mount: "secrets",
+            path: oidcBaoPath(this.args.clusterKey, definition.metadata.name),
+            data: {
+              client_id: clientId,
+              client_secret: clientSecret,
+              authorization_url: providerConfig.authorizeUrl,
+              token_url: providerConfig.tokenUrl,
+              userinfo_url: providerConfig.userInfoUrl,
+              issuer: providerConfig.issuerUrl,
+              end_session_url: providerConfig.logoutUrl,
+              jwks_url: providerConfig.jwksUrl,
+              openid_configuration_url: pulumi.interpolate`${providerConfig.issuerUrl}.well-known/openid-configuration`,
+            },
+            customMetadata: baoProvenance({
+              source_title: `${this.args.clusterKey}-${definition.metadata.name}-oidc-credentials`,
+            }),
           },
-          customMetadata: baoProvenance({
-            source_title: `${this.args.clusterKey}-${definition.metadata.name}-oidc-credentials`,
-          }),
-        },
-        { parent: provider, provider: this.args.globals.baoProvider },
-      );
+          { parent: provider, provider: this.args.globals.baoProvider },
+        );
+      } else {
+        pulumi.log.warn(`BAO_TOKEN is not set — skipping the OpenBao dual-write for ${resourceName}. 1Password stays authoritative; the canonical OpenBao path will be empty until a tokened run.`, provider);
+      }
 
       return {
         provider,

--- a/components/bao.ts
+++ b/components/bao.ts
@@ -238,6 +238,12 @@ export function baoKvSecret(name: string, args: BaoKvSecretArgs, opts: pulumi.Cu
       // copy has to be marked secret too — otherwise values reach state (and
       // `pulumi stack export`) in the clear.
       additionalSecretOutputs: ["data", "dataJson"],
+      // Dual-write is conditional while the operator has no BAO_TOKEN (see
+      // GlobalResources.baoDualWriteEnabled). A run without a token drops these
+      // from the program, and without this a drop would DELETE the live secret
+      // — the one outcome Phase 6/7 cannot survive. Retaining orphans the
+      // secret instead, which the next tokened run overwrites in place.
+      retainOnDelete: true,
       ...opts,
     },
   );

--- a/components/globals.ts
+++ b/components/globals.ts
@@ -134,6 +134,23 @@ export class GlobalResources extends ComponentResource {
   }
 
   /**
+   * Whether the Phase 8a dual-writes should run at all.
+   *
+   * The in-cluster Pulumi operator has no BAO_TOKEN wiring yet (the AppRole in
+   * `vault/bootstrap/openbao/pulumi-approle.sops.yaml` is still delivered by
+   * hand), so demanding a token unconditionally stalls every stack that reaches
+   * a dual-write site. Callers skip the write when this is false and say so;
+   * the paired `retainOnDelete` on those resources means a token-less run drops
+   * them from state WITHOUT deleting anything already in OpenBao, so a skip can
+   * never destroy migrated data.
+   *
+   * Remove this once the operator mints tokens and go back to hard-failing.
+   */
+  public get baoDualWriteEnabled(): boolean {
+    return !!process.env.BAO_TOKEN || runtime.isDryRun();
+  }
+
+  /**
    * OpenBao (Phase 8a of the 1Password→OpenBao migration).
    *
    * Lazy on purpose, unlike every other provider here. Constructing it eagerly
@@ -146,9 +163,10 @@ export class GlobalResources extends ComponentResource {
     if (this._baoProvider) return this._baoProvider;
 
     const token = process.env.BAO_TOKEN ?? "";
-    // Preview never calls the API, so an absent token must not break it — but
-    // an update would write nowhere and silently leave the canonical paths
-    // empty, which is exactly the failure Phase 6/7 depends on not happening.
+    // Preview never calls the API, so an absent token must not break it. On a
+    // real update this getter must never hand back a provider that would write
+    // nowhere — callers gate on `baoDualWriteEnabled` before reaching here, so
+    // arriving without a token means that gate was bypassed.
     if (!token && !runtime.isDryRun()) {
       throw new Error("BAO_TOKEN is not set — OpenBao writes would be skipped. Mint a token from the `pulumi` AppRole (vault repo: bootstrap/openbao/pulumi-approle.sops.yaml) and export BAO_ADDR/BAO_TOKEN.");
     }


### PR DESCRIPTION
## Why

`59c23c2d` (#683) made a missing `BAO_TOKEN` a hard failure on any non-preview run. The guard is right in principle — a silent no-write leaves the canonical OpenBao paths empty, which is exactly what Phase 6/7 depends on not happening. But the credential delivery never landed alongside it: the Stack CRs in `kubernetes/apps/pulumi/*/stack.yaml` carry no `BAO_ADDR`/`BAO_TOKEN` envRef, and there is no AppRole secret in the `pulumi` namespace.

Result: **five stacks stalled.** `equestria`, `home-operations`, `ocracoke` and `sgc` broke exactly at that commit (last success `74f3f5e4`, 3 failures each); `gulf-of-mexico` hit it too. All five sat at `Stalled=True / UpdateFailed`, which the operator does not retry until spec or source changes — they could not self-heal. `authentik`, `backups`, `unifi-network` and `vault` were unaffected because they never reach a dual-write site.

## What

- `globals.ts` gains `baoDualWriteEnabled` — true when `BAO_TOKEN` is set, or on preview. `baoProvider` still throws, so it can never hand back a provider that would write nowhere; callers gate before reaching it.
- Both dual-write sites (`authentik.ts`, `ProxmoxBackupServerLxc.ts`) skip the write and log a warning naming the resource, so a run that writes nothing to OpenBao says so out loud.
- `baoKvSecret` gains `retainOnDelete: true`.

### The `retainOnDelete` is the load-bearing part

Skipping a resource removes it from the program. Once a tokened run has created these secrets, a later token-less run would otherwise **delete the live OpenBao secret** — the precise outcome the original throw existed to prevent. Softening without this would have traded a stall for silent data loss. Retaining orphans the secret instead, and the next tokened run overwrites it in place.

## Scope

Interim measure, and the doc comment says so. Once the operator mints AppRole tokens the right way — ESO's `VaultDynamicSecret` generator is already installed on equestria, and the AppRole lives in `vault/bootstrap/openbao/pulumi-approle.sops.yaml` — drop `baoDualWriteEnabled` and go back to hard-failing.

## Verification

- `biome check` clean on all four files.
- `tsc --noEmit`: no errors in any changed file. The branch has 6 pre-existing errors (`helpers.ts` TS6307 + 5 in `truenas-types.ts`); `main`'s baseline is 8, the extra two being stale `@pulumi/vault` resolution errors that a fresh `npm ci` clears.
- Not yet run against a live stack — the stacks reconcile from `main`, so this needs to merge before the five stalled stacks can be nudged with the `pulumi.com/reconciliation-request` annotation.

> One caveat: `gulf-of-mexico` had 17 failures *before* the OpenBao commit, from a corrupt `/opt/stacks/wyoming/compose.yaml` on `dockge-luna` (`"10300: "` instead of `"10300:10300"`, giving `invalid containerPort`). That has been fixed on the host and the compose command now succeeds, but I could not see far enough back in the operator log to rule out a third cause behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)