### PR TITLE
fix(backups): let the sftp reader see 0700 data; exclude technitium stats

### DIFF
--- a/docker/_common/rclone-sftp/compose.yaml
+++ b/docker/_common/rclone-sftp/compose.yaml
@@ -1,6 +1,34 @@
 services:
+  # Read-only SFTP view of this host's stack data, consumed by backrest on
+  # celestia as the pre-sync source for every dockge backup plan.
+  #
+  # Runs as uid 0 with CAP_DAC_READ_SEARCH and nothing else. That combination
+  # is deliberate and load-bearing: as uid 65534 this server could not read
+  # anything mode-0700 owned by a stack's runtime user, and an EPERM here does
+  # not reach the client as an error — the serve side answers the directory
+  # request with an EMPTY LISTING, so the client copies nothing and exits 0.
+  # Those paths were therefore absent from every snapshot while the backup
+  # went on reporting success. That covered forgejo's git repositories
+  # (data/git, 0700 uid 1000), all 1.2 GB of hermes, pdm's acme/auth/access,
+  # and technitium/tailscale.
+  #
+  # CAP_DAC_READ_SEARCH is exactly "bypass file read and directory search
+  # permission checks" and nothing more. cap_drop ALL removes the rest,
+  # including DAC_OVERRIDE (write-permission bypass), and every mount below
+  # is :ro, so this container can read the host's stack data and cannot alter
+  # it. Do NOT relax this to plain root — the dropped caps are the reason
+  # running as uid 0 is acceptable here.
+  #
+  # A non-root user cannot hold the capability: docker's cap_add populates the
+  # permitted set, but caps are cleared on the setuid to a non-root user
+  # unless they are ambient, and compose cannot set ambient caps. uid 0 with
+  # a minimal cap set is the workable form.
   rclone-sftp:
-    user: "65534:65534"
+    user: "0:0"
+    cap_drop:
+      - ALL
+    cap_add:
+      - DAC_READ_SEARCH
     container_name: rclone-sftp
     image: rclone/rclone:1.75.0@sha256:b06aed988cf5967de7c25be5925240983981c757f4ed1ac9d2fa659d51d60548
     restart: unless-stopped
@@ -17,7 +45,7 @@ services:
       - /opt/stacks-data/:/data/stacks/:ro
       - /opt/stacks-data/${APP}/keys:/config/ssh:ro
     tmpfs:
-      - /.cache:uid=65534,gid=65534
+      - /.cache:uid=0,gid=0
     networks:
       - dockge_default
     labels:

--- a/stacks/backups/index.ts
+++ b/stacks/backups/index.ts
@@ -35,6 +35,14 @@ const dockgeInstances = dockgeDetails.apply(details => {
             // what this plan actually protects. Do not remove this line without
             // replacing it with a proper WAL-archiving setup.
             "/postgres/pgdata",
+            // Technitium's hourly query-statistics files (1103 of them, 222 MB
+            // on celestia). The current hour's .stat is being appended to for
+            // the whole hour, so rclone reliably copies it mid-write and fails
+            // the transfer with "corrupted on transfer: md5 hashes differ" —
+            // which aborts the ON_ERROR_FATAL pre-sync hook and takes the
+            // entire plan's snapshot with it. Pure telemetry for the DNS
+            // dashboards; nothing is reconstructed from it.
+            "/technitium/config/stats",
             "/authentik-outpost",
             "/backrest",
             "/autoheal",


### PR DESCRIPTION
## Why

`Backups: Celestia / celestia-dockge` has been failing every night since **2026-08-04** — no successful snapshot in four days. The pre-sync rclone hook is `ON_ERROR_FATAL`, so any error aborts the plan before restic runs.

Two independent causes.

### 1. The SFTP reader cannot see 0700 data — and fails silently

`rclone-sftp` runs as uid 65534 and serves `/opt/stacks-data` read-only. It cannot read anything mode-0700 owned by a stack's runtime user.

The loud half: four forgejo key files at 0600 (`data/{ssh/gitea.rsa, ssh/gitea.rsa.pub, jwt/private.pem, actions_id_token/private.pem}`) return `permission denied` and fail the sync.

**The silent half is the real problem.** An EPERM on a *directory* never reaches the client as an error — the serve side answers the request with an empty listing, the client copies nothing and exits 0. So these have simply been absent from every snapshot while the backup reported success:

| Path | Mode | Size |
|---|---|---|
| `forgejo/data/git` (repositories + LFS) | 0700 uid 1000 | — |
| `hermes` | 0700 uid 1000 | **1.2 GB** |
| `forgejo/data/indexers`, `forgejo/data/custom` | 0700 uid 1000 | 80 K |
| `pdm/{acme,auth,access,autoinst,subscriptions}` | 0700/0750 | 100 K |
| `technitium/tailscale` | 0700 | 68 K |

No repositories exist in forgejo yet, so **nothing has actually been lost** — but every repo created from here would have gone unbacked-up without a single error.

Fixed at the reader rather than by loosening permissions on each app's data (which is per-app whack-a-mole, and the app may reset them): **uid 0 with `cap_drop: ALL` + `cap_add: DAC_READ_SEARCH`**. That capability is precisely "bypass file read and directory search permission checks" — `DAC_OVERRIDE` (write bypass) is dropped, and all three mounts are already `:ro`, so the container can read the host's stack data and cannot alter it.

A non-root user can't hold the capability: `cap_add` populates the permitted set, but caps are cleared on setuid to non-root unless ambient, and compose can't set ambient caps. uid 0 with a minimal cap set is the workable form.

**Verified on dockge-celestia** with throwaway containers, without touching the running service:

```
uid 0  + cap_drop ALL + cap_add DAC_READ_SEARCH
  ls 0700 dir      -> READ_0700_DIR_OK
  read 0600 file   -> READ_0600_FILE_OK
  ls hermes        -> READ_HERMES_OK
  touch on :ro     -> Read-only file system   (WRITE_BLOCKED_OK)

uid 65534
  ls 0700 dir      -> Permission denied
  read 0600 file   -> READ_DENIED
```

### 2. Technitium hourly stats

1103 `.stat` files, 222 MB on celestia. The current hour's file is appended to continuously, so rclone copies it mid-write and fails with `corrupted on transfer: md5 hashes differ`. Excluded — it's telemetry for the DNS dashboards; nothing is reconstructed from it.

## Review notes

**The security trade-off is the thing to review.** This grants the backup reader read access to everything under `/opt/stacks-data`, including secrets that were previously unreadable to it (`pdm/acme` account keys, `technitium/tailscale` node state). The key-holder set is unchanged — it's still only backrest's key — and `/backrest`, `/backups` and `/rclone-sftp` (the key material itself) stay excluded from the plan. If you'd rather not run as uid 0 at all, the alternative is per-app permission changes plus relocating forgejo's key files via `FORGEJO__server__SSH_SERVER_HOST_KEYS` / `FORGEJO__oauth2__JWT_SIGNING_PRIVATE_KEY_FILE` — narrower blast radius, but it leaves `data/git` needing a fix of its own and has to be redone for each new app.

**Not deployed.** The compose change reaches hosts through `stacks/home`; nothing has been applied. The live container is still on uid 65534.

**Still failing after this:** `technitium/config/zones/driscoll.tech.zone` (69 MB, rewritten constantly — it changed mid-copy today too) fails identically and will keep aborting the plan. It holds real DNS data so excluding it isn't obviously right. Given `driscoll.tech` is a Forwarder zone driven by `StandardDns` from Pulumi, the records are reproducible — but a consistent dump via Technitium's settings-backup API, mirroring the `pgdata`/`pg_dump` precedent already in this file, is the better fix. Wanted your call before doing either, so **this PR alone will not turn the celestia backup green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
