### PR TITLE
feat(pulumi): the pulumi-namespace OnePasswordItem CRs become ExternalSecrets

### DIFF
--- a/kubernetes/apps/pulumi/secrets/externalsecret.yaml
+++ b/kubernetes/apps/pulumi/secrets/externalsecret.yaml
@@ -36,3 +36,118 @@ spec:
         - regexp:
             source: '[\W]'
             target: _
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — the four convertible OnePasswordItem CRs that used to live in
+# ./secret.yaml. Each keeps its Secret NAME and KEYS: the 1Password Operator
+# wrote one Secret key per item field, and Phase 4 migrated those items
+# field-for-field, so a bare `extract` reproduces the same Secret.
+#
+# `pulumi-operator-passphrase` is deliberately NOT here — see ./secret.yaml.
+#
+# Not circular, despite appearances: ESO talks to OpenBao directly with its own
+# ServiceAccount token, so sourcing the 1Password Connect token from OpenBao
+# introduces no cycle. (It does become pointless at Phase 11, when nothing reads
+# Connect any more; deleting it then is simpler than converting it was.)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pulumi-operator-github
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: pulumi-operator-github
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Eris Github Access Token
+        key: shared/eris-github-access-token
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pulumi-operator-connect-token
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: pulumi-operator-connect-token
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Eris 1Password Connect Access Token
+        key: shared/eris-1password-connect-access-token
+      # The item has a field literally named "valid from". A space is not a
+      # legal Kubernetes Secret key, so without this the API server rejects the
+      # entire Secret. The 1Password Operator sanitised the same way, which is
+      # why the live Secret already reads `valid-from`.
+      rewrite:
+        - regexp:
+            source: "[^-._a-zA-Z0-9]"
+            target: "-"
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Named for its consumer, not its source: this is the Minio root credential on
+# truenas, which the home-operations stacks use as the Pulumi state backend.
+#
+# ONE KEY IS DROPPED: `website`. The operator synthesised it from the item's URL
+# field, which is not a field and so was never migrated. Nothing reads it —
+# checked against every workload in the cluster before removing it.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: truenas-home-operations
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: truenas-home-operations
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/minio root user
+        key: shared/minio-root-user
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authentik-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: authentik-secret
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Authentik Token
+        key: shared/authentik-token

--- a/kubernetes/apps/pulumi/secrets/secret.yaml
+++ b/kubernetes/apps/pulumi/secrets/secret.yaml
@@ -1,15 +1,19 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
-metadata:
-    name: pulumi-operator-github
-    annotations:
-      reloader.stakater.com/auto: "true"
-spec:
-    itemPath: "vaults/Eris/items/Eris Github Access Token"
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
+#
+# THE LAST OnePasswordItem IN THE ESTATE, AND IT STAYS THAT WAY.
+#
+# Phase 6 converted every other OnePasswordItem CR to an ExternalSecret against
+# ClusterSecretStore/openbao; the four that used to live in this file are now in
+# ./externalsecret.yaml. This one cannot follow them.
+#
+# PULUMI_CONFIG_PASSPHRASE is bootstrap-tier (vault:bootstrap/INVENTORY.md §2):
+# Pulumi must decrypt its own state before it can authenticate to anything, so
+# it can never be sourced from OpenBao. The choice is 1Password or SOPS, and
+# 1Password is where it is. See vault:docs/openbao-migration/PLAN.md §C, row 10.
+#
+# Consequence for Phase 11: `onepassword-connect` cannot be removed from this
+# cluster while this CR exists. That is by design, not an oversight.
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
@@ -18,33 +22,3 @@ metadata:
       reloader.stakater.com/auto: "true"
 spec:
     itemPath: "vaults/Eris/items/Pulumi Passphrase"
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
-metadata:
-    name: pulumi-operator-connect-token
-    annotations:
-      reloader.stakater.com/auto: "true"
-spec:
-    itemPath: "vaults/Eris/items/Eris 1Password Connect Access Token"
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
-metadata:
-    name: truenas-home-operations
-    annotations:
-      reloader.stakater.com/auto: "true"
-spec:
-    itemPath: vaults/Eris/items/minio root user
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
-metadata:
-    name: authentik-secret
-    annotations:
-      reloader.stakater.com/auto: "true"
-spec:
-    itemPath: vaults/Eris/items/Authentik Token


### PR DESCRIPTION
Phase 6, the OnePasswordItem half — **step 5 of 5**, and the last of the 22 CRs. Merge after equestria-cluster#3099–#3102.

Four of the five CRs in `kubernetes/apps/pulumi/secrets/secret.yaml` move to `./externalsecret.yaml`. Between them they feed **all nine Pulumi Stack CRs**: `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` from `truenas-home-operations`, `CONNECT_TOKEN`, `GITHUB_TOKEN`, and the Authentik token mounted as a volume.

| Secret | OpenBao path | notes |
|---|---|---|
| `pulumi/pulumi-operator-github` | `secrets/shared/eris-github-access-token` | keys identical |
| `pulumi/pulumi-operator-connect-token` | `secrets/shared/eris-1password-connect-access-token` | needs the rewrite |
| `pulumi/truenas-home-operations` | `secrets/shared/minio-root-user` | `website` dropped |
| `pulumi/authentik-secret` | `secrets/shared/authentik-token` | keys identical |

Verified against the live server: every key the live Secret carries exists in OpenBao under the same name, none is empty.

- **`website` dropped** — the operator synthesised it from the item URL, which is not a field and so was never migrated. Every Stack CR reads only `username`/`password` from that Secret; nothing anywhere reads `website`.
- **The rewrite** — `eris-1password-connect-access-token` has a field literally named `valid from`. A space is not a legal Secret key, so the API server would reject the whole Secret. `[^-._a-zA-Z0-9] -> -` reproduces the operator’s own sanitisation.

### Not circular

Sourcing the 1Password Connect token *from* OpenBao introduces no cycle: ESO authenticates to OpenBao with its own ServiceAccount token, so Connect is never in the chain that starts OpenBao. It does become pointless at Phase 11 — deleting it then will be simpler than converting it was.

### `pulumi-operator-passphrase` stays, and is now the last OnePasswordItem in the estate

`PULUMI_CONFIG_PASSPHRASE` is bootstrap-tier (`vault:bootstrap/INVENTORY.md` §2, `PLAN.md` §C row 10): Pulumi must decrypt its own state before it can authenticate to anything, so it can never come from OpenBao. The consequence is written into the file — **Phase 11 cannot remove `onepassword-connect` from equestria while this CR exists**, and that is by design.

This path is applied only by equestria; SGC does not source `home-operations` at all, so its own CRs are untouched (Phase 7).

**Verify after merge:** the four `externalsecret`s in `pulumi` `SecretSynced`, and one Stack CR reconciles a `pulumi preview` without an auth error.

<!-- crew:agent=claude -->