### PR TITLE
fix(dns): let external-dns AXFR the driscoll.tech zone

### DIFF
--- a/stacks/unifi-network/technitium-zone.ts
+++ b/stacks/unifi-network/technitium-zone.ts
@@ -21,6 +21,15 @@ export function configureTechnitiumZones(globals: GlobalResources) {
     {
       name: "driscoll.tech",
       type: "Forwarder",
+      // external-dns runs `--rfc2136-tsig-axfr` against this zone to learn what
+      // already exists before it reconciles. A new Technitium zone denies zone
+      // transfer, so every AXFR came back REFUSED ("bad xfr rcode: 5"), every
+      // cycle re-created every record, and the writes succeeding kept it
+      // silent. The requests arrive through each cluster's tailscale egress
+      // proxy, so they source from the tailnet CGNAT range rather than a fixed
+      // address; the TSIG key below is the actual authentication.
+      allowTransfers: ["100.64.0.0/10"],
+      zoneTransferTsigKeyNames: ["external-dns"],
     },
     { ...cro, protect: true, retainOnDelete: true },
   );


### PR DESCRIPTION
## The problem

`technitium-dns` (external-dns, rfc2136 provider) has been in a permanent rewrite loop against `dns-celestia` on both clusters — continuously since at least 2026-08-07T14:13Z, which is only the edge of Loki's retention, so likely longer.

Every reconcile cycle:

```
level=error msg="AXFR error: dns: bad xfr rcode: 5"
```

rcode 5 is REFUSED. Without a zone transfer external-dns can't see what already exists, so it re-creates every record every cycle — ~2546 `Adding RR` in ten minutes on sgc. The writes succeed, so DNS stays correct and nothing alerts. Pure invisible continuous load.

## Root cause

Live `/api/zones/options/get` for `driscoll.tech`:

```
zoneTransfer:             "Deny"        ← this is it
zoneTransferTsigKeyNames: ["external-dns"]
update:                   "Allow"  (+ 2 updateSecurityPolicies for external-dns)
type:                     "Forwarder"
```

Not a TSIG problem. The key was already authorized for transfer, and the `update` policy is why the writes work. Technitium defaults a new zone's transfer policy to `Deny`, and the zone was created here with only `name`/`type`, so nothing ever moved it off the default. Everything else on that zone was set by hand outside Pulumi.

## The fix

`allowTransfers: ["100.64.0.0/10"]` + `zoneTransferTsigKeyNames: ["external-dns"]`.

Three things checked before settling on that shape:

- **The provider cannot express `zoneTransfer = "Allow"`.** In darkhonor/terraform-provider-technitium's `setZoneOptions`, a non-empty `allow_transfer` maps to `UseSpecifiedNetworkACL`, an empty list to `AllowOnlyZoneNameServers`, and unset means the option is never sent at all. The network ACL is the only available lever, so it has to be right.
- **The ACL is the tailnet CGNAT range** because external-dns reaches Technitium through each cluster's tailscale egress proxy — `tailnet-inbound-0` on equestria is `100.91.83.6`. Per-proxy IPs churn on recreation; the range doesn't. TSIG remains the actual authentication.
- **It won't clobber the hand-set options.** `ZoneOptionsSet` sends only the keys it's given and Technitium's `options/set` is a partial update, so `update`/`updateSecurityPolicies` are untouched. Only `name` and `type` are RequiresReplace, so this is an in-place update on a `protect: true` zone.

## Verification

Targeted preview is clean — one in-place update, two additive fields, no deletes, 42 unchanged:

```
~ technitium:index/zone:Zone: (update) 🔒
    [id=driscoll.tech]
  + allowTransfers          : [ [0]: "100.64.0.0/10" ]
  + zoneTransferTsigKeyNames: [ [0]: "external-dns" ]

Resources:
    ~ 1 to update
    42 unchanged
```

**Not yet applied.** Apply targeted rather than a bare `pulumi up` — this stack carries the StandardDns/UniFi armed-delete and phantom-delete landmines:

```
pulumi up --yes --target 'urn:pulumi:unifi-network::applications::custom:technitium:Zones$technitium:index/zone:Zone::driscoll-tech'
```

## Also worth watching after the apply

equestria's external-dns is not merely doing redundant work — it's failing outright:

```
Failed to do run once: soft error
RFC2136 had errors in one or more of its batches:
[soft error read tcp 10.206.0.37:55034->10.196.230.60:53: i/o timeout]
(consecutive soft errors: 96)
```

That's the i/o timeout symptom, consistent with dns-celestia being saturated by the combined rewrite load from both clusters. It should clear once the AXFR works, but worth re-checking rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
