### PR TITLE
fix(openbao): the dual-write gate never learned about the AppRole

### DIFF
--- a/components/ProxmoxBackupServerLxc.ts
+++ b/components/ProxmoxBackupServerLxc.ts
@@ -599,7 +599,7 @@ systemctl reload proxmox-backup-proxy.service
         mergeOptions(cro, { dependsOn: [...(args.dependsOn ?? [])], provider: args.globals.baoProvider }),
       );
     } else {
-      pulumi.log.warn(`BAO_TOKEN is not set — skipping the OpenBao dual-write for ${args.host.name}. 1Password stays authoritative; the canonical OpenBao path will be empty until a tokened run.`, this);
+      pulumi.log.warn(`No OpenBao credentials (BAO_TOKEN, or BAO_ROLE_ID + BAO_SECRET_ID) — skipping the OpenBao dual-write for ${args.host.name}. 1Password stays authoritative; the canonical OpenBao path will be empty until a credentialed run.`, this);
     }
 
     this.tailscaleIpAddress = deviceInfo.deviceInfo.addresses.apply(z => z[0]);

--- a/components/authentik.ts
+++ b/components/authentik.ts
@@ -278,7 +278,7 @@ export class AuthentikApplicationManager extends pulumi.ComponentResource {
           { parent: provider, provider: this.args.globals.baoProvider },
         );
       } else {
-        pulumi.log.warn(`BAO_TOKEN is not set — skipping the OpenBao dual-write for ${resourceName}. 1Password stays authoritative; the canonical OpenBao path will be empty until a tokened run.`, provider);
+        pulumi.log.warn(`No OpenBao credentials (BAO_TOKEN, or BAO_ROLE_ID + BAO_SECRET_ID) — skipping the OpenBao dual-write for ${resourceName}. 1Password stays authoritative; the canonical OpenBao path will be empty until a credentialed run.`, provider);
       }
 
       return {

--- a/components/globals.ts
+++ b/components/globals.ts
@@ -144,10 +144,18 @@ export class GlobalResources extends ComponentResource {
    * them from state WITHOUT deleting anything already in OpenBao, so a skip can
    * never destroy migrated data.
    *
+   * It must accept the SAME credentials as `baoProvider` below — a token OR the
+   * AppRole. Checking only BAO_TOKEN made an AppRole run authenticate fine and
+   * then silently skip every dual-write, so `pulumi up` reported success while
+   * `secrets/hosts/pbs/` and the app `.../oidc` paths stayed empty. The
+   * `isDryRun()` arm hides that from preview too: preview advertises the creates
+   * and the apply quietly drops them, so a clean preview proves nothing here.
+   *
    * Remove this once the operator mints tokens and go back to hard-failing.
    */
   public get baoDualWriteEnabled(): boolean {
-    return !!process.env.BAO_TOKEN || runtime.isDryRun();
+    const haveApprole = !!process.env.BAO_ROLE_ID && !!process.env.BAO_SECRET_ID;
+    return !!process.env.BAO_TOKEN || haveApprole || runtime.isDryRun();
   }
 
   /**


### PR DESCRIPTION
## The bug

#692 made the `pulumi` AppRole the normal way Pulumi authenticates to OpenBao, and `baoProvider` accepts it (`components/globals.ts:196-205`). But `baoDualWriteEnabled` still only recognised `BAO_TOKEN`:

```ts
return !!process.env.BAO_TOKEN || runtime.isDryRun();
```

So an AppRole run authenticates perfectly well and then silently skips every Phase 8a dual-write:

```
warning: BAO_TOKEN is not set — skipping the OpenBao dual-write for celestia.
```

## Why it went unnoticed

This is worse than a plain no-op, because of the `isDryRun()` arm:

- **preview** takes the dry-run branch and advertises 12 `vault:kv/secretV2:SecretV2` creates
- **apply** takes the real branch, finds no `BAO_TOKEN`, and drops all twelve

A clean preview is therefore not evidence the dual-write will happen. A `pulumi up` on `stacks/home` reported success while `secrets/hosts/pbs/` and every app `.../oidc` path stayed empty — verified live against `https://bao.equestria.driscoll.tech`:

```console
$ bao kv list secrets/hosts        # dockge/ only, no pbs/
$ bao kv list secrets/clusters/equestria/apps/grafana
postgres                           # no oidc
```

## The fix

Accept the same two credential shapes the provider does. Both skip warnings now name the AppRole too, so the next person isn't hunting for a token they were never supposed to need.

## Not fixed here

`stacks/home` currently aborts on the UniFi provider before it reaches the dual-write sites, so this cannot be verified end-to-end until that clears. It's an independent problem — the API key returns 200 on the failing path and the controller is healthy; the provider fails in its own Configure step probing a legacy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)