### PR TITLE
feat(tailscale): grant tcp:2023 so the openbao dump replication can land

### DIFF
--- a/components/constants.ts
+++ b/components/constants.ts
@@ -87,6 +87,12 @@ export const Tailscale = {
     // dockge→dockge, management→dockge) and this port must not ride along with
     // it. See the `openbao-transit-unseal` grant in acl-manager.ts.
     baoTransit: ["tcp:8200"] as TailscaleNetworkCapability[],
+    // The bao-standby dump receiver on dockge-as (rclone serve sftp). The
+    // equestria replication CronJob writes the nightly age-encrypted pg_dump
+    // here. Separate from baoTransit for the same reason that one is separate
+    // from dockgeManagement: the two ports serve different jobs and should be
+    // grantable independently.
+    baoDumps: ["tcp:2023"] as TailscaleNetworkCapability[],
   } as const,
   autogroups: {
     admin: "autogroup:admin" as TailscaleAutogroups,

--- a/stacks/unifi-network/acl-manager.ts
+++ b/stacks/unifi-network/acl-manager.ts
@@ -433,6 +433,24 @@ export function assignTailscaleAcls(globals: GlobalResources): pulumi.Output<any
       { accept: [] },
     );
 
+    // The Phase 5 nightly dump: equestria's openbao-replica CronJob ships an
+    // age-encrypted pg_dump to the bao-standby receiver on dockge-as:2023.
+    // Same shape and same reasoning as the grant above — the traffic leaves
+    // through the tailnet-inbound ProxyGroup carrying tag:egress, and the
+    // egress Service already declares the port (bao-dumps=2023), so without
+    // this grant the connection is forwarded and then dies in the ACL. It
+    // presents as a plain "connection refused" from the pod, which reads like
+    // the receiver is down rather than like a policy problem.
+    manager.setGrant(
+      "openbao-dump-replication",
+      {
+        src: [tag.egress],
+        dst: [tag.dockge],
+        ip: ports.baoDumps,
+      },
+      { accept: [] },
+    );
+
     pulumi.output(manager.getJson()).apply(json => {
       writeFileSync("tailscale-acl.json", json);
     });


### PR DESCRIPTION
The Phase 5 nightly job ships an age-encrypted `pg_dump` from equestria to the bao-standby receiver on `dockge-as:2023`. Everything exists **except the tailnet grant**:

| Piece | State |
|---|---|
| receiver | `bao-standby-dump-sftp  Up 2 hours  100.111.10.9:2023->2023/tcp` |
| egress Service ports | `https=443 ssh=22 adguard=4000 bao=8200 bao-dumps=2023` |
| host directory | `/opt/stacks-data/bao-standby/dumps` (nobody:nogroup) |
| from an openbao pod | `2023 CLOSED` / `8200 OPEN` |

8200 is open because `openbao-transit-unseal` grants it. 2023 has no grant, so the egress proxy forwards the port and the connection dies in the ACL.

That grant's own comment predicted this: *"the egress Service forwards the port and the connection still dies in the ACL, which looks exactly like a misconfigured seal address."* Here it presents as a plain connection refused, which reads like the receiver is down — it isn't.

Mirrors that grant: `src: [tag.egress]` alone (the one hop that needs it), `dst: [tag.dockge]`. `baoDumps` is its own `ports` entry rather than folded into `baoTransit` because the two serve different jobs and should be grantable independently.

⚠️ Needs `pulumi up` on `stacks/unifi-network` to take effect — not done in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)