### PR TITLE
fix(dashboard): dynacat's pushover key is built from a substitution

### DIFF
--- a/dashboard/externalsecret.yaml
+++ b/dashboard/externalsecret.yaml
@@ -92,7 +92,11 @@ spec:
 
   dataFrom:
     - extract:
-        key: ${CLUSTER_TITLE} Pushover Key
+        # was: ${CLUSTER_TITLE} Pushover Key
+        # CLUSTER_TITLE is the display-cased name and addressed a 1Password
+        # item TITLE; the OpenBao slug is lowercase, which is CLUSTER_CNAME.
+        # Carrying CLUSTER_TITLE across yields shared/Equestria-... and a 403.
+        key: shared/${CLUSTER_CNAME}-pushover-key
       rewrite:
         - regexp:
             source: "[\\W]"


### PR DESCRIPTION
`dynacat-env` went `SecretSyncedError` immediately after #706:

```
GET .../v1/secrets/data/Equestria%20Pushover%20Key
Code: 403. permission denied
```

## Cause

One of its sixteen keys is `'${CLUSTER_TITLE} Pushover Key'` — **not a literal title** — so the rewrite that mapped the other fifteen never matched it. It stayed pointing at a 1Password item *title* while the store had already flipped to OpenBao, so ESO asked OpenBao for a path that doesn't exist.

Same shape as the alertmanager case in equestria-cluster#3094, and it **changes variable** rather than carrying across: `CLUSTER_TITLE` is display-cased (`Equestria`) because it addressed a 1Password title; the OpenBao slug is lowercase, which is `CLUSTER_CNAME`. Keeping `CLUSTER_TITLE` would have produced `shared/Equestria-pushover-key`.

## How I let it through

The rewrite reported **15 of 16** and I did check for un-rewritten keys — but the check excluded anything starting with `${...}`, on the assumption that a substitution-built key was already path-shaped. That assumption is exactly wrong for keys built from an item *title*, and it's the blind spot that let this through. I saw the 15/16, investigated, and drew the wrong conclusion from a check I'd written badly.

The verification in this PR instead asserts that **every OpenBao-bound key starts with a known mount prefix** (`shared/`, `clusters/`, `hosts/`), which catches this class directly rather than by pattern-guessing.

## Blast radius

`deletionPolicy: Retain` meant `dynacat-env` kept all **56 keys** throughout and the app was unaffected — the failure was confined to the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
