### PR TITLE
feat(volsync): the home-operations copy of the component, onto OpenBao

### DIFF
--- a/kubernetes/components/volsync/externalsecret.yaml
+++ b/kubernetes/components/volsync/externalsecret.yaml
@@ -8,7 +8,7 @@ spec:
   refreshInterval: 4m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: "${APP}-volsync-secret"
     template:
@@ -23,4 +23,6 @@ spec:
         RESTIC_PASSWORD: "{{ .credential }}"
   dataFrom:
     - extract:
-        key: 'Volsync Password'
+        # was: 'Volsync Password'   (1Password item title in vault Eris)
+        # Path within the `secrets` mount; the store pins `path: secrets`.
+        key: shared/volsync-password


### PR DESCRIPTION
equestria-cluster#3088 moved **38 of 39** volsync ExternalSecrets. `equestria/dynacat` didn't move — and its Kustomization had reconciled cleanly, which was the confusing part.

## Because there are two copies of the components

```
ks equestria/dynacat -> GitRepository/flux-system/home-operations  path=./dashboard
```

dynacat doesn't source from `equestria-cluster` at all. **`kubernetes/components/` exists in both repos, and 16 equestria Kustomizations source from this one.** Editing the equestria-cluster copy moved everything except the apps fed from here.

## Same change, same verification

- template reads only `.credential`
- `secrets/shared/volsync-password` has it at 47 bytes
- dynacat's rendered `RESTIC_PASSWORD` already matches it byte for byte

## Carry this into the rest of Phase 6

Component-shaped work has to be done in **both repos**, and "grep the cluster repo" will keep under-reporting. The only other 1Password-backed component here is `alerts/github-status` — which is the 17-namespace `github-status-token`, so **that one has a twin too** and will hit the same thing.

After this: 39/39 volsync, **43 of 78** overall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
