### PR TITLE
feat(alerts): the home-operations copy of github-status-token, onto OpenBao

### DIFF
--- a/kubernetes/components/alerts/github-status/externalsecret.yaml
+++ b/kubernetes/components/alerts/github-status/externalsecret.yaml
@@ -7,7 +7,10 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    # Phase 6. The twin of this component in equestria-cluster changes in the
+    # same batch — 16 equestria Kustomizations source from THIS copy, and
+    # editing only one repo is what left dynacat behind during volsync.
+    name: openbao
   target:
     name: github-status-token-secret
     template:
@@ -17,7 +20,8 @@ spec:
         githubAppPrivateKey: "{{ .github_app_private_key }}"
   dataFrom:
     - extract:
-        key: Github Actions Runner (david-driscoll)
+        # was: Github Actions Runner (david-driscoll)
+        key: shared/github-actions-runner-david-driscoll
       rewrite:
         - regexp:
             source: "[\\W]"


### PR DESCRIPTION
Twin of equestria-cluster#3089.

This repo holds **its own copy** of `components/alerts/github-status`, and **16 equestria Kustomizations source from here** rather than from the cluster repo.

## Shipping both together on purpose

During the volsync step only the cluster repo was edited. That moved 38 of 39 and left `equestria/dynacat` behind — with a Kustomization reporting *perfectly healthy*, which is what made it hard to spot. Not worth repeating.

## Same verification as the twin

All three template fields exist in OpenBao under identical names (the `[\W]->_` rewrite is a no-op — already snake_case):

```
github_app_id                len=6     sha=35ec2213
github_app_installation_id   len=8     sha=a1560cf0
github_app_private_key       len=1674  sha=7a05fc28

17 namespaces x 3 fields = 51 comparisons, 0 mismatches
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
