### PR TITLE
fix(dockge): sort globbed stack files so compose triggers stop reshuffling

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -755,6 +755,18 @@ export class DockgeLxc extends ComponentResource {
       return null;
     }
 
+    // glob() gives NO ordering guarantee — it walks directories concurrently and yields
+    // entries in completion order, so a deeply nested stack (prometheus, with config/,
+    // config/rules/ and config/alloy/) comes back in a different order from run to run
+    // once several stacks are globbing at once. That order flows into this Map, into the
+    // per-file resource list in createStack(), and finally into the compose Command's
+    // positional `triggers` array — where a pure reshuffle showed up as a diff on
+    // `triggers[6]`…`triggers[9]` with inputDiff:false and replaced the Command, i.e.
+    // restarted a healthy Docker stack for no reason. Sort so the order is a property of
+    // the file names rather than of disk timing.
+    commonFiles.sort();
+    files.sort();
+
     const filesMap = new Map<string, string>();
     for (const file of files) {
       const relativePath = relative(path, file);
@@ -1019,6 +1031,13 @@ export class DockgeLxc extends ComponentResource {
         `${this.shortName}-${stackName}-compose`,
         {
           connection: this.remoteConnection,
+          // Positional: Pulumi diffs this array slot by slot, so the ORDER of `copyFiles`
+          // is load-bearing, not just its contents. That order comes from getStackFiles(),
+          // which sorts for exactly this reason — keep it that way. If `copyFiles` ever
+          // gains entries from a source that does not preserve a stable order, a pure
+          // reshuffle shows up here as a diff on `triggers[n]` with inputDiff:false and
+          // replaces this command, and `deleteBeforeReplace` + `docker compose up -d`
+          // means that restarts a healthy stack.
           triggers: [...copyFiles.map(f => f.id)],
           create: interpolate`cd /opt/stacks/${stackName} && docker compose -f compose.yaml build && docker compose -f compose.yaml up -d && docker compose -f compose.yaml start`,
         },


### PR DESCRIPTION
## Problem

`pulumi preview` on `stacks/home` intermittently reported `replace` on `*-compose` resources when nothing had changed. The diff reasons looked like this:

```json
{
  "op": "replace",
  "diffReasons": ["triggers[8]", "triggers[9]", "triggers[6]", "triggers[7]"],
  "detailedDiff": { "triggers[6]": { "kind": "update-replace", "inputDiff": false } }
}
```

`inputDiff: false` with unchanged values means the trigger values did not change — they moved position in the array.

Because the compose Command is `deleteBeforeReplace: true` and runs `docker compose -f compose.yaml build && docker compose -f compose.yaml up -d && docker compose -f compose.yaml start`, a spurious replace **restarts a healthy Docker stack**.

## Root cause

`getStackFiles()` built its file Map straight from `glob("**/*")`. glob gives no ordering guarantee — it walks directories concurrently and yields entries in completion order.

Reproduced by running the real `getStackFiles` logic for all 15 `_common` stacks concurrently, the way the program does:

```
stacks globbed concurrently: 15 | iterations: 10
stacks with VARYING file order: 1
  prometheus -> 2 distinct orderings
```

`prometheus` is the most deeply nested stack (`config/`, `config/rules/`, `config/alloy/`) and is exactly the stack whose compose flapped (`as-prometheus-compose`, `celestia-dockge-prometheus-compose`). The order flows: glob → `filesMap` → `others` → `copyFiles` → the positional `triggers` array.

Note the earlier hypothesis — that the async `copyFiles.push` calls inside the `.apply()` in `createStack()` were racing the synchronous pushes — is **not** the cause. `if (hasCompose)` reads `copyFiles` synchronously right after the loop, so those apply-callback pushes always land after `triggers` is built and cannot affect it.

## Fix

Sort both glob results so the order is a property of the file names rather than of disk timing. Also documents why the sort is load-bearing at the `triggers` site.

## Verification

Two consecutive previews, sorted operation lists compared:

```bash
mise exec -- op run --no-masking -- pulumi preview --stack home-operations --non-interactive --json > run.json
jq -r '.steps[] | "\(.op)\t\(.urn)"' run.json | sort
```

- **Before:** sets differed run to run.
- **After:** byte-identical, 100 operations each, across repeated runs.

(Run pulumi from within `stacks/home` — only `stacks/home/.mise.toml` sets the correct `s3://home-operations/home` backend.)

## One-time cost

**23 `*-compose` replaces** on the next `pulumi up` — each one `docker compose build && up -d && start`, i.e. one restart per affected stack. The compose Command has no `delete` command, so the delete half of each replace runs nothing.

Worth scheduling when a brief restart of those 23 stacks is acceptable.

The 7 `*-init` replaces that appear on every preview are unrelated and by design (`triggers: [Date.now()]`, "always run").

🤖 Generated with [Claude Code](https://claude.com/claude-code)