### PR TITLE
feat(pulumi): vault-ssh-credentials onto OpenBao

### DIFF
--- a/kubernetes/apps/pulumi/secrets/externalsecret.yaml
+++ b/kubernetes/apps/pulumi/secrets/externalsecret.yaml
@@ -11,7 +11,7 @@ spec:
   refreshPolicy: Periodic
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: vault-ssh-credentials
     creationPolicy: Owner
@@ -27,7 +27,8 @@ spec:
         known_hosts: '{{ .known_hosts }}'
   dataFrom:
     - extract:
-        key: GitHub david-driscoll/vault Deploy Key
+        # was: GitHub david-driscoll/vault Deploy Key
+        key: shared/github-david-driscoll-vault-deploy-key
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None


### PR DESCRIPTION
The twin of the equestria-cluster change in #3090 — this repo has **its own copy** of the ExternalSecret feeding Flux's `GitRepository` deploy key for the vault repo.

```diff
-    name: onepassword-connect
+    name: openbao
-        key: GitHub david-driscoll/vault Deploy Key
+        key: shared/github-david-driscoll-vault-deploy-key
```

Same key, same path, same fields — template untouched.

Third time the two-repo split has mattered this phase (after `volsync` and `github-status`), so it's worth restating: **grepping only the cluster repo under-reports Phase 6 scope.**

This leaves **no ExternalSecret on `onepassword-connect` in this repo.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
