### PR TITLE
fix(uptime): /config cannot be :ro — Gatus is down on alpha-site

### DIFF
--- a/docker/alpha-site/uptime/compose.yaml
+++ b/docker/alpha-site/uptime/compose.yaml
@@ -23,7 +23,19 @@ services:
       traefik.http.services.uptime.loadbalancer.server.port: 9595
     volumes:
       - /opt/stacks-data/${APP}/data/:/data/
-      - /opt/stacks-data/${APP}/config:/config:ro
+      # NOT :ro, and it cannot be. Gatus reads every YAML in GATUS_CONFIG_PATH
+      # as one merged config, so the Pulumi-written endpoint files (here) and
+      # the in-repo static files (below) have to arrive in the same directory —
+      # the static ones as individual file mounts layered on top of this one.
+      # runc has to CREATE a mountpoint inside this directory for any such file
+      # that does not already exist in it, and on a :ro mount that create fails
+      # with "make mountpoint: read-only file system" before the container
+      # process ever starts. `default.yaml` only escaped it by having a stale
+      # 0-byte twin in stacks-data from June; `openbao-break-glass.yaml` had no
+      # such twin and took the whole uptime stack down when it was added.
+      # Keep the individual file mounts below :ro — that is where read-only
+      # actually belongs.
+      - /opt/stacks-data/${APP}/config:/config
       - ./config/default.yaml:/config/default.yaml:ro
       # Heartbeat endpoints the equestria openbao-replica cronjobs report
       # into — in-repo rather than Pulumi-written because the consumers are


### PR DESCRIPTION
## Gatus is currently down

`uptime.driscoll.tech` returns 404 and the `uptime` container on `dockge-as` is stuck in `created`:

```
Status=created  ExitCode=128  StartedAt=0001-01-01T00:00:00Z
docker logs uptime  ->  0 lines
```

**There are no Gatus logs, and there is no bad config item.** Gatus never executed — this fails in runc during container init:

```
error mounting "/opt/stacks/uptime/config/openbao-break-glass.yaml"
  to rootfs at "/config/openbao-break-glass.yaml":
  create mountpoint for /config/openbao-break-glass.yaml
  mount: make mountpoint: read-only file system
```

## Why

Gatus reads every YAML under `GATUS_CONFIG_PATH` as one merged config. So the Pulumi-written endpoint files (the `stacks-data` directory) and the in-repo static files have to arrive in the *same* directory — the static ones as individual file mounts layered on top of the directory mount.

runc must **create** a mountpoint inside that directory for any layered file that isn't already present in it. The directory was mounted `:ro`, so that create fails.

`default.yaml` only ever worked by accident — a stale **0-byte** twin has sat in `/opt/stacks-data/uptime/config/` since 2026-06-08, so its mountpoint already existed:

```
-rw-r--r-- 1 root root     0 Jun  8 11:46 default.yaml      <- 0 bytes, vestigial
-rw-r--r-- 1 root root 16669 Jun  9 20:37 uptime-backups-celestia.yaml
...
```

`openbao-break-glass.yaml`, added by the Phase 5 bao-standby work (`e5654296`), had no such twin.

## Why it surfaced now

The breakage was latent for days. `home-operations` was stalled on the missing `BAO_TOKEN` and never applied the new mount. Merging #689 unstalled the stack, it applied, and Gatus stopped. So this is fallout from unstalling — not from #689 itself, which did exactly what it should.

## The fix

Drop `:ro` from the directory mount. The individual file mounts stay `:ro`, which is where read-only actually belongs — Gatus only writes to `/data`.

## Not verified live

I could not apply or test this on `dockge-as`: both the compose edit and a `touch` of the missing mountpoint were refused by the sandbox permission policy. The diagnosis is from `docker inspect` on the host and is unambiguous, but **the fix itself is reasoned, not observed.**

To restore Gatus immediately without waiting for a Pulumi run, either works:

```bash
ssh alpha-site 'pct exec 100 -- touch /opt/stacks-data/uptime/config/openbao-break-glass.yaml && pct exec 100 -- docker start uptime'
```

...or apply this change and re-run `stacks/home`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
