### PR TITLE
chore(secrets): drop the CLOUDFLARE_SECRET substitution

### DIFF
--- a/kubernetes/components/common/shared-secrets.sops.yaml
+++ b/kubernetes/components/common/shared-secrets.sops.yaml
@@ -7,74 +7,73 @@ metadata:
     reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
     reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
 stringData:
-    PUID: ENC[AES256_GCM,data:7e5n,iv:gmVNLAG0nGGL+ZV2yWOyY7lMOuYu+4wlZmlns5FnKDY=,tag:7vjYQnNEcsJuH1Yx6HrxCw==,type:str]
-    PGID: ENC[AES256_GCM,data:czDu,iv:w0W7X/zHjHMZOinL8R7FC/x856D8sa2j0Mob9dDaFyg=,tag:1BoZlnJhltuG/clcuzxWwg==,type:str]
-    #
-    TIMEZONE: ENC[AES256_GCM,data:ar7/tKtZnwGTcqK4DV4hbg==,iv:Yo89U5qRklHGTqOrNn9z4XBoukx0ygAxT7wMQbczx2Y=,tag:46pfEaQF4EAUSJhFzpjcGA==,type:str]
-    ROOT_DOMAIN: ENC[AES256_GCM,data:iJZw/0KAPUSxG5O+eQ==,iv:/v1wZKfNMuLJUc4i3mJDvV1Oltr1rEd5v/GdOXb36OM=,tag:SIUu0SETlL4RhNbllcdySA==,type:str]
-    TAILSCALE_DOMAIN: ENC[AES256_GCM,data:qbl4Q9RgXdnVhXdpwB8PaL8=,iv:EpEAY61bEXmTX7jsGeToXkx625fvkUesjUJQasnleHQ=,tag:HG8FBuDXqADy0pBLODoptA==,type:str]
-    BACKBLAZE_DOMAIN: ENC[AES256_GCM,data:wfTork9TjQ4hWfD0NgHB32GTh3iQ/K9KNSwmqbRC,iv:dEFVEKpFJVKNAjp6iWRPRJYhBgNoGKQtlUYQxpIV7g4=,tag:RJJ+01Wu/2FKjnRacRZETg==,type:str]
-    BACKBLAZE_KEY: ENC[AES256_GCM,data:JRAuLELvxkFWlhRi0Ey5maW/4rQGAeWggWwK20C+u4E=,iv:bmt9m7B8xMZTjXL3EyJ3uD+JcabrlekQM5V8UBmmcPs=,tag:T/HYsOAadWNx6/0vjsqsdg==,type:str]
-    CLOUDFLARE_SECRET: ENC[AES256_GCM,data:wCl22iO6etOCl48b1kKGxWpcj3CphMAVWj4pNL3UJFAfpKR1j6O42vm9g6I=,iv:PgN4tDV4bH+Namg2ncgotjIBDOB8x060eGkycj3FaF0=,tag:1z2UGb/ypeDPHXYDlpZxPA==,type:str]
-    INTERNAL_NETWORK: ENC[AES256_GCM,data:OsqU2nTtEZik7tGP,iv:KZqC/XzuJS3g8a8GK0iFcl5WYTElZvm113GAHW3XhQU=,tag:bxY8SwQ0pte34Zaq8NYwkQ==,type:str]
-    #ENC[AES256_GCM,data:2PPfRSDpkCG8wBI=,iv:0Ffl5NhRchr4y9iEXNCygB3c/Cr4oo8IEyO23DhZKUw=,tag:f14zGBmjEMi8xFwCWYO35A==,type:comment]
-    ALPHA_SITE_IP: ENC[AES256_GCM,data:EkfQUffpvdnQ2iLg,iv:tk0AmV15MHpSP33BnBcfs2/PR+3PX6Uq6z6fl+vrHk8=,tag:/08JPEKReUpLWsLBfoB6SA==,type:str]
-    ALPHA_SITE_TAILSCALE_IP: ENC[AES256_GCM,data:CauWMjIPDKAPQLqEr3g=,iv:aJuwG+KTN6W1FmUnXz1ikEn3D39vHkgV7YvVGVKmB6M=,tag:wnC45lfafAzRXiaXpPkxiQ==,type:str]
-    DOCKGE_DOMAIN: ENC[AES256_GCM,data:jkkPPQ3JIDgZQf6H0RuWQPzEA0vFK9Jj,iv:RQTc3aOsWQr/SCnEcfLxx3VF2pNwRRdcCH66NjgIuG0=,tag:/ikjOrEenC5jTnJc1gwLrQ==,type:str]
-    DOCKGE_IP: ENC[AES256_GCM,data:zyclP0EZFnLKuQ==,iv:c98VYPq5pZE8dE6nYiZ8kFy1JiV9QpJe6h0xT7mvrxs=,tag:ZS+NPWk/Gc19wRVK0pt+Rg==,type:str]
-    DOCKGE_TAILSCALE_IP: ENC[AES256_GCM,data:Du8tDijp/z+1Oh2E,iv:+ejS2FWwTMBNMQsjx+HYLZPvVArZsuUKbrrA9luz1KU=,tag:BEvmWBG+5kbqxyJxM0CihQ==,type:str]
-    #ENC[AES256_GCM,data:ovrXO02H,iv:vV+aOrloPZBA/TgClfO0ofgghH8ROh1t4PytHmNQDbI=,tag:k/03tGaQxO2UBtPG3xEQEw==,type:comment]
-    DISCORD_DOMAIN: ENC[AES256_GCM,data:1pV8Pf0LFaBJw3xPnxisGxyaZjKS,iv:mlBSYS4W2CwTS3kHyKJ2lUXswpRxbhYCutdbO5FTaQU=,tag:ydnhlscW5ch/mRVDiFPhmA==,type:str]
-    DISCORD_IP: ENC[AES256_GCM,data:2Hn0jJ3jf7ZH,iv:BhUFFDr2w/NIfRqCuT19potCgZhpO+1lcVMaDznDfmk=,tag:baAJVU/GkoILECpaHb7vpw==,type:str]
-    DISCORD_TAILSCALE_IP: ENC[AES256_GCM,data:KMdjKGgB8pbWH6Q=,iv:ghbrrxRKERSZhYaDx0EwrvEZXxnY+VkGDhePgBHVH30=,tag:BW8bsejNlLNKv6CMfTTSNw==,type:str]
-    #ENC[AES256_GCM,data:+XDaaj3y+QE=,iv:Mnb2f3Fo4T+2iYr3gbfD3Ozz7Gq5SERx6bUe9NyTJQY=,tag:75bmxqegu9ATYGQ5GZfHHw==,type:comment]
-    SPIKE_DOMAIN: ENC[AES256_GCM,data:Xwu5b4gEhQQLnk9mbtdKkMuwQw==,iv:cMROuA/3h/XCuqS8DiV/0XPNdWvrwOFP5m+FEB5YLps=,tag:Etr/VBy6Zj4zpStQXJQQcQ==,type:str]
-    SPIKE_IP: ENC[AES256_GCM,data:D4U/Axugd3/iu/A=,iv:GwteN9703eKr/fRkE7jlwSLfIIgza8i7HeMMvHsAtT0=,tag:Ym3U8LilcdlRtW0PtMtM2Q==,type:str]
-    #ENC[AES256_GCM,data:41m9NmY=,iv:tkA2W4/TotiPy8kNBJ/l4JZK6j6G6SvC4Wkg8SvDdIk=,tag:uvnUVrzsd2S/7UBqqmBhuQ==,type:comment]
-    SPIKE_TAILSCALE_IP: ENC[AES256_GCM,data:abiu9wXrwKJ1PSESMw==,iv:e20KPfJYmNKtOzQ/AQRtBy8PDcU6zQUlCq9//jI67AE=,tag:/F7ii81sMDjZBp9AVxB1cg==,type:str]
-    #
-    TWILIGHT_SPARKLE_IP: ENC[AES256_GCM,data:B4BNWiazBE0fCsWC,iv:ta825mpvnqYFRH7pgvUyhcaVDuD8PclaZDmS9w+tJO8=,tag:rJBSxujkJauD2tBB/wUIuw==,type:str]
-    TWILIGHT_SPARKLE_TAILSCALE_IP: ENC[AES256_GCM,data:JC0VeC7iyNqo9ct+oNE=,iv:znStRxlWHi6MmP50/uqlSbEfotLU4/j9Z3+EiniqJtM=,tag:agJnrZFu2Clmbo3SV7k6jg==,type:str]
-    #
-    CELESTIA_IP: ENC[AES256_GCM,data:dnAYjXKhmxKRW11g,iv:VaIPkdCUBC3e5Fg2/B09AuHty1TxDLLyB1gPUY6UROQ=,tag:7sGsmYCDmSg8tLXhZsZoqg==,type:str]
-    CELESTIA_TAILSCALE_IP: ENC[AES256_GCM,data:QNYQ0XrDY9swyHmZqjM=,iv:8+NX1yU+V1eoOTwfb3jU56zHjDu6IJRbYEVp5nTlDzE=,tag:evFIpSZ/Wvt/VJXzAN9u1A==,type:str]
-    #
-    LUNA_IP: ENC[AES256_GCM,data:mlrrhZAIbW7REERk,iv:l9FiCCa9qHR4yBTn07Pe2jTHfAMbYZ86kG2hpgD+rAU=,tag:nJr6SLSWZyrwwszX72gvJg==,type:str]
-    LUNA_TAILSCALE_IP: ENC[AES256_GCM,data:LiPJq7vZcFBuS35qY2Q=,iv:90pr00xuNy/KOixpf//cmBdWfWatIni14wioV/BNLpo=,tag:dhj6U23JwbV3BDxOc7gFkg==,type:str]
-    #
-    EQUESTRIA_API_IP: ENC[AES256_GCM,data:W6YOuOcGjL/PoUkk1Q==,iv:K1WYCX6haBB4t5qFXs1sYTeSG5jZxIDLTU3oh7RmWkM=,tag:t1D+1QIHakj5BUK9YfBUOg==,type:str]
-    SGC_API_IP: ENC[AES256_GCM,data:V/rp01WXufIeWRgy6Q==,iv:xvXA8gjn7lA1n4Mrxl+kT0MoOyYUyE6v1VG9bpPe+BY=,tag:R87AMfntZ70ERAC0WJ0aXg==,type:str]
+  PUID: ENC[AES256_GCM,data:7e5n,iv:gmVNLAG0nGGL+ZV2yWOyY7lMOuYu+4wlZmlns5FnKDY=,tag:7vjYQnNEcsJuH1Yx6HrxCw==,type:str]
+  PGID: ENC[AES256_GCM,data:czDu,iv:w0W7X/zHjHMZOinL8R7FC/x856D8sa2j0Mob9dDaFyg=,tag:1BoZlnJhltuG/clcuzxWwg==,type:str]
+  #
+  TIMEZONE: ENC[AES256_GCM,data:ar7/tKtZnwGTcqK4DV4hbg==,iv:Yo89U5qRklHGTqOrNn9z4XBoukx0ygAxT7wMQbczx2Y=,tag:46pfEaQF4EAUSJhFzpjcGA==,type:str]
+  ROOT_DOMAIN: ENC[AES256_GCM,data:iJZw/0KAPUSxG5O+eQ==,iv:/v1wZKfNMuLJUc4i3mJDvV1Oltr1rEd5v/GdOXb36OM=,tag:SIUu0SETlL4RhNbllcdySA==,type:str]
+  TAILSCALE_DOMAIN: ENC[AES256_GCM,data:qbl4Q9RgXdnVhXdpwB8PaL8=,iv:EpEAY61bEXmTX7jsGeToXkx625fvkUesjUJQasnleHQ=,tag:HG8FBuDXqADy0pBLODoptA==,type:str]
+  BACKBLAZE_DOMAIN: ENC[AES256_GCM,data:wfTork9TjQ4hWfD0NgHB32GTh3iQ/K9KNSwmqbRC,iv:dEFVEKpFJVKNAjp6iWRPRJYhBgNoGKQtlUYQxpIV7g4=,tag:RJJ+01Wu/2FKjnRacRZETg==,type:str]
+  BACKBLAZE_KEY: ENC[AES256_GCM,data:JRAuLELvxkFWlhRi0Ey5maW/4rQGAeWggWwK20C+u4E=,iv:bmt9m7B8xMZTjXL3EyJ3uD+JcabrlekQM5V8UBmmcPs=,tag:T/HYsOAadWNx6/0vjsqsdg==,type:str]
+  INTERNAL_NETWORK: ENC[AES256_GCM,data:OsqU2nTtEZik7tGP,iv:KZqC/XzuJS3g8a8GK0iFcl5WYTElZvm113GAHW3XhQU=,tag:bxY8SwQ0pte34Zaq8NYwkQ==,type:str]
+  #ENC[AES256_GCM,data:2PPfRSDpkCG8wBI=,iv:0Ffl5NhRchr4y9iEXNCygB3c/Cr4oo8IEyO23DhZKUw=,tag:f14zGBmjEMi8xFwCWYO35A==,type:comment]
+  ALPHA_SITE_IP: ENC[AES256_GCM,data:EkfQUffpvdnQ2iLg,iv:tk0AmV15MHpSP33BnBcfs2/PR+3PX6Uq6z6fl+vrHk8=,tag:/08JPEKReUpLWsLBfoB6SA==,type:str]
+  ALPHA_SITE_TAILSCALE_IP: ENC[AES256_GCM,data:CauWMjIPDKAPQLqEr3g=,iv:aJuwG+KTN6W1FmUnXz1ikEn3D39vHkgV7YvVGVKmB6M=,tag:wnC45lfafAzRXiaXpPkxiQ==,type:str]
+  DOCKGE_DOMAIN: ENC[AES256_GCM,data:jkkPPQ3JIDgZQf6H0RuWQPzEA0vFK9Jj,iv:RQTc3aOsWQr/SCnEcfLxx3VF2pNwRRdcCH66NjgIuG0=,tag:/ikjOrEenC5jTnJc1gwLrQ==,type:str]
+  DOCKGE_IP: ENC[AES256_GCM,data:zyclP0EZFnLKuQ==,iv:c98VYPq5pZE8dE6nYiZ8kFy1JiV9QpJe6h0xT7mvrxs=,tag:ZS+NPWk/Gc19wRVK0pt+Rg==,type:str]
+  DOCKGE_TAILSCALE_IP: ENC[AES256_GCM,data:Du8tDijp/z+1Oh2E,iv:+ejS2FWwTMBNMQsjx+HYLZPvVArZsuUKbrrA9luz1KU=,tag:BEvmWBG+5kbqxyJxM0CihQ==,type:str]
+  #ENC[AES256_GCM,data:ovrXO02H,iv:vV+aOrloPZBA/TgClfO0ofgghH8ROh1t4PytHmNQDbI=,tag:k/03tGaQxO2UBtPG3xEQEw==,type:comment]
+  DISCORD_DOMAIN: ENC[AES256_GCM,data:1pV8Pf0LFaBJw3xPnxisGxyaZjKS,iv:mlBSYS4W2CwTS3kHyKJ2lUXswpRxbhYCutdbO5FTaQU=,tag:ydnhlscW5ch/mRVDiFPhmA==,type:str]
+  DISCORD_IP: ENC[AES256_GCM,data:2Hn0jJ3jf7ZH,iv:BhUFFDr2w/NIfRqCuT19potCgZhpO+1lcVMaDznDfmk=,tag:baAJVU/GkoILECpaHb7vpw==,type:str]
+  DISCORD_TAILSCALE_IP: ENC[AES256_GCM,data:KMdjKGgB8pbWH6Q=,iv:ghbrrxRKERSZhYaDx0EwrvEZXxnY+VkGDhePgBHVH30=,tag:BW8bsejNlLNKv6CMfTTSNw==,type:str]
+  #ENC[AES256_GCM,data:+XDaaj3y+QE=,iv:Mnb2f3Fo4T+2iYr3gbfD3Ozz7Gq5SERx6bUe9NyTJQY=,tag:75bmxqegu9ATYGQ5GZfHHw==,type:comment]
+  SPIKE_DOMAIN: ENC[AES256_GCM,data:Xwu5b4gEhQQLnk9mbtdKkMuwQw==,iv:cMROuA/3h/XCuqS8DiV/0XPNdWvrwOFP5m+FEB5YLps=,tag:Etr/VBy6Zj4zpStQXJQQcQ==,type:str]
+  SPIKE_IP: ENC[AES256_GCM,data:D4U/Axugd3/iu/A=,iv:GwteN9703eKr/fRkE7jlwSLfIIgza8i7HeMMvHsAtT0=,tag:Ym3U8LilcdlRtW0PtMtM2Q==,type:str]
+  #ENC[AES256_GCM,data:41m9NmY=,iv:tkA2W4/TotiPy8kNBJ/l4JZK6j6G6SvC4Wkg8SvDdIk=,tag:uvnUVrzsd2S/7UBqqmBhuQ==,type:comment]
+  SPIKE_TAILSCALE_IP: ENC[AES256_GCM,data:abiu9wXrwKJ1PSESMw==,iv:e20KPfJYmNKtOzQ/AQRtBy8PDcU6zQUlCq9//jI67AE=,tag:/F7ii81sMDjZBp9AVxB1cg==,type:str]
+  #
+  TWILIGHT_SPARKLE_IP: ENC[AES256_GCM,data:B4BNWiazBE0fCsWC,iv:ta825mpvnqYFRH7pgvUyhcaVDuD8PclaZDmS9w+tJO8=,tag:rJBSxujkJauD2tBB/wUIuw==,type:str]
+  TWILIGHT_SPARKLE_TAILSCALE_IP: ENC[AES256_GCM,data:JC0VeC7iyNqo9ct+oNE=,iv:znStRxlWHi6MmP50/uqlSbEfotLU4/j9Z3+EiniqJtM=,tag:agJnrZFu2Clmbo3SV7k6jg==,type:str]
+  #
+  CELESTIA_IP: ENC[AES256_GCM,data:dnAYjXKhmxKRW11g,iv:VaIPkdCUBC3e5Fg2/B09AuHty1TxDLLyB1gPUY6UROQ=,tag:7sGsmYCDmSg8tLXhZsZoqg==,type:str]
+  CELESTIA_TAILSCALE_IP: ENC[AES256_GCM,data:QNYQ0XrDY9swyHmZqjM=,iv:8+NX1yU+V1eoOTwfb3jU56zHjDu6IJRbYEVp5nTlDzE=,tag:evFIpSZ/Wvt/VJXzAN9u1A==,type:str]
+  #
+  LUNA_IP: ENC[AES256_GCM,data:mlrrhZAIbW7REERk,iv:l9FiCCa9qHR4yBTn07Pe2jTHfAMbYZ86kG2hpgD+rAU=,tag:nJr6SLSWZyrwwszX72gvJg==,type:str]
+  LUNA_TAILSCALE_IP: ENC[AES256_GCM,data:LiPJq7vZcFBuS35qY2Q=,iv:90pr00xuNy/KOixpf//cmBdWfWatIni14wioV/BNLpo=,tag:dhj6U23JwbV3BDxOc7gFkg==,type:str]
+  #
+  EQUESTRIA_API_IP: ENC[AES256_GCM,data:W6YOuOcGjL/PoUkk1Q==,iv:K1WYCX6haBB4t5qFXs1sYTeSG5jZxIDLTU3oh7RmWkM=,tag:t1D+1QIHakj5BUK9YfBUOg==,type:str]
+  SGC_API_IP: ENC[AES256_GCM,data:V/rp01WXufIeWRgy6Q==,iv:xvXA8gjn7lA1n4Mrxl+kT0MoOyYUyE6v1VG9bpPe+BY=,tag:R87AMfntZ70ERAC0WJ0aXg==,type:str]
 sops:
-    age:
-        - recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPSnNFeFRTMmxhbEZPNEdZ
-            UHpuMEFpZDl3bmwvemFNWDQ2VUFHT2NnMmxrCkhkL1pPMThWeDlRcE9JV3FQSzIv
-            cDE0UHZSeFpTRmIzdHZxT3liTzFadGsKLS0tIERxU3FscUsreU4ySldKZDFqaUN0
-            Mnd5aXBtc1RvbUFKSE0vV1JHdkprdzQKhP5X8jatDfMom13BwfY3tXwn1ZjoEW54
-            LGU5hq9G8nZTcv1/DetxpQOL1ww74xW5eDEX9WCrF2GkOCWtwPKk4w==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0M01mNzE3U09NdDJvZWs5
-            c2I0ZUQ1MkEwdFpnY0xBMW9ENHd6WC9YcTBZCkxrSkgvUzRLMlpzZ1FFZ0lxZ2Ry
-            K3J2SjRINjlGSzMvWWlrUGlseHB4dUUKLS0tIGRvbUtQMFgrdlhka1UzM0xKZUVP
-            cFZ0cm54L0VDSmRqMUYwKy8yMDF6SW8KBUFluKIoQj0SVnMbJzqNM2BcUIRR3iBB
-            jYzqXKhzWbCZcE70ici1UIvzb9kU9rHAVPL0kjrw4G+kY4GHuggBcg==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlVW9sMFZnRmorWDJwOGJn
-            MktRVXJkL0cycDJ3ZnV6S2xjTVB3RytTeVhRCkdjakdBQ0lVL2NFNTVRUGloSEJ3
-            UDBlcWNHM0phL3I3ZFpYYy9oNTJmZEUKLS0tIDNuWnVnRTRtYk45bk1PUDRkcW1z
-            eU5ybDhRWWloVTZKcEZXR25JTUh1YjQKqafytasolE54+VsZqIMN2ZrgUirTteys
-            ZLLzYKjUsk6Y/Da4VBq/madFO+6HsIqzcnVIURbAAgt/r9Qho4DK1A==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-07-31T02:05:49Z"
-    mac: ENC[AES256_GCM,data:+qOlLOd0fpzPJ9IIP9tykD3dx90TLUPrBi0zk77vzeo89jKnRIXxAJlV7TuHHj2TaH2FTtRv37hLYuPO8ngaMz9Dn6TxwcP/ItHHls8v5GxFZwMQUWpBq9htQ/Uup4wCM61G0x5v7KgsoSZSNzKSwUApXyaaWBwR0xIaDdDWalc=,iv:pUMy/lw0OCkISmySR3E9f1MMfRU9FQTf/L4kEhCwPVM=,tag:qhHwgSE+qFboQ3yYTQkM/A==,type:str]
-    encrypted_regex: ^(data|stringData)$
-    mac_only_encrypted: true
-    version: 3.10.2
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPSnNFeFRTMmxhbEZPNEdZ
+        UHpuMEFpZDl3bmwvemFNWDQ2VUFHT2NnMmxrCkhkL1pPMThWeDlRcE9JV3FQSzIv
+        cDE0UHZSeFpTRmIzdHZxT3liTzFadGsKLS0tIERxU3FscUsreU4ySldKZDFqaUN0
+        Mnd5aXBtc1RvbUFKSE0vV1JHdkprdzQKhP5X8jatDfMom13BwfY3tXwn1ZjoEW54
+        LGU5hq9G8nZTcv1/DetxpQOL1ww74xW5eDEX9WCrF2GkOCWtwPKk4w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0M01mNzE3U09NdDJvZWs5
+        c2I0ZUQ1MkEwdFpnY0xBMW9ENHd6WC9YcTBZCkxrSkgvUzRLMlpzZ1FFZ0lxZ2Ry
+        K3J2SjRINjlGSzMvWWlrUGlseHB4dUUKLS0tIGRvbUtQMFgrdlhka1UzM0xKZUVP
+        cFZ0cm54L0VDSmRqMUYwKy8yMDF6SW8KBUFluKIoQj0SVnMbJzqNM2BcUIRR3iBB
+        jYzqXKhzWbCZcE70ici1UIvzb9kU9rHAVPL0kjrw4G+kY4GHuggBcg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlVW9sMFZnRmorWDJwOGJn
+        MktRVXJkL0cycDJ3ZnV6S2xjTVB3RytTeVhRCkdjakdBQ0lVL2NFNTVRUGloSEJ3
+        UDBlcWNHM0phL3I3ZFpYYy9oNTJmZEUKLS0tIDNuWnVnRTRtYk45bk1PUDRkcW1z
+        eU5ybDhRWWloVTZKcEZXR25JTUh1YjQKqafytasolE54+VsZqIMN2ZrgUirTteys
+        ZLLzYKjUsk6Y/Da4VBq/madFO+6HsIqzcnVIURbAAgt/r9Qho4DK1A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-10T14:37:57Z"
+  mac: ENC[AES256_GCM,data:9SICAbj1JX9uemqU01615ftK+or2YkGfO03Jo992/ct68GRw+nd4zo58aSv4ICZsnxP2cgtZXmdjMJgxKzX2n865Ds3habm/YVBcOquE3igGWVhilht0LvJT/wwnLKOxp6G1nmmS5tPtWlk1rfpfhiMI84pa1yYs64Sk/Nv8Sf0=,iv:PmjlsAIafofvRXZHOF69gq0vWBBKfmH+sY3jDABQU60=,tag:Nw2PV82unIgLhZWMKlj4IQ==,type:str]
+  mac_only_encrypted: true
+  version: 3.10.2


### PR DESCRIPTION
Phase 6 follow-up, paired with equestria-cluster#3104.

The variable held a 1Password item path and existed only to be interpolated into a `OnePasswordItem` CR’s `itemPath`. Those CRs are ExternalSecrets now (#709) and spell their OpenBao path literally, so nothing in this repo references it. This copy of `components/common` is applied only to the `pulumi` namespace, which never referenced it either.

### Reviewing the diff

Only one line is substantive. `sops unset` rewrites the whole document and normalises the file to the `stores.yaml.indent: 2` this repo’s `.sops.yaml` declares. Every remaining ciphertext is **byte-identical to HEAD** — verified by comparing `KEY: ENC[...]` lines with leading whitespace stripped, where the only difference is the removed key (28 → 27 values). The file still decrypts and `ROOT_DOMAIN` round-trips unchanged.

SGC keeps the variable until Phase 7 — `shared-secrets.sops.yaml` is a hand-synced triplicate across the three repos, so it is deliberately divergent until then.

<!-- crew:agent=claude -->