### PR TITLE
fix(dockge): make compose triggers order-independent by construction

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -764,6 +764,10 @@ export class DockgeLxc extends ComponentResource {
     // `triggers[6]`…`triggers[9]` with inputDiff:false and replaced the Command, i.e.
     // restarted a healthy Docker stack for no reason. Sort so the order is a property of
     // the file names rather than of disk timing.
+    //
+    // createStack() now sorts the trigger list independently as well, so this is no
+    // longer the only thing standing between a concurrent directory walk and a stack
+    // restart — but it is still what makes the resources get built in a sane order.
     commonFiles.sort();
     files.sort();
 
@@ -795,6 +799,16 @@ export class DockgeLxc extends ComponentResource {
     applications: ApplicationReturn[];
   }> {
     const copyFiles = [];
+    // Trigger identities for this stack's compose Command, tracked separately
+    // from `copyFiles` because the two need different guarantees. `copyFiles`
+    // is a dependency set, where order is irrelevant; `triggers` is an ORDERED
+    // array that the command provider treats as force-new, so a pure reorder —
+    // same resources, same ids — is enough to replace the Command and restart
+    // the stack's containers. Each entry therefore carries the Pulumi resource
+    // name as a stable key and the array is sorted by it before use, so the
+    // triggers depend only on WHICH resources exist, never on the order they
+    // happened to be constructed in.
+    const composeTriggers: { key: string; id: any }[] = [];
     const _cluster = this.cluster;
     const tailscaleDomain = this.args.globals.tailscaleDomain;
     // Prepend stack-specific substitutions so they run BEFORE the vaultRegex resolver.
@@ -880,17 +894,18 @@ export class DockgeLxc extends ComponentResource {
 
         const chownCmd = stackUsers.apply(users => (users.length > 0 ? users.flatMap(u => [`chown -R ${u} /opt/stacks-data/${stackName}`, `chown -R ${u} /opt/stacks/${stackName}`]).join(" && ") : "true"));
 
-        copyFiles.push(
-          new remote.Command(
-            `${this.shortName}-${stackName}-chown-stack`,
-            {
-              connection: this.remoteConnection,
-              create: chownCmd,
-              update: chownCmd,
-            },
-            { parent: stackParent, dependsOn: [stackParent] },
-          ),
+        const chownName = `${this.shortName}-${stackName}-chown-stack`;
+        const chownStack = new remote.Command(
+          chownName,
+          {
+            connection: this.remoteConnection,
+            create: chownCmd,
+            update: chownCmd,
+          },
+          { parent: stackParent, dependsOn: [stackParent] },
         );
+        copyFiles.push(chownStack);
+        composeTriggers.push({ key: chownName, id: chownStack.id });
 
         const tailscaleServices: Resource[] = [];
         const hostRegex = /Host\(`(.*?)`\)/g;
@@ -983,27 +998,28 @@ export class DockgeLxc extends ComponentResource {
         continue;
       }
 
-      copyFiles.push(
-        copyFileToRemote(`${this.shortName}-${stackName}-${file.replace(/\//g, "-")}-copy-file`, {
-          connection: this.remoteConnection,
-          remotePath: interpolate`/opt/stacks/${stackName}/${file}`,
-          content: replacedContent,
-          // The source path is a trigger because provenance matters on its own:
-          // the same remotePath can be fed by docker/_common/<stack>/… or by the
-          // host-specific docker/<host>/<stack>/… override, and a switch between
-          // the two is a real change even when the bytes are identical.
-          //
-          // It must be relative to `dockerPath`, never absolute. An absolute path
-          // encodes WHERE THE REPO IS CHECKED OUT, which differs per machine —
-          // state written from a checkout at /share/source and a run from
-          // ~/Development/... disagree on every single file, and each run replaces
-          // all ~100 of them back and forth forever while `triggers[0]` (the
-          // content hash) sits there unchanged, proving nothing actually differs.
-          triggers: [replacedContent, relative(dockerPath, absoluteFilePath)],
-          parent: stackParent,
-          dependsOn: dependsOn,
-        }),
-      );
+      const copyName = `${this.shortName}-${stackName}-${file.replace(/\//g, "-")}-copy-file`;
+      const copy = copyFileToRemote(copyName, {
+        connection: this.remoteConnection,
+        remotePath: interpolate`/opt/stacks/${stackName}/${file}`,
+        content: replacedContent,
+        // The source path is a trigger because provenance matters on its own:
+        // the same remotePath can be fed by docker/_common/<stack>/… or by the
+        // host-specific docker/<host>/<stack>/… override, and a switch between
+        // the two is a real change even when the bytes are identical.
+        //
+        // It must be relative to `dockerPath`, never absolute. An absolute path
+        // encodes WHERE THE REPO IS CHECKED OUT, which differs per machine —
+        // state written from a checkout at /share/source and a run from
+        // ~/Development/... disagree on every single file, and each run replaces
+        // all ~100 of them back and forth forever while `triggers[0]` (the
+        // content hash) sits there unchanged, proving nothing actually differs.
+        triggers: [replacedContent, relative(dockerPath, absoluteFilePath)],
+        parent: stackParent,
+        dependsOn: dependsOn,
+      });
+      copyFiles.push(copy);
+      composeTriggers.push({ key: copyName, id: copy.id });
     }
 
     if (hasCompose) {
@@ -1019,8 +1035,15 @@ export class DockgeLxc extends ComponentResource {
             create: interpolate`cd /opt/stacks/${stackName} && bash init.sh`,
           },
           {
+            // Snapshot, not the live array. Pulumi reads `dependsOn` inside an
+            // async prepare step, so passing `copyFiles` by reference let it
+            // pick up whatever the tailscale/DNS resources built inside the
+            // `.apply()` above had managed to push by then — a set that varied
+            // per run and was never something to rely on. Those resources are
+            // registered strictly after this point in every run, so the honest
+            // dependency set is the file copies, and only those.
             parent: stackParent,
-            dependsOn: copyFiles,
+            dependsOn: [...copyFiles],
             deleteBeforeReplace: true,
           },
         );
@@ -1031,14 +1054,20 @@ export class DockgeLxc extends ComponentResource {
         `${this.shortName}-${stackName}-compose`,
         {
           connection: this.remoteConnection,
-          // Positional: Pulumi diffs this array slot by slot, so the ORDER of `copyFiles`
-          // is load-bearing, not just its contents. That order comes from getStackFiles(),
-          // which sorts for exactly this reason — keep it that way. If `copyFiles` ever
-          // gains entries from a source that does not preserve a stable order, a pure
-          // reshuffle shows up here as a diff on `triggers[n]` with inputDiff:false and
-          // replaces this command, and `deleteBeforeReplace` + `docker compose up -d`
-          // means that restarts a healthy stack.
-          triggers: [...copyFiles.map(f => f.id)],
+          // Positional: Pulumi diffs this array slot by slot, so the ORDER is load-bearing,
+          // not just the contents. A pure reshuffle shows up as a diff on `triggers[n]`
+          // with inputDiff:false and replaces this command, and `deleteBeforeReplace` +
+          // `docker compose up -d` means that restarts a healthy stack.
+          //
+          // So it is built from `composeTriggers` rather than from `copyFiles` directly:
+          // every entry carries its Pulumi resource name and the array is sorted by it,
+          // making the order a property of WHICH resources exist rather than of when they
+          // were constructed. getStackFiles() sorting its glob results is what keeps the
+          // construction order sane; this is what keeps the plan from depending on it.
+          //
+          // Plain codepoint order, NOT localeCompare — that would make the plan depend on
+          // the runner's locale.
+          triggers: [...composeTriggers].sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0)).map(t => t.id),
           create: interpolate`cd /opt/stacks/${stackName} && docker compose -f compose.yaml build && docker compose -f compose.yaml up -d && docker compose -f compose.yaml start`,
         },
         {


### PR DESCRIPTION
Follow-on to #714. That PR fixed the root cause — `glob` returning stack files in I/O-completion order — and left a comment on the compose Command's `triggers` warning that the array is positional and that its order is load-bearing:

> If `copyFiles` ever gains entries from a source that does not preserve a stable order, a pure reshuffle shows up here as a diff on `triggers[n]` with inputDiff:false and replaces this command…

That is already true today. `copyFiles` gains entries from inside an `.apply()` — the `tailscale.Service`, `tailscale serve` Command and `StandardDns` records built while scanning compose content for `Host(...)` — pushed in whatever order the content Outputs resolve.

They are harmless **only by accident of timing**. `Output.apply` is always promise-based (`@pulumi/pulumi` `output.js:215`, `Promise.all(...).then(...)`), and `triggers: [...copyFiles.map(f => f.id)]` spreads synchronously, so those pushes land strictly after the Command is constructed and never reach the array. Nothing enforces that. Moving the construction one tick later, or `await`ing anything in `createStack()`, silently arms it.

## Changes

**Triggers are now order-independent by construction.** The array is built from `composeTriggers`, whose entries carry the Pulumi resource name as a stable key, sorted by it before mapping to ids. Plain codepoint order, deliberately **not** `localeCompare` — that would make the plan depend on the runner's locale. The triggers now depend on *which* resources exist, never on when they were built.

**Second site, same async-registration bug.** The init Command passed `copyFiles` by **reference** as `dependsOn`. Pulumi reads `dependsOn` in an async prepare step, so it picked up whichever in-`apply` resources happened to have been pushed by then — a set that varied per run. Now snapshotted (`[...copyFiles]`), matching what `composeDeps` already does one line above. Those resources were never reliably captured, so nothing depended on them.

## Verification

Three `stacks/gulf-of-mexico` previews — 1Password ×2, then `BAO_STORE_READS=1` — produce **identical plans**.

`luna-dockge-prometheus-compose` — the resource whose replace/no-replace flip-flopped depending on the secret store, which is what started this investigation — is now **absent from all three plans**.

Typecheck clean for this file; only the pre-existing `TS6307` / `TS2314` failures remain.

## One-time cost

Sorting by resource name moves the `*-chown-stack` entry for stacks where the old file-path order put it elsewhere. With #714 already deployed that is **2 compose Commands on gulf-of-mexico** (`arcane-agent`, `postgres`), each a pure reshuffle of unchanged values. The compose Command has no `delete` command, so the delete half of each replace runs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)