### PR TITLE
feat(openbao): BaoStore, so stacks can read secrets from OpenBao

### DIFF
--- a/components/bao.ts
+++ b/components/bao.ts
@@ -47,20 +47,64 @@ export interface KvReadResult {
 
 export class BaoClient {
   private readonly addr: string;
-  private readonly token: string;
+  /**
+   * Resolved lazily so an AppRole login happens on first use rather than at
+   * construction — `BaoStore` is built for every stack, including the ones
+   * that never read a secret, and a login there would be a network call in
+   * `pulumi preview` on stacks that do not touch OpenBao.
+   */
+  private tokenPromise?: Promise<string>;
+  private readonly staticToken?: string;
+  private readonly roleId?: string;
+  private readonly secretId?: string;
 
-  constructor(addr = process.env.BAO_ADDR, token = process.env.BAO_TOKEN) {
+  constructor(addr = process.env.BAO_ADDR, token = process.env.BAO_TOKEN, roleId = process.env.BAO_ROLE_ID, secretId = process.env.BAO_SECRET_ID) {
     if (!addr) throw new Error("BAO_ADDR is not set");
-    if (!token) throw new Error("BAO_TOKEN is not set");
+    // Two ways in, matching `GlobalResources.baoProvider` exactly. They must
+    // stay matched: a client that accepts only BAO_TOKEN while the provider
+    // accepts the AppRole is how Phase 8a's dual-write gate silently skipped
+    // every write on an AppRole run.
+    if (!token && !(roleId && secretId)) {
+      throw new Error('No OpenBao credentials — set BAO_TOKEN, or BAO_ROLE_ID/BAO_SECRET_ID. Run `eval "$(bootstrap/openbao/pulumi-env.sh)"` from the vault repo.');
+    }
     this.addr = addr.replace(/\/+$/, "");
-    this.token = token;
+    this.staticToken = token || undefined;
+    this.roleId = roleId || undefined;
+    this.secretId = secretId || undefined;
+  }
+
+  /**
+   * Exchange the AppRole for a token, once per process.
+   *
+   * `skipChildToken` has no analogue here because this client never mints a
+   * child: the `pulumi` policy has no capability on `auth/token/create`, which
+   * is the same 403 the provider works around.
+   */
+  private token(): Promise<string> {
+    if (this.staticToken) return Promise.resolve(this.staticToken);
+    this.tokenPromise ??= (async () => {
+      const res = await fetch(`${this.addr}/v1/auth/approle/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role_id: this.roleId, secret_id: this.secretId }),
+      });
+      if (!res.ok) {
+        const detail = await res.text().catch(() => "");
+        throw new Error(`AppRole login failed: ${res.status} ${res.statusText}${detail ? ` — ${detail}` : ""}`);
+      }
+      const body = (await res.json()) as { auth?: { client_token?: string } };
+      const clientToken = body.auth?.client_token;
+      if (!clientToken) throw new Error("AppRole login returned no client_token");
+      return clientToken;
+    })();
+    return this.tokenPromise;
   }
 
   private async request(method: string, path: string, body?: unknown): Promise<unknown> {
     const res = await fetch(`${this.addr}/v1/${path}`, {
       method,
       headers: {
-        "X-Vault-Token": this.token,
+        "X-Vault-Token": await this.token(),
         ...(body === undefined ? {} : { "Content-Type": "application/json" }),
       },
       body: body === undefined ? undefined : JSON.stringify(body),

--- a/components/globals.ts
+++ b/components/globals.ts
@@ -1,11 +1,12 @@
 import { Provider as CloudflareProvider } from "@pulumi/cloudflare";
 import { Provider as MinioProvider } from "@pulumi/minio";
-import { ComponentResource, type ComponentResourceOptions, type CustomResourceOptions, interpolate, type Output, output, runtime, secret } from "@pulumi/pulumi";
+import { ComponentResource, type ComponentResourceOptions, type CustomResourceOptions, interpolate, log, type Output, output, runtime, secret } from "@pulumi/pulumi";
 import { Provider as TailscaleProvider } from "@pulumi/tailscale";
 import { Provider as TechnitiumProvider } from "@pulumi/technitium";
 import { Provider as UnifiFirewallProvider } from "@pulumi/terrifi";
 import { Provider as VaultProvider } from "@pulumi/vault";
 import { Provider as UnifiProvider } from "@pulumiverse/unifi";
+import { BaoStore, baoStoreReadsEnabled } from "./store/bao.ts";
 import { VaultStore } from "./store/index.ts";
 
 export type GlobalResourcesArgs = object;
@@ -39,7 +40,15 @@ export class GlobalResources extends ComponentResource {
     this.searchDomain = output("driscoll.tech");
     this.gateway = output("10.10.0.1");
 
-    const store = (this.store = new VaultStore());
+    // Phase 8: BAO_STORE_READS flips every `globals.store` read from 1Password
+    // to OpenBao in one place. Deliberately explicit — see the comment on
+    // `baoStoreReadsEnabled` for why this must not be inferred from whether
+    // credentials happen to be present. Logged at info so the run's own output
+    // says which store its values came from; a value that differs between the
+    // two is otherwise indistinguishable from a real config change.
+    const useBao = baoStoreReadsEnabled();
+    log.info(`Secret reads: ${useBao ? "OpenBao (BAO_STORE_READS)" : "1Password Connect"}`);
+    const store = (this.store = useBao ? new BaoStore() : new VaultStore());
     this.tailscaleDomain = store.tailscaleDomain;
     this.tailscaleCredential = store.getSecretByTitle<{
       hostname: string;

--- a/components/store/bao.test.ts
+++ b/components/store/bao.test.ts
@@ -1,0 +1,227 @@
+/**
+ * npx tsx --test components/store/bao.test.ts
+ *
+ * Covers the Phase 8 read path: KV v2 result -> the object shape stacks
+ * already consume. No Pulumi engine and no network — `shapeItem` is pure, and
+ * `BaoClient`'s wire behaviour is covered in scripts/op-to-bao/mapping.test.ts
+ * against a stub server.
+ *
+ * The point of these is the `secret()` markers. A field that loses one still
+ * renders the right value, still produces a clean `pulumi preview`, and writes
+ * the credential to state in the clear — there is no symptom until someone
+ * runs `pulumi stack export`.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { isSecret, runtime } from "@pulumi/pulumi";
+import { assertNotDirectory, BaoStore, baoStoreReadsEnabled, resolveBaoPath, shapeItem } from "./bao.ts";
+
+runtime.setMocks({
+  newResource: args => ({ id: `${args.name}-id`, state: args.inputs }),
+  call: args => args.inputs,
+});
+
+type KvResult = NonNullable<Parameters<typeof shapeItem>[1]>;
+
+function kv(data: Record<string, unknown>, customMetadata: Record<string, string> | null = null): KvResult {
+  return { data, metadata: { version: 1, created_time: "2026-08-08T15:14:48Z", custom_metadata: customMetadata } };
+}
+
+/** Resolve a shaped item to plain values plus whether it carries a secret. */
+async function resolve(item: ReturnType<typeof shapeItem>) {
+  const value = await new Promise<Record<string, unknown>>(res => item.apply(v => (res(v), v)));
+  return { value, isSecret: await isSecret(item) };
+}
+
+/** Is this single field marked secret, independent of its siblings? */
+async function fieldIsSecret(result: KvResult, key: string) {
+  // Re-shape one field at a time: `output()` propagates secretness upward, so
+  // a whole shaped item reports secret if ANY field is. Isolating the field is
+  // the only way to prove the marker landed on the right one.
+  const single = shapeItem("t", kv({ [key]: result.data[key] }, result.metadata.custom_metadata));
+  return (await resolve(single)).isSecret;
+}
+
+describe("shapeItem", () => {
+  it("maps root fields to top-level keys", async () => {
+    const { value } = await resolve(shapeItem("shared/x", kv({ username: "u", hostname: "h" })));
+    assert.equal(value.username, "u");
+    assert.equal(value.hostname, "h");
+  });
+
+  it("marks only the fields listed in concealed_fields", async () => {
+    const result = kv({ username: "u", credential: "c" }, { concealed_fields: "credential", contains_secrets: "true" });
+    assert.equal(await fieldIsSecret(result, "credential"), true);
+    assert.equal(await fieldIsSecret(result, "username"), false);
+  });
+
+  it("resolves dotted concealed paths inside a section", async () => {
+    const result = kv({ ssh: { username: "root", password: "p" } }, { concealed_fields: "ssh.password", contains_secrets: "true" });
+    const { value, isSecret } = await resolve(shapeItem("hosts/dockge/x", result));
+    assert.deepEqual(value.ssh, { username: "root", password: "p" });
+    // The section carries a concealed leaf, so the item as a whole is secret.
+    assert.equal(isSecret, true);
+    // ...and a section with no concealed leaf is not.
+    const plain = shapeItem("t", kv({ ssh: { username: "root" } }, { concealed_fields: "ssh.password" }));
+    assert.equal((await resolve(plain)).isSecret, false);
+  });
+
+  it("refuses a path marked contains_secrets with no concealed_fields", () => {
+    // Losing the list would silently downgrade every value to plaintext in
+    // state, which nothing else in the pipeline would notice.
+    assert.throws(() => shapeItem("shared/x", kv({ credential: "c" }, { contains_secrets: "true" })), /refusing to read its values as plaintext/);
+  });
+
+  it("decodes a file to its content under the file's name, always secret", async () => {
+    const files = { "key.pem": { filename: "key.pem", content_b64: Buffer.from("PRIVATE").toString("base64"), sha256: "…" } };
+    const { value } = await resolve(shapeItem("shared/x", kv({ files })));
+    assert.equal(value["key.pem"], "PRIVATE");
+    assert.equal(await fieldIsSecret(kv({ files }), "files"), true);
+  });
+
+  it("rejects a files entry that is not a content envelope", () => {
+    assert.throws(() => shapeItem("shared/x", kv({ files: { "key.pem": "raw bytes" } })), /is not a \{content_b64\} envelope/);
+  });
+
+  it("takes meta.title from source_title and meta.tags from source_tags", async () => {
+    const { value } = await resolve(shapeItem("hosts/dockge/dockgelxc-celestia", kv({}, { source_title: "DockgeLxc: Celestia", source_tags: "dockge,lxc" })));
+    assert.deepEqual(value.meta, { title: "DockgeLxc: Celestia", tags: ["dockge", "lxc"] });
+  });
+
+  it("falls back to the path when source_title is absent, and never invents tags", async () => {
+    // Pulumi-written secrets carry `source: pulumi` provenance, not the
+    // op-to-bao migration labels, so both of these are legitimately missing.
+    const { value } = await resolve(shapeItem("clusters/equestria/apps/headlamp/oidc", kv({})));
+    assert.deepEqual(value.meta, { title: "clusters/equestria/apps/headlamp/oidc", tags: [] });
+  });
+
+  it("throws a path-naming error when the secret is absent", () => {
+    assert.throws(() => shapeItem("shared/nope", undefined), /secrets\/shared\/nope does not exist/);
+  });
+});
+
+describe("BaoStore", () => {
+  /** A BaoClient stand-in: no constructor credential check, no network. */
+  function stubClient(paths: Record<string, KvResult>) {
+    return {
+      read: async (_mount: string, path: string) => paths[path],
+      list: async (_mount: string, prefix: string) =>
+        Object.keys(paths)
+          .filter(p => p.startsWith(`${prefix}/`))
+          .map(p => p.slice(prefix.length + 1))
+          .sort(),
+    } as unknown as ConstructorParameters<typeof BaoStore>[0];
+  }
+
+  it("resolves a 1Password title to shared/<slug>", async () => {
+    const store = new BaoStore(stubClient({ "shared/cloudflare-driscoll-tech": kv({ zoneId: "z" }) }));
+    const item = await new Promise<any>(res => store.getSecretByTitle<{ zoneId: string }>("Cloudflare (driscoll.tech)").apply(v => (res(v), v)));
+    assert.equal(item.zoneId, "z");
+  });
+
+  it("reads a path once however many times it is asked for", async () => {
+    let reads = 0;
+    const client = {
+      read: async (_m: string, _p: string) => {
+        reads++;
+        return kv({ hostname: "opossum-yo.ts.net" });
+      },
+    } as unknown as ConstructorParameters<typeof BaoStore>[0];
+    const store = new BaoStore(client);
+    store.getSecretByTitle("Tailscale Terraform OAuth Client");
+    store.getSecretByTitle("Tailscale Terraform OAuth Client");
+    await new Promise<any>(res => store.tailscaleDomain.apply(v => (res(v), v)));
+    assert.equal(reads, 1);
+  });
+
+  it("lists hosts/dockge/ in place of tag:dockge", async () => {
+    const store = new BaoStore(
+      stubClient({
+        "hosts/dockge/dockgelxc-celestia": kv({ name: "celestia" }, { source_title: "DockgeLxc: Celestia" }),
+        "hosts/dockge/dockgelxc-luna": kv({ name: "luna" }, { source_title: "DockgeLxc: Luna" }),
+        "shared/unrelated": kv({ name: "no" }),
+      }),
+    );
+    const items = await new Promise<any[]>(res => store.getDockgeInstances().apply(v => (res(v as any[]), v)));
+    assert.deepEqual(
+      items.map(i => i.name),
+      ["celestia", "luna"],
+    );
+  });
+
+  it("rejects a nested directory under a listed prefix rather than reading it", () => {
+    // LIST marks a directory with a trailing slash. Reading one as a secret
+    // would 404 far from the cause, so the guard names the layout change.
+    assert.throws(() => assertNotDirectory("hosts/dockge", "sub/"), /is a directory, not a secret/);
+    assert.doesNotThrow(() => assertNotDirectory("hosts/dockge", "dockgelxc-celestia"));
+  });
+});
+
+describe("resolveBaoPath", () => {
+  it("slugs an ordinary title into shared/", () => {
+    assert.equal(resolveBaoPath("Cloudflare (driscoll.tech)").path, "shared/cloudflare-driscoll-tech");
+    assert.equal(resolveBaoPath("minio root user").path, "shared/minio-root-user");
+  });
+
+  it("sends a generated OIDC credential to its per-app path, not to shared/", () => {
+    // Phase 4 deliberately skipped this family; Phase 8a writes it here. The
+    // default rule would look for a path that will never exist.
+    assert.equal(resolveBaoPath("equestria-headlamp-oidc-credentials").path, "clusters/equestria/apps/headlamp/oidc");
+  });
+
+  it("splits a dashed cluster key at the right dash", () => {
+    // Splitting on the FIRST dash yields cluster `alpha`, app `site-technitium`.
+    assert.equal(resolveBaoPath("alpha-site-technitium-oidc-credentials").path, "clusters/alpha-site/apps/technitium/oidc");
+  });
+
+  it("refuses to guess when an OIDC title names no known cluster", () => {
+    assert.equal(resolveBaoPath("something-random-oidc-credentials").path, undefined);
+    assert.match(resolveBaoPath("something-random-oidc-credentials").reason ?? "", /names no known cluster key/);
+  });
+
+  it("keeps the seal chain on 1Password, permanently", () => {
+    const r = resolveBaoPath("OpenBao Alpha Site Static Unseal");
+    assert.equal(r.path, undefined);
+    assert.match(r.reason ?? "", /INVENTORY §2/);
+  });
+
+  it("keeps cross-stack inventory and cluster definitions on 1Password for now", () => {
+    for (const title of ["Authentik Outputs", "Backup Plan", "Cluster: Alpha Site"]) {
+      assert.equal(resolveBaoPath(title).path, undefined, title);
+    }
+  });
+
+  it("does not slug a UUID-addressed item into a UUID-shaped path", () => {
+    // `shared/soz3lyvs6k24e5gh3udqp4sngi` is a path that cannot exist; saying
+    // so beats a 404 from somewhere deep in an apply().
+    const r = resolveBaoPath("soz3lyvs6k24e5gh3udqp4sngi");
+    assert.equal(r.path, undefined);
+    assert.match(r.reason ?? "", /addressed by UUID/);
+  });
+});
+
+describe("baoStoreReadsEnabled", () => {
+  it("is off unless explicitly turned on", () => {
+    const prior = process.env.BAO_STORE_READS;
+    try {
+      for (const [value, expected] of [
+        [undefined, false],
+        ["", false],
+        ["0", false],
+        ["false", false],
+        ["1", true],
+        ["true", true],
+        ["TRUE", true],
+        ["yes", true],
+      ] as const) {
+        if (value === undefined) delete process.env.BAO_STORE_READS;
+        else process.env.BAO_STORE_READS = value;
+        assert.equal(baoStoreReadsEnabled(), expected, `BAO_STORE_READS=${String(value)}`);
+      }
+    } finally {
+      if (prior === undefined) delete process.env.BAO_STORE_READS;
+      else process.env.BAO_STORE_READS = prior;
+    }
+  });
+});

--- a/components/store/bao.ts
+++ b/components/store/bao.ts
@@ -1,0 +1,271 @@
+/**
+ * OpenBao-backed reads for Pulumi — Phase 8 of the 1Password→OpenBao migration
+ * (vault repo: docs/openbao-migration/PLAN.md §D.3, §G).
+ *
+ * `VaultStore` is the seam PLAN §D.3 identified: every stack reaches secrets
+ * through `globals.store`, so reimplementing its reads against OpenBao covers
+ * the whole repo without touching a single stack file. `BaoStore` is that
+ * reimplementation.
+ *
+ * ## It extends rather than replaces, on purpose
+ *
+ * Phase 8 has four independent halves (secret reads, the `vals` resolver,
+ * cross-stack inventory, retiring `dynamic/1password/`) and they cannot land
+ * together. `BaoStore extends VaultStore` and overrides ONLY what OpenBao can
+ * serve today; everything else keeps the inherited 1Password implementation and
+ * moves over in its own commit. The alternative — a parallel class behind an
+ * interface — means two code paths for every method, including the ten that are
+ * not changing yet.
+ *
+ * Still on 1Password after this file (each is a later slice):
+ *
+ *   getCluster / getAllClusters    cluster definitions become checked-in code
+ *   getBackupPlans                 producer-side write-back moves to OpenBao
+ *   getTailscaleExports            same
+ *   proxmoxBackupServers           needs both of the above to resolve
+ *   replaceOnePasswordPlaceholders `vals` replaces it (PLAN §D.1)
+ *
+ * ## Field shapes carry over unchanged
+ *
+ * `op-to-bao` wrote 1Password fields to KV verbatim — root fields as top-level
+ * keys, sections as nested objects, files as `{filename, content_b64, sha256}`.
+ * So the object this hands a stack is the same object `getSecretItem` built,
+ * and the interfaces with spaces in their keys (`SshKeyDefinition`'s
+ * `"private key"`) still line up. That is a PULUMI-side fact only: ESO's
+ * providers sanitise key names where OpenBao does not, which is the trap
+ * `sgc/home-assistant-ssh` fell into (STATUS.md, Phase 7).
+ *
+ * ## Secrecy comes from custom_metadata, not from the value
+ *
+ * 1Password's Concealed field type is what `getSecretItem` marks `secret()`.
+ * OpenBao has no field types, so `op-to-bao` recorded the set as
+ * `custom_metadata.concealed_fields` — comma-joined, dotted for section fields
+ * (`ssh.password`). A KV v2 data read returns custom_metadata inline, so this
+ * costs no extra round trip. A path that lost that list would silently
+ * downgrade every value to plaintext in Pulumi state, so a path marked
+ * `contains_secrets: true` with no `concealed_fields` is an error here, not
+ * "nothing is secret".
+ */
+
+import { all, log, type Output, output, secret } from "@pulumi/pulumi";
+import { BaoClient, baoSlug } from "../bao.ts";
+import { VaultStore } from "./index.ts";
+import type { Meta } from "./interfaces.ts";
+
+/** The KV v2 mount every credential lives in. `docs` holds reference material. */
+const SECRETS_MOUNT = "secrets";
+
+/**
+ * Whether stacks read secrets from OpenBao instead of 1Password.
+ *
+ * Explicit rather than inferred from credential presence. The Phase 8a
+ * dual-write gate inferred, and an AppRole run then authenticated fine and
+ * silently skipped every write while `pulumi up` reported success (STATUS.md,
+ * "OIDC is live"). The same failure mode here would be worse: a silent
+ * fallback means nobody can tell which store a value came from, and the two
+ * agree only for as long as dual-run holds.
+ */
+export function baoStoreReadsEnabled(): boolean {
+  const v = (process.env.BAO_STORE_READS ?? "").toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
+}
+
+/** A KV path shaped like a 1Password item. */
+type BaoItem = Record<string, unknown> & Meta;
+
+export class BaoStore extends VaultStore {
+  private readonly bao: BaoClient;
+  /**
+   * One read per path per process. Stacks ask for the same credential from
+   * several components (`Tailscale Terraform OAuth Client` is read twice in
+   * `globals.ts` alone), and `OPClient` memoises for the same reason.
+   */
+  private readonly cache = new Map<string, Output<BaoItem>>();
+
+  constructor(bao?: BaoClient) {
+    super();
+    // Constructed lazily by default so building a BaoStore does not demand
+    // credentials on a stack that never reads one.
+    this.bao = bao ?? new BaoClient();
+  }
+
+  /**
+   * Read a KV path and shape it like `getSecretItem` output. `path` is within
+   * the `secrets` mount, no leading slash — e.g.
+   * `shared/cloudflare-driscoll-tech`.
+   */
+  public getSecretByPath<T>(path: string): Output<T & Meta> {
+    return this.read(path) as Output<T & Meta>;
+  }
+
+  /**
+   * The 1Password title a stack still names, resolved to its OpenBao path —
+   * or read from 1Password when no OpenBao path exists.
+   *
+   * Call sites move to `getSecretByPath` over time; this exists so they do not
+   * all have to move at once. See `resolveBaoPath` for why a single default
+   * rule is not enough.
+   */
+  public override getSecretByTitle<T>(title: string): Output<T & Meta> {
+    const resolved = resolveBaoPath(title);
+    if (resolved.path) return this.getSecretByPath<T>(resolved.path);
+    // Warn, every time, naming the reason. These are enumerated exceptions,
+    // not a blanket "try OpenBao, fall back if it 404s" — that would turn a
+    // typo'd path, or a secret deleted from OpenBao, into a silent read of a
+    // stale 1Password copy that nothing would ever surface.
+    log.warn(`${title}: reading from 1Password — ${resolved.reason}`);
+    return this.getOnePasswordItemByTitle<T>(title) as Output<T & Meta>;
+  }
+
+  /**
+   * `tag:dockge` became the `hosts/dockge/` prefix — a KV LIST is what
+   * reproduces `findItemsByTag`, which has no KV v2 equivalent.
+   */
+  public override getDockgeInstances() {
+    return this.listUnder("hosts/dockge") as ReturnType<VaultStore["getDockgeInstances"]>;
+  }
+
+  private listUnder(prefix: string): Output<BaoItem[]> {
+    return output(this.bao.list(SECRETS_MOUNT, prefix)).apply(keys =>
+      all(
+        keys.map(key => {
+          assertNotDirectory(prefix, key);
+          return this.read(`${prefix}/${key}`);
+        }),
+      ),
+    ) as unknown as Output<BaoItem[]>;
+  }
+
+  private read(path: string): Output<BaoItem> {
+    const cached = this.cache.get(path);
+    if (cached) return cached;
+    const item = output(this.bao.read(SECRETS_MOUNT, path)).apply(result => shapeItem(path, result));
+    this.cache.set(path, item);
+    return item;
+  }
+}
+
+/** Cluster keys that prefix a generated per-app credential title. */
+const CLUSTER_KEYS = ["equestria", "sgc", "celestia", "luna", "skystar", "alpha-site", "twilight-sparkle"];
+
+/**
+ * Titles whose 1Password item is deliberately NOT in OpenBao.
+ *
+ * Two different reasons, and they must not be conflated:
+ *
+ *   never   INVENTORY.md §2 forbids it. `OpenBao Alpha Site Static Unseal` is
+ *           the key that unseals the thing that unseals OpenBao — putting it
+ *           inside OpenBao is the circular dependency the whole seal chain
+ *           exists to avoid. Its destination is SOPS, not a KV path.
+ *   later   inventory, waiting on the cross-stack channel (`Authentik Outputs`
+ *           is produced by the authentik stack and read by four others).
+ */
+const NOT_IN_OPENBAO: Record<string, string> = {
+  "OpenBao Alpha Site Static Unseal": "seal-chain material; INVENTORY §2 forbids it from ever living in OpenBao",
+  "Authentik Outputs": "cross-stack inventory; moves to secrets/clusters/_inventory/ in a later Phase 8 slice",
+  "Backup Plan": "cross-stack inventory; moves to secrets/clusters/_inventory/ in a later Phase 8 slice",
+};
+
+/**
+ * A 1Password title → its OpenBao path, or why there is not one.
+ *
+ * The `default` rule in `scripts/op-to-bao/mapping.ts` is `shared/<slug>`, and
+ * it covers every credential this repo names as a string literal. It is NOT
+ * enough on its own — a `pulumi preview` of `stacks/home` against OpenBao found
+ * four more shapes, each a different reason the default is wrong:
+ *
+ *   `<cluster>-<app>-oidc-credentials`  generated per-app credential. Phase 4
+ *       deliberately did not migrate these; Phase 8a writes them to
+ *       `clusters/<key>/apps/<app>/oidc`, so the default rule looks for a path
+ *       that will never exist.
+ *   a bare 26-character UUID  four items are addressed by id rather than title
+ *       (mapping.ts flags them `UNRESOLVED-`). Slugging a UUID yields the UUID.
+ *   `Cluster: …`  cluster definitions, becoming checked-in code.
+ *   the NOT_IN_OPENBAO set above.
+ *
+ * Splitting on the FIRST dash would mis-parse `alpha-site-technitium-…`, so the
+ * cluster key is matched against the known set, longest first — the same
+ * ambiguity `oidcBaoPath` avoids by taking its arguments separately.
+ */
+export function resolveBaoPath(title: string): { path: string; reason?: undefined } | { path?: undefined; reason: string } {
+  const excluded = NOT_IN_OPENBAO[title];
+  if (excluded) return { reason: excluded };
+
+  if (title.startsWith("Cluster: ")) return { reason: "cluster definitions become checked-in code in a later Phase 8 slice" };
+
+  // 1Password item ids are 26 lowercase base32 characters. A title that IS one
+  // means the call site addresses the item by id, and no path derives from it.
+  if (/^[a-z0-9]{26}$/.test(title)) return { reason: "item is addressed by UUID, which no OpenBao path derives from (mapping.ts: 'name it')" };
+
+  const oidc = /^(.+)-oidc-credentials$/.exec(title);
+  if (oidc) {
+    const key = CLUSTER_KEYS.filter(k => oidc[1].startsWith(`${k}-`)).sort((a, b) => b.length - a.length)[0];
+    if (key) return { path: `clusters/${key}/apps/${baoSlug(oidc[1].slice(key.length + 1))}/oidc` };
+    return { reason: `'${title}' looks like a generated OIDC credential but names no known cluster key` };
+  }
+
+  return { path: `shared/${baoSlug(title)}` };
+}
+
+/**
+ * A KV LIST marks a nested directory with a trailing slash.
+ *
+ * One appearing under a prefix this store treats as flat means the path layout
+ * changed; reading it as a secret would 404 somewhere far from the cause.
+ */
+export function assertNotDirectory(prefix: string, key: string): void {
+  if (key.endsWith("/")) throw new Error(`${SECRETS_MOUNT}/${prefix}/${key} is a directory, not a secret — the OpenBao path layout changed`);
+}
+
+/**
+ * KV v2 read result → the object `getSecretItem` would have built.
+ *
+ * Exported for its tests: this is where a field silently loses its `secret()`
+ * marker, and that is not visible in a `pulumi preview` diff.
+ */
+export function shapeItem(path: string, result: Awaited<ReturnType<BaoClient["read"]>>): Output<BaoItem> {
+  if (!result) throw new Error(`${SECRETS_MOUNT}/${path} does not exist in OpenBao`);
+
+  const cm = result.metadata.custom_metadata ?? {};
+  const concealed = new Set((cm.concealed_fields ?? "").split(",").filter(Boolean));
+  if (cm.contains_secrets === "true" && concealed.size === 0) {
+    throw new Error(`${SECRETS_MOUNT}/${path} is marked contains_secrets but lists no concealed_fields — refusing to read its values as plaintext`);
+  }
+
+  const item: Record<string, unknown> = {
+    meta: {
+      title: cm.source_title ?? path,
+      tags: (cm.source_tags ?? "").split(",").filter(Boolean),
+    },
+  };
+
+  for (const [key, value] of Object.entries(result.data)) {
+    // Files were flattened to {filename, content_b64, sha256} per name.
+    // `getSecretItem` exposes a file as its CONTENT under its name, so decode
+    // back to that rather than handing stacks the envelope.
+    if (key === "files" && isRecord(value)) {
+      for (const [name, file] of Object.entries(value)) {
+        if (!isRecord(file) || typeof file.content_b64 !== "string") throw new Error(`${SECRETS_MOUNT}/${path}: files.${name} is not a {content_b64} envelope`);
+        item[name] = secret(Buffer.from(file.content_b64, "base64").toString("utf8"));
+      }
+      continue;
+    }
+    // A nested object is a 1Password section; concealment is recorded with a
+    // dotted path, so it resolves per leaf.
+    if (isRecord(value)) {
+      item[key] = Object.fromEntries(Object.entries(value).map(([k, v]) => [k, concealed.has(`${key}.${k}`) ? secret(v) : output(v)]));
+      continue;
+    }
+    item[key] = concealed.has(key) ? secret(value) : output(value);
+  }
+
+  // `output()` deep-resolves the Outputs nested in this plain object and keeps
+  // their secretness — exactly how `getSecretItem` returns its item. The cast
+  // is the same one `getSecretItem` makes: unwrapping leaves TS with
+  // UnwrappedObject<…> where callers want the item shape.
+  return output(item) as unknown as Output<BaoItem>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/components/store/index.ts
+++ b/components/store/index.ts
@@ -1,26 +1,45 @@
 import { all, type Input, interpolate, jsonStringify, log, type Output, output, secret, type Unwrap } from "@pulumi/pulumi";
-import type { ClusterDefinition, DockgeClusterDefinition, DockgeLxcDefinition, KubernetesClusterDefinition, Meta, ProxmoxBackupServerLxcDefinition } from "./interfaces.ts";
 import { OPClient, TypeEnum } from "../op.ts";
+import type { ClusterDefinition, DockgeClusterDefinition, DockgeLxcDefinition, KubernetesClusterDefinition, Meta, ProxmoxBackupServerLxcDefinition } from "./interfaces.ts";
 
-const op = new OPClient();
+/**
+ * Lazy, not module-scope. `new OPClient()` constructs a 1Password Connect
+ * client eagerly and throws without CONNECT_HOST/CONNECT_TOKEN, so importing
+ * this module at all used to demand 1Password credentials — including from
+ * `BaoStore`, which subclasses `VaultStore` and may never touch 1Password, and
+ * from unit tests, which never should.
+ */
+let _op: OPClient | undefined;
+function op(): OPClient {
+  return (_op ??= new OPClient());
+}
 
 export * from "./interfaces.ts";
 
 type OnePasswordItem = Unwrap<ReturnType<OPClient["mapItem"]>>;
 export class VaultStore {
-  public readonly tailscaleDomain;
-  constructor() {
-    this.tailscaleDomain = this.getSecretByTitle<{ hostname: string }>("Tailscale Terraform OAuth Client").apply(z => z.hostname);
+  private _tailscaleDomain?: Output<string>;
+  /**
+   * Lazy, not constructor-assigned. `BaoStore extends VaultStore` and overrides
+   * `getSecretByTitle`, so reading a secret from the base constructor would
+   * dispatch into the subclass BEFORE its own fields (the client, the cache)
+   * are initialised — class fields run after `super()` returns — and throw on
+   * an undefined client. Nothing else here reads a secret at construction time;
+   * keep it that way.
+   */
+  public get tailscaleDomain(): Output<string> {
+    this._tailscaleDomain ??= this.getSecretByTitle<{ hostname: string }>("Tailscale Terraform OAuth Client").apply(z => z.hostname);
+    return this._tailscaleDomain;
   }
   public getDockgeInstances() {
-    return output(op.findItemsByTag("dockge")).apply(items => all(items.map(getSecretItem<DockgeLxcDefinition>)));
+    return output(op().findItemsByTag("dockge")).apply(items => all(items.map(getSecretItem<DockgeLxcDefinition>)));
   }
   public getCluster(title: string) {
-    return output(op.getItemByTitle(title)).apply(getSecretItem<ClusterDefinition>);
+    return output(op().getItemByTitle(title)).apply(getSecretItem<ClusterDefinition>);
   }
 
   public getAllClusters() {
-    return output(op.findItemsByTag("cluster-definition")).apply(items => all(items.map(getSecretItem<ClusterDefinition>)));
+    return output(op().findItemsByTag("cluster-definition")).apply(items => all(items.map(getSecretItem<ClusterDefinition>)));
   }
 
   public getDockerClusters() {
@@ -28,13 +47,13 @@ export class VaultStore {
   }
 
   public getBackupPlans<T>() {
-    return output(op.findItemsByTag("backup-plan"))
+    return output(op().findItemsByTag("backup-plan"))
       .apply(items => all(items.map(getSecretItem<{ plan: string }>)).apply(items => items.map(item => JSON.parse(item.plan) as { plans: T[] })))
       .apply(plans => plans.flatMap(z => z.plans));
   }
 
   public getTailscaleExports() {
-    return output(op.findItemsByTag("tailscale-export"))
+    return output(op().findItemsByTag("tailscale-export"))
       .apply(items =>
         all(
           items.map(
@@ -79,7 +98,7 @@ export class VaultStore {
   }
 
   public getKubeConfig(title: string) {
-    return output(op.getItemByTitle(title)).apply(generateKubeConfig);
+    return output(op().getItemByTitle(title)).apply(generateKubeConfig);
   }
 
   public getKubernetesClusters(): Output<(KubernetesClusterDefinition & { kubeConfig: string })[]> {
@@ -105,11 +124,26 @@ export class VaultStore {
   }
 
   public proxmoxBackupServers(withTag: string = "pbs") {
-    return output(op.findItemsByTag(withTag)).apply(items => all(items.map(item => createProxmoxBackupServerDefinition(op, item))));
+    return output(op().findItemsByTag(withTag)).apply(items => all(items.map(item => createProxmoxBackupServerDefinition(op(), item))));
   }
 
   public getSecretByTitle<T>(title: string) {
-    return output(op.getItemByTitle(title)).apply(getSecretItem<T>);
+    return this.getOnePasswordItemByTitle<T>(title);
+  }
+
+  /**
+   * Read from 1Password specifically, bypassing any subclass override.
+   *
+   * `BaoStore` overrides `getSecretByTitle`, so anything below that calls
+   * `this.getSecretByTitle` dispatches to OpenBao — including the `op://Eris/…`
+   * placeholder resolver, whose reference syntax names 1Password by
+   * construction. That mattered immediately: `op://Eris/OpenBao Alpha Site
+   * Static Unseal/…` is seal-chain material INVENTORY §2 forbids from ever
+   * entering OpenBao, so resolving it there is not a lookup failure to paper
+   * over, it is a category error.
+   */
+  protected getOnePasswordItemByTitle<T>(title: string) {
+    return output(op().getItemByTitle(title)).apply(getSecretItem<T>);
   }
 
   private readonly vaultRegex = /op:\/\/Eris\/([\w| -]+)\/([\w| -]+)/g;
@@ -121,7 +155,7 @@ export class VaultStore {
           matches
             .map(match => match.slice(1) as [string, string])
             .map(([itemTitle, fieldName]) =>
-              this.getSecretByTitle<{ [key: string]: string | undefined }>(itemTitle).apply(
+              this.getOnePasswordItemByTitle<{ [key: string]: string | undefined }>(itemTitle).apply(
                 item =>
                   ({
                     itemTitle,

--- a/scripts/bao-store-parity.ts
+++ b/scripts/bao-store-parity.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env -S npx tsx
+
+/**
+ * Phase 8 read-parity check: does `BaoStore` hand a stack the same object
+ * `VaultStore` does?
+ *
+ * `op-to-bao --verify` already compares the two stores' DATA field by field.
+ * This is a different question and the one that actually gates flipping
+ * `BAO_STORE_READS`: the value can be identical and the *object* still differ —
+ * a missing key, a field the 1Password Operator invented (`website`), or, worst
+ * of all, a field that lost its `secret()` marker and would land in Pulumi
+ * state in the clear. None of those show up in a `pulumi preview` diff.
+ *
+ * Every title here is one this repo names literally through
+ * `globals.store.getSecretByTitle`. Keep the list in step with those call sites;
+ * a credential that is not listed is not covered.
+ *
+ *   mise exec -- op run --no-masking -- npx tsx scripts/bao-store-parity.ts
+ *
+ * Env: CONNECT_HOST / CONNECT_TOKEN (1Password), plus BAO_ADDR and either
+ * BAO_TOKEN or BAO_ROLE_ID/BAO_SECRET_ID — `eval "$(bootstrap/openbao/pulumi-env.sh)"`
+ * in the vault repo exports the latter three.
+ *
+ * Exits non-zero on any mismatch, so it can gate a cutover in CI.
+ */
+
+import { BaoStore } from "@components/store/bao.ts";
+import { VaultStore } from "@components/store/index.ts";
+import { isSecret, type Output } from "@pulumi/pulumi";
+
+/** Titles read via `getSecretByTitle` somewhere in stacks/ or components/. */
+const TITLES = [
+  "Alpha Site Proxmox ApiKey",
+  "Cloudflare (driscoll.tech)",
+  "Dockge Credential",
+  "Eris Truenas Credentials",
+  "Proxmox",
+  "Proxmox ApiKey",
+  "Rclone SFTP Key",
+  "Tailscale Terraform OAuth Client",
+  "Technitium ApiKey",
+  "Unifi Api Key Eris Cluster",
+  "Volsync Password",
+  "minio root user",
+];
+
+const resolve = <T>(o: Output<T>): Promise<T> => new Promise(res => o.apply(v => (res(v), v)));
+
+/**
+ * `meta` is deliberately excluded from the value comparison.
+ *
+ * OpenBao has no notion of a 1Password category or item URL, so `meta.category`
+ * and `meta.urls` do not exist on the OpenBao side by design — only
+ * `meta.title` is consumed anywhere in this repo, and it is checked separately.
+ */
+function fields(item: Record<string, unknown>): Record<string, unknown> {
+  const { meta: _meta, ...rest } = item;
+  return rest;
+}
+
+function canonical(item: Record<string, unknown>): string {
+  return JSON.stringify(fields(item), Object.keys(fields(item)).sort());
+}
+
+let failures = 0;
+const op = new VaultStore();
+const bao = new BaoStore();
+
+for (const title of TITLES) {
+  try {
+    const opItem = op.getSecretByTitle<Record<string, unknown>>(title);
+    const baoItem = bao.getSecretByTitle<Record<string, unknown>>(title);
+    const [a, b] = await Promise.all([resolve(opItem), resolve(baoItem)]);
+    const [aSecret, bSecret] = await Promise.all([isSecret(opItem), isSecret(baoItem)]);
+
+    const keysA = Object.keys(fields(a)).sort();
+    const keysB = Object.keys(fields(b)).sort();
+    const valuesMatch = canonical(a) === canonical(b);
+    const secrecyMatches = aSecret === bSecret;
+    const titleMatches = (a.meta as { title: string }).title === (b.meta as { title: string }).title;
+
+    if (valuesMatch && secrecyMatches && titleMatches) {
+      console.log(`OK    ${title}`);
+      continue;
+    }
+    failures++;
+    console.log(`DIFF  ${title}`);
+    // Never print values — this runs with both stores open. Keys and flags are
+    // enough to identify every failure mode this check exists for.
+    if (!valuesMatch) {
+      console.log(`        1Password keys: ${keysA.join(", ")}`);
+      console.log(`        OpenBao   keys: ${keysB.join(", ")}`);
+      const shared = keysA.filter(k => keysB.includes(k));
+      const differing = shared.filter(k => JSON.stringify(a[k]) !== JSON.stringify(b[k]));
+      if (differing.length > 0) console.log(`        differing values in: ${differing.join(", ")}`);
+    }
+    if (!secrecyMatches) console.log(`        SECRET MARKER: 1Password=${aSecret} OpenBao=${bSecret}`);
+    if (!titleMatches) console.log(`        meta.title: 1Password=${JSON.stringify(a.meta)} OpenBao=${JSON.stringify(b.meta)}`);
+  } catch (error) {
+    failures++;
+    console.log(`FAIL  ${title}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+// `getDockgeInstances` is the other overridden read, and it is the one where
+// the two stores could disagree on the SET rather than on a value: 1Password
+// finds items by tag, OpenBao by the `hosts/dockge/` path prefix, and an item
+// tagged after the migration exists in one and not the other.
+try {
+  const [opItems, baoItems] = await Promise.all([resolve(op.getDockgeInstances()), resolve(bao.getDockgeInstances())]);
+  const key = (items: readonly Record<string, unknown>[]) =>
+    items
+      .map(i => (i.meta as { title: string }).title)
+      .sort()
+      .join(", ");
+  const byTitle = (items: readonly Record<string, unknown>[]) => new Map(items.map(i => [(i.meta as { title: string }).title, i]));
+  const opByTitle = byTitle(opItems);
+  const baoByTitle = byTitle(baoItems);
+
+  if (key(opItems) !== key(baoItems)) {
+    failures++;
+    console.log("DIFF  getDockgeInstances (different sets)");
+    console.log(`        tag:dockge        ${key(opItems)}`);
+    console.log(`        hosts/dockge/     ${key(baoItems)}`);
+  } else {
+    const drifted = [...opByTitle].filter(([title, a]) => canonical(a) !== canonical(baoByTitle.get(title) as Record<string, unknown>));
+    if (drifted.length > 0) {
+      failures++;
+      console.log("DIFF  getDockgeInstances");
+      for (const [title, a] of drifted) {
+        const b = baoByTitle.get(title) as Record<string, unknown>;
+        console.log(`        ${title}`);
+        console.log(`          1Password keys: ${Object.keys(fields(a)).sort().join(", ")}`);
+        console.log(`          OpenBao   keys: ${Object.keys(fields(b)).sort().join(", ")}`);
+      }
+    } else {
+      console.log(`OK    getDockgeInstances (${opItems.length})`);
+    }
+  }
+} catch (error) {
+  failures++;
+  console.log(`FAIL  getDockgeInstances: ${error instanceof Error ? error.message : String(error)}`);
+}
+
+const checks = TITLES.length + 1;
+console.log(failures === 0 ? `\n${checks}/${checks} in parity` : `\n${failures} of ${checks} mismatched`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Phase 8 of the 1Password→OpenBao migration. Pairs with david-driscoll/vault#173, which adds the `pulumi-env.sh` these runs need.

PLAN §D.3 identified `VaultStore` as the seam: every stack reaches secrets through `globals.store`, so reimplementing its reads against OpenBao covers the whole repo without touching a stack file. This is that reimplementation, behind `BAO_STORE_READS`. **Unset, nothing changes** — that is why this is safe to merge before any cutover.

It **extends** `VaultStore` rather than replacing it. Phase 8 has four independent halves and they cannot land together, so this overrides only what OpenBao can serve today and the rest keeps the inherited 1Password implementation until its own slice.

## `getSecretByTitle` needs a resolver, not one default rule

`shared/<slug(title)>` covers every credential the repo names as a string literal and **nothing else**. A `pulumi preview` of `stacks/home` against OpenBao found four more shapes, each wrong for a different reason:

| Shape | Why the default rule is wrong |
|---|---|
| `<cluster>-<app>-oidc-credentials` | Lives at `clusters/<key>/apps/<app>/oidc`; Phase 4 skipped the family deliberately. `alpha-site-technitium-…` also splits at the *wrong dash* under a lazy regex, so the cluster key is matched against the known set, longest first |
| bare 26-char UUIDs | Some call sites address an item by id. Slugging a UUID yields the UUID — a path that cannot exist |
| `Cluster: …` | Inventory; becomes checked-in code in a later slice |
| `OpenBao Alpha Site Static Unseal` | Must **never** be in OpenBao |

That last one was a **category error, not a gap**. `replaceOnePasswordPlaceholders` called `this.getSecretByTitle`, so virtual dispatch sent every `op://Eris/…` reference — a syntax that names 1Password by construction — to OpenBao. Its first casualty was the seal chain: INVENTORY §2 forbids the static unseal key from living inside the thing it unseals, so "look it up in OpenBao" is a question that must never be asked. The resolver now separates `never` from `later`, and the placeholder path reads through a `protected getOnePasswordItemByTitle` no subclass overrides.

**Fallbacks are enumerated and warn on every read, never inferred.** A blanket "try OpenBao, fall back on 404" would turn a typo'd path — or a secret deleted from OpenBao — into a silent read of a stale 1Password copy.

## Two supporting fixes that were required, not optional

- **`BaoClient` accepts the AppRole**, not only `BAO_TOKEN`. Accepting less than `baoProvider` does is the exact mismatch that made the Phase 8a dual-write gate authenticate fine and then silently skip every write while `up` reported success.
- **`OPClient` construction is lazy, and `tailscaleDomain` is a getter.** The former made importing the store module demand 1Password credentials, including from unit tests. The latter is load-bearing: reading a secret from the base constructor dispatches into the subclass *before* its own fields exist, because class fields initialise after `super()` returns.

## Verification

`scripts/bao-store-parity.ts` (new) answers what `op-to-bao --verify` does not. `--verify` compares the two stores' **data**; this compares the **object** each store hands a stack — key set, values, and the `secret()` markers, which is where a credential would silently reach Pulumi state in the clear with no symptom until `pulumi stack export`.

- [x] **13/13 in parity** live — the 12 credentials named by literal title, plus all 4 `getDockgeInstances` entries
- [x] **`stacks/backups`** previews byte-identically with `BAO_STORE_READS=1` (11 unchanged, zero diff outside the store banner)
- [x] **`stacks/home`** — 161 non-`mkdir` resource operations, **byte-identical** to the 1Password plan; 0 errors; one expected warning (`Authentik Outputs`)
- [x] 21 new unit tests, 53 across the repo, all passing; biome clean; no new type errors

### Read the control run before trusting a single diff

The two stores' `stacks/home` plans first appeared to differ by four `*-mkdir` lines, which looks exactly like the migration broke something. Running **1Password twice** showed two runs of the *same* store differ by six. `mkdirOutput` (`components/helpers.ts:22-48`) memoises one `remote.Command` per (host, *directory*) but names it after whichever *file* reached that directory first, decided by async resolution order inside an `apply()`. Pre-existing, unrelated to this PR, tracked separately — but it means **you cannot judge a store cutover on this repo from one pair of previews.**

## Not in this PR

Cluster definitions as code; inventory write-back to `secrets/clusters/_inventory/*`; `vals` replacing the placeholder resolver; retiring `dynamic/1password/`. Each is its own slice, listed in the vault repo's STATUS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)