### PR TITLE
feat(pulumi-operator): give every stack the OpenBao AppRole, via SOPS

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,28 @@
+---
+# SOPS config for home-operations. Mirrors equestria-cluster/.sops.yaml and uses
+# the SAME three estate age recipients, so the existing age.key decrypts these
+# files unchanged and Flux's `sops-age` Secret works without any new key
+# material.
+#
+# Why this repo needs SOPS at all: the Pulumi operator authenticates to OpenBao
+# with the `pulumi` AppRole, and per vault:bootstrap/INVENTORY.md §2 the
+# credential Pulumi authenticates WITH cannot live in a store that mediates
+# access. Sourcing it from 1Password would make the operator depend on
+# 1Password Connect in order to reach OpenBao — exactly the dependency Phase 11
+# exists to remove.
+#
+# encrypted_regex keeps Kubernetes Secret keys (`data`/`stringData`) encrypted
+# while leaving apiVersion/kind/metadata readable, so Flux and kustomize can
+# still parse the manifest before decryption.
+creation_rules:
+  - path_regex: kubernetes/.*\.sops\.ya?ml
+    encrypted_regex: "^(data|stringData)$"
+    mac_only_encrypted: true
+    key_groups:
+      - age:
+        - "age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf"
+        - "age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr"
+        - "age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6"
+stores:
+  yaml:
+    indent: 2

--- a/kubernetes/apps/pulumi/applications/equestria.yaml
+++ b/kubernetes/apps/pulumi/applications/equestria.yaml
@@ -62,6 +62,26 @@ spec:
       secret:
         name: pulumi-operator-passphrase
         key: password
+    # OpenBao (Phase 8a dual-write). Without these three,
+    # GlobalResources.baoDualWriteEnabled is false and every dual-write is
+    # silently skipped while the run still reports success.
+    #
+    # openbao-active, not openbao: the general Service also routes to standbys,
+    # which answer with a 307 redirect to the leader.
+    BAO_ADDR:
+      type: Literal
+      literal:
+        value: "http://openbao-active.kube-system.svc.cluster.local:8200"
+    BAO_ROLE_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: role-id
+    BAO_SECRET_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: secret-id
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/applications/equestria.yaml
+++ b/kubernetes/apps/pulumi/applications/equestria.yaml
@@ -66,6 +66,11 @@ spec:
     # GlobalResources.baoDualWriteEnabled is false and every dual-write is
     # silently skipped while the run still reports success.
     #
+    # Set on EVERY stack, not just the ones that dual-write today: the getter
+    # is lazy, so a stack that never touches OpenBao never builds the provider
+    # and these are inert. Wiring them uniformly means the next stack to grow a
+    # dual-write site just works, instead of failing the same silent way.
+    #
     # openbao-active, not openbao: the general Service also routes to standbys,
     # which answer with a 307 redirect to the leader.
     BAO_ADDR:

--- a/kubernetes/apps/pulumi/applications/sgc.yaml
+++ b/kubernetes/apps/pulumi/applications/sgc.yaml
@@ -62,6 +62,26 @@ spec:
       secret:
         name: pulumi-operator-passphrase
         key: password
+    # OpenBao (Phase 8a dual-write). Without these three,
+    # GlobalResources.baoDualWriteEnabled is false and every dual-write is
+    # silently skipped while the run still reports success.
+    #
+    # openbao-active, not openbao: the general Service also routes to standbys,
+    # which answer with a 307 redirect to the leader.
+    BAO_ADDR:
+      type: Literal
+      literal:
+        value: "http://openbao-active.kube-system.svc.cluster.local:8200"
+    BAO_ROLE_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: role-id
+    BAO_SECRET_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: secret-id
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/applications/sgc.yaml
+++ b/kubernetes/apps/pulumi/applications/sgc.yaml
@@ -66,6 +66,11 @@ spec:
     # GlobalResources.baoDualWriteEnabled is false and every dual-write is
     # silently skipped while the run still reports success.
     #
+    # Set on EVERY stack, not just the ones that dual-write today: the getter
+    # is lazy, so a stack that never touches OpenBao never builds the provider
+    # and these are inert. Wiring them uniformly means the next stack to grow a
+    # dual-write site just works, instead of failing the same silent way.
+    #
     # openbao-active, not openbao: the general Service also routes to standbys,
     # which answer with a 307 redirect to the leader.
     BAO_ADDR:

--- a/kubernetes/apps/pulumi/authentik/stack.yaml
+++ b/kubernetes/apps/pulumi/authentik/stack.yaml
@@ -63,6 +63,31 @@ spec:
       secret:
         name: pulumi-operator-passphrase
         key: password
+    # OpenBao (Phase 8a dual-write). Without these three,
+    # GlobalResources.baoDualWriteEnabled is false and every dual-write is
+    # silently skipped while the run still reports success.
+    #
+    # Set on EVERY stack, not just the ones that dual-write today: the getter
+    # is lazy, so a stack that never touches OpenBao never builds the provider
+    # and these are inert. Wiring them uniformly means the next stack to grow a
+    # dual-write site just works, instead of failing the same silent way.
+    #
+    # openbao-active, not openbao: the general Service also routes to standbys,
+    # which answer with a 307 redirect to the leader.
+    BAO_ADDR:
+      type: Literal
+      literal:
+        value: "http://openbao-active.kube-system.svc.cluster.local:8200"
+    BAO_ROLE_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: role-id
+    BAO_SECRET_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: secret-id
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/backups/stack.yaml
+++ b/kubernetes/apps/pulumi/backups/stack.yaml
@@ -63,6 +63,31 @@ spec:
       secret:
         name: pulumi-operator-passphrase
         key: password
+    # OpenBao (Phase 8a dual-write). Without these three,
+    # GlobalResources.baoDualWriteEnabled is false and every dual-write is
+    # silently skipped while the run still reports success.
+    #
+    # Set on EVERY stack, not just the ones that dual-write today: the getter
+    # is lazy, so a stack that never touches OpenBao never builds the provider
+    # and these are inert. Wiring them uniformly means the next stack to grow a
+    # dual-write site just works, instead of failing the same silent way.
+    #
+    # openbao-active, not openbao: the general Service also routes to standbys,
+    # which answer with a 307 redirect to the leader.
+    BAO_ADDR:
+      type: Literal
+      literal:
+        value: "http://openbao-active.kube-system.svc.cluster.local:8200"
+    BAO_ROLE_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: role-id
+    BAO_SECRET_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: secret-id
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
+++ b/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
@@ -63,6 +63,31 @@ spec:
       secret:
         name: pulumi-operator-passphrase
         key: password
+    # OpenBao (Phase 8a dual-write). Without these three,
+    # GlobalResources.baoDualWriteEnabled is false and every dual-write is
+    # silently skipped while the run still reports success.
+    #
+    # Set on EVERY stack, not just the ones that dual-write today: the getter
+    # is lazy, so a stack that never touches OpenBao never builds the provider
+    # and these are inert. Wiring them uniformly means the next stack to grow a
+    # dual-write site just works, instead of failing the same silent way.
+    #
+    # openbao-active, not openbao: the general Service also routes to standbys,
+    # which answer with a 307 redirect to the leader.
+    BAO_ADDR:
+      type: Literal
+      literal:
+        value: "http://openbao-active.kube-system.svc.cluster.local:8200"
+    BAO_ROLE_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: role-id
+    BAO_SECRET_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: secret-id
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/home-operations/stack.yaml
+++ b/kubernetes/apps/pulumi/home-operations/stack.yaml
@@ -68,6 +68,11 @@ spec:
     # GlobalResources.baoDualWriteEnabled is false and every dual-write is
     # silently skipped while the run still reports success.
     #
+    # Set on EVERY stack, not just the ones that dual-write today: the getter
+    # is lazy, so a stack that never touches OpenBao never builds the provider
+    # and these are inert. Wiring them uniformly means the next stack to grow a
+    # dual-write site just works, instead of failing the same silent way.
+    #
     # openbao-active, not openbao: the general Service also routes to standbys,
     # which answer with a 307 redirect to the leader.
     BAO_ADDR:

--- a/kubernetes/apps/pulumi/home-operations/stack.yaml
+++ b/kubernetes/apps/pulumi/home-operations/stack.yaml
@@ -64,6 +64,26 @@ spec:
       secret:
         name: pulumi-operator-passphrase
         key: password
+    # OpenBao (Phase 8a dual-write). Without these three,
+    # GlobalResources.baoDualWriteEnabled is false and every dual-write is
+    # silently skipped while the run still reports success.
+    #
+    # openbao-active, not openbao: the general Service also routes to standbys,
+    # which answer with a 307 redirect to the leader.
+    BAO_ADDR:
+      type: Literal
+      literal:
+        value: "http://openbao-active.kube-system.svc.cluster.local:8200"
+    BAO_ROLE_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: role-id
+    BAO_SECRET_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: secret-id
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/ocracoke/stack.yaml
+++ b/kubernetes/apps/pulumi/ocracoke/stack.yaml
@@ -63,6 +63,31 @@ spec:
       secret:
         name: pulumi-operator-passphrase
         key: password
+    # OpenBao (Phase 8a dual-write). Without these three,
+    # GlobalResources.baoDualWriteEnabled is false and every dual-write is
+    # silently skipped while the run still reports success.
+    #
+    # Set on EVERY stack, not just the ones that dual-write today: the getter
+    # is lazy, so a stack that never touches OpenBao never builds the provider
+    # and these are inert. Wiring them uniformly means the next stack to grow a
+    # dual-write site just works, instead of failing the same silent way.
+    #
+    # openbao-active, not openbao: the general Service also routes to standbys,
+    # which answer with a 307 redirect to the leader.
+    BAO_ADDR:
+      type: Literal
+      literal:
+        value: "http://openbao-active.kube-system.svc.cluster.local:8200"
+    BAO_ROLE_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: role-id
+    BAO_SECRET_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: secret-id
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/secrets/ks.yaml
+++ b/kubernetes/apps/pulumi/secrets/ks.yaml
@@ -26,6 +26,15 @@ spec:
     kind: GitRepository
     name: home-operations
     namespace: flux-system
+  # Required for openbao-approle.sops.yaml. The components/common patch adds
+  # decryption to the parent `pulumi` Kustomization but not to this child, so
+  # without this block the SOPS ciphertext is applied verbatim and the operator
+  # authenticates to OpenBao with the literal string "ENC[AES256_GCM,...]".
+  # `sops-age` already exists in this namespace.
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
   postBuild:
     substitute:
       APP: *app

--- a/kubernetes/apps/pulumi/secrets/kustomization.yaml
+++ b/kubernetes/apps/pulumi/secrets/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./gitrepository.yaml
   - ./secret.yaml
   - ./externalsecret.yaml
+  - ./openbao-approle.sops.yaml

--- a/kubernetes/apps/pulumi/secrets/openbao-approle.sops.yaml
+++ b/kubernetes/apps/pulumi/secrets/openbao-approle.sops.yaml
@@ -1,0 +1,57 @@
+# The OpenBao `pulumi` AppRole, for the Pulumi Kubernetes Operator.
+#
+# Consumed as BAO_ROLE_ID / BAO_SECRET_ID envRefs on the Stack CRs. Without
+# it GlobalResources.baoDualWriteEnabled is false and every Phase 8a
+# dual-write is silently skipped while the run still reports success.
+#
+# SOPS rather than a OnePasswordItem on purpose: this is the credential
+# Pulumi authenticates WITH, so per vault:bootstrap/INVENTORY.md §2 it must
+# not come from a store that mediates access. Sourcing it from 1Password
+# would make reaching OpenBao depend on 1Password Connect being alive.
+#
+# The authoritative copy is vault:bootstrap/openbao/pulumi-approle.sops.yaml.
+# Rotating the AppRole means updating BOTH.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pulumi-operator-bao-approle
+  annotations:
+    reloader.stakater.com/auto: "true"
+type: Opaque
+stringData:
+  role-id: ENC[AES256_GCM,data:4ciTcZn5DXYYv3//PXp7d8ffowz8OPYc8T6tbBtx6qEyTJkz,iv:Krw2Cupa6QSl4+FFM0RouYmHvnrHklwGJzP6luDo8aU=,tag:mtZFMAlUwWALl2fquZ3/8w==,type:str]
+  secret-id: ENC[AES256_GCM,data:MDvV8gu/zXoAvpwuQw7M0U+KF5sXmJgutP1iGKnOfMjnvwRA,iv:YBuERRu16evrhSTpXkmURzsynh71/vD/CHyjaN69hQg=,tag:pVlXVJtCoDSiAQHU6aPCLA==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDVllpaGRzYzA5ai94T2Z5
+        ZWd2cmFtT1FRSDRLcEE5S1JldmhMTnJWWDNFCmYyRGFZOE5XWUE2VC9uWGNlOGlw
+        YnU0OTRLZlY0OGNtS3pySklwSHJxa0UKLS0tIFR2Tko3MXVoeG9mcjZNNHhPNFpU
+        M1FvTFdCWVBEeHFocGd2RXc5M3QwbEEKg/haXckumP8/j1sSCMgV2nOz2HKD9P/S
+        vG8tDdgbN5meQc26zvxxu6yb1zjbXojnRf2p9ttPEQ9xDb+kuq22uQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVWktRM0RxZnpLSkJIbUg0
+        N0t4a1FPM3U1Wlp1QzE0QkFXMnpLUVlVUkVVCmVJT0s0eXZNLzZBdEQ0cTkrU3Ay
+        OWVGMlU2SlFuS0syVTYzcG54OXgzNWsKLS0tIHNHTGpjeHVIMXRLSUE1NnA0aUdi
+        cXQvOEs2NjhHM3Q5V3o3ZThuVG8wU1kKmwPQJEKqRPSxz3M7FromfZfbmTJgtI1t
+        uGlAEZPKKl4KkQq+ebtueILTgfo7NYoY7TD4ypiJ4Rlik4xwr9D34w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1TithaDR4Zm9pRzNRZEd3
+        ekpRNTJhMDFUUFFkcmVmSUVlNGJwdi96a1hnClhQVHZPVXVjUUVuRWNITkZzd0Vi
+        Q3YwcG5UTUNWYi8vZ083a2JYUHhRZ0UKLS0tIGZMbVJJczNaUHo3MUV0RHFEYWY0
+        QnhYRUpUN2RHS05ETXRtdE1SbVAzMTgKGZMnnrfyh+4wNsJaWfDiZRjh91oThu99
+        K1AUKFM7xKb5DvFn6rV/TlzPc0zyG702eZ7GQGYKg+KxAjXRmnDNTw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-10T00:00:08Z"
+  mac: ENC[AES256_GCM,data:9sF7CVc3tIHhI9JDJzLc3eDuaEFdswla0pQD7qub7lvJT6rvm8WZEaeDp/Gxng61gKvR3xI+hlBeb32NolVyTIq8mSmr/i+VEUlWpx6pvgb2QxhZH62zCmyRFcpz1lh4jadVfkMXJ3GDHV3hlpOp2SfsqmDiTRkjnxy3RCBQB1M=,iv:qiJeyheEuIgLvAO7B//6AlOAgZ3xEPL5nngxJZVByXE=,tag:HTnXhuKSdOHi6Wuvjc50sg==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/pulumi/unifi-network/stack.yaml
+++ b/kubernetes/apps/pulumi/unifi-network/stack.yaml
@@ -62,6 +62,31 @@ spec:
       secret:
         name: pulumi-operator-passphrase
         key: password
+    # OpenBao (Phase 8a dual-write). Without these three,
+    # GlobalResources.baoDualWriteEnabled is false and every dual-write is
+    # silently skipped while the run still reports success.
+    #
+    # Set on EVERY stack, not just the ones that dual-write today: the getter
+    # is lazy, so a stack that never touches OpenBao never builds the provider
+    # and these are inert. Wiring them uniformly means the next stack to grow a
+    # dual-write site just works, instead of failing the same silent way.
+    #
+    # openbao-active, not openbao: the general Service also routes to standbys,
+    # which answer with a 307 redirect to the leader.
+    BAO_ADDR:
+      type: Literal
+      literal:
+        value: "http://openbao-active.kube-system.svc.cluster.local:8200"
+    BAO_ROLE_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: role-id
+    BAO_SECRET_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: secret-id
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/vault/stack.yaml
+++ b/kubernetes/apps/pulumi/vault/stack.yaml
@@ -68,6 +68,11 @@ spec:
     # GlobalResources.baoDualWriteEnabled is false and every dual-write is
     # silently skipped while the run still reports success.
     #
+    # Set on EVERY stack, not just the ones that dual-write today: the getter
+    # is lazy, so a stack that never touches OpenBao never builds the provider
+    # and these are inert. Wiring them uniformly means the next stack to grow a
+    # dual-write site just works, instead of failing the same silent way.
+    #
     # openbao-active, not openbao: the general Service also routes to standbys,
     # which answer with a 307 redirect to the leader.
     BAO_ADDR:

--- a/kubernetes/apps/pulumi/vault/stack.yaml
+++ b/kubernetes/apps/pulumi/vault/stack.yaml
@@ -64,6 +64,26 @@ spec:
       secret:
         name: pulumi-operator-passphrase
         key: password
+    # OpenBao (Phase 8a dual-write). Without these three,
+    # GlobalResources.baoDualWriteEnabled is false and every dual-write is
+    # silently skipped while the run still reports success.
+    #
+    # openbao-active, not openbao: the general Service also routes to standbys,
+    # which answer with a 307 redirect to the leader.
+    BAO_ADDR:
+      type: Literal
+      literal:
+        value: "http://openbao-active.kube-system.svc.cluster.local:8200"
+    BAO_ROLE_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: role-id
+    BAO_SECRET_ID:
+      type: Secret
+      secret:
+        name: pulumi-operator-bao-approle
+        key: secret-id
   secretsRef:
     github:token:
       type: Secret


### PR DESCRIPTION
## The actual reason Phase 8a stalled

Every Pulumi stack in this estate runs under the **Pulumi Kubernetes Operator**, not from a laptop:

```
authentik  backups  equestria  gulf-of-mexico  home-operations  ocracoke  sgc  unifi-network  vault
```

The operator has no OpenBao credentials, so `GlobalResources.baoDualWriteEnabled` is false on every 300s resync and each Phase 8a dual-write is silently skipped — while the run still reports success. That's why equestria and sgc still have **zero** `.../oidc` paths. Running the stacks locally would only have been overwritten on the next resync.

## SOPS, not a OnePasswordItem

The operator's other four secrets are `OnePasswordItem` CRs, so that was the obvious-looking choice. It's the wrong one here.

`vault:bootstrap/INVENTORY.md` §2 is explicit that the credential Pulumi authenticates **with** must not come from a store that mediates access. Sourcing it from 1Password would make *reaching OpenBao depend on 1Password Connect being alive* — the exact dependency Phase 11 exists to remove, layered onto a chain where `external-secrets-stores` already `dependsOn` `onepassword-connect`.

## Three pieces

| Piece | Note |
|---|---|
| `.sops.yaml` | New to this repo. Mirrors equestria-cluster's, same three estate age recipients, so the existing `age.key` and Flux's `sops-age` Secret work unchanged |
| `decryption:` on `apps/pulumi/secrets/ks.yaml` | **The easy one to miss.** `components/common` patches decryption onto the parent `pulumi` Kustomization but not this child — verified live as `decryption=NONE`. Without it the ciphertext is applied verbatim and the operator authenticates with the literal string `ENC[AES256_GCM,...]` |
| `BAO_*` envRefs | On **all nine** Stack CRs |

`sops-age` already exists in the `pulumi` namespace (153d), so no new key material anywhere.

`BAO_ADDR` points at `openbao-active`, not `openbao` — the general Service also routes to standbys, which answer with a 307 redirect to the leader.

## Why all nine and not just the four that dual-write today

Safe because the provider getter is **lazy**: `GlobalResources.baoProvider` is only constructed when something asks for it, so a stack that never touches OpenBao never builds it and the three variables sit inert.

Worth doing because the failure mode when they're absent is *silent*. A stack that grows its first dual-write site would skip it and still report success — the exact bug that cost most of 2026-08-08 to find. Uniform wiring means the next one just works.

## Verified before pushing

- secret round-trips through sops; `role-id`/`secret-id` are `ENC[...]` on disk while `kind`/`metadata` stay readable for kustomize
- all nine Stack CRs parse, each with 12 envRefs, and each asserts the right secret name and both keys
- `kubectl kustomize` on the secrets dir builds

## Rotation caveat

The authoritative copy stays `vault:bootstrap/openbao/pulumi-approle.sops.yaml`. Rotating the AppRole means updating **both** — noted in the file itself.

## After merge

The operator should write the missing `secrets/clusters/{equestria,sgc}/apps/<app>/oidc` paths on its next resync, completing Phase 8a and unblocking Phases 6–7. Worth verifying the paths actually appear rather than trusting a green run — a silently-skipped dual-write is precisely what this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)