### PR TITLE
fix(dockge): the file-copy trigger encoded the checkout path, not the file

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -976,7 +976,18 @@ export class DockgeLxc extends ComponentResource {
           connection: this.remoteConnection,
           remotePath: interpolate`/opt/stacks/${stackName}/${file}`,
           content: replacedContent,
-          triggers: [replacedContent, absoluteFilePath],
+          // The source path is a trigger because provenance matters on its own:
+          // the same remotePath can be fed by docker/_common/<stack>/… or by the
+          // host-specific docker/<host>/<stack>/… override, and a switch between
+          // the two is a real change even when the bytes are identical.
+          //
+          // It must be relative to `dockerPath`, never absolute. An absolute path
+          // encodes WHERE THE REPO IS CHECKED OUT, which differs per machine —
+          // state written from a checkout at /share/source and a run from
+          // ~/Development/... disagree on every single file, and each run replaces
+          // all ~100 of them back and forth forever while `triggers[0]` (the
+          // content hash) sits there unchanged, proving nothing actually differs.
+          triggers: [replacedContent, relative(dockerPath, absoluteFilePath)],
           parent: stackParent,
           dependsOn: dependsOn,
         }),


### PR DESCRIPTION
## What

`copyFileToRemote` takes the source path as a trigger, which is correct in principle — the same `remotePath` can be fed by `docker/_common/<stack>/…` or by the host-specific `docker/<host>/<stack>/…` override, and switching between the two is a real change even when the bytes are identical.

It was passing the **absolute** path, which also encodes *where the repo happens to be checked out*.

## Why it matters

State written from a checkout at `/share/source` and a run from `~/Development/...` disagree on **every single file**. Each run replaces ~100 `CopyToRemote` resources to match its own paths, and the next run from the other machine replaces them straight back — indefinitely.

`triggers[0]` (the content hash) was identical across the whole set the entire time, so nothing ever actually differed:

```
old triggers[3]: /share/source/docker/alpha-site/uptime/config/default.yaml
new triggers[3]: /Users/david/Development/.../docker/alpha-site/uptime/config/default.yaml
     triggers[0]: 34bca3e22dd4e0a60aa517be826a3ac8   ← unchanged
```

This was found while debugging why `pulumi preview` on `stacks/home` reported 145 replaces; 101 of them were this and nothing else.

## The fix

Anchor to `dockerPath`, which is already defined at `components/DockgeLxc.ts:31`. That keeps the provenance distinction (`_common/uptime/…` vs `alpha-site/uptime/…`) and drops the machine-specific prefix. `relative` was already imported.

## Note for the reviewer

The first run after this merges still replaces them once, to migrate the recorded triggers off the old absolute paths. That has **already been applied** to the `home-operations` stack from this branch (identical content re-copied, no content change). After that they are stable across machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)