### PR TITLE
feat(openbao): dual-write Authentik Outputs to OpenBao

### DIFF
--- a/stacks/authentik/index.ts
+++ b/stacks/authentik/index.ts
@@ -1,4 +1,5 @@
 import { FullItem } from "@1password/connect";
+import { baoKvSecret, baoProvenance } from "@components/bao.ts";
 import { GlobalResources } from "@components/globals.ts";
 import { awaitOutput } from "@components/helpers.ts";
 import { OnePasswordItem, type OnePasswordItemSectionInput, PurposeEnum, TypeEnum } from "@dynamic/1password/OnePasswordItem.ts";
@@ -79,6 +80,34 @@ const _authentikSecret = new OnePasswordItem("authentik-outputs", {
     },
   }),
 });
+
+// Phase 8 dual-write. `Authentik Outputs` is the estate's one piece of
+// cross-stack inventory with four consumers (home, ocracoke, gulf-of-mexico,
+// applications), and PLAN §G's `StackReference` answer is unavailable here —
+// every stack has its own DIY backend, so nothing can reference this project.
+// OpenBao is the channel instead.
+//
+// Written ALONGSIDE the OnePasswordItem above, never instead of it: 1Password
+// stays authoritative until Phase 11, and the consumers do not read this path
+// until a `pulumi up` on THIS stack has populated it. Switching a reader first
+// would give it an empty object rather than an error.
+if (globals.baoDualWriteEnabled) {
+  baoKvSecret(
+    "authentik-outputs-bao",
+    {
+      mount: "secrets",
+      path: "clusters/_inventory/authentik-outputs",
+      // The same four sections the 1Password item carries, as nested objects.
+      // These are Authentik object IDs, not credentials — but they go in the
+      // `secrets` mount because that is the only KV mount consumers can read.
+      data: pulumi.output({ groups, roles, flows, scopeMappings }),
+      customMetadata: baoProvenance({ source_title: "Authentik Outputs" }),
+    },
+    { provider: globals.baoProvider, parent: globals },
+  );
+} else {
+  pulumi.log.warn("BAO credentials absent — skipping the Authentik Outputs dual-write; consumers still read 1Password");
+}
 
 const clusterDefinition = await awaitOutput(globals.store.getCluster("Cluster: Stargate Command"));
 const _tailscaleBrand = new Brand(


### PR DESCRIPTION
First of the three cross-stack inventory flows. **Write only — no consumer is switched here.**

`Authentik Outputs` is the estate's highest-value inventory: four consumers (home, ocracoke, gulf-of-mexico, applications) and the last thing every OpenBao preview warns about. PLAN §G's `StackReference` answer is unavailable — each stack has its own DIY backend, so nothing can reference this project — so OpenBao is the channel.

## The ordering constraint

Unlike the cluster secrets, this value is **produced by Pulumi**, not static. So it cannot be seeded by a one-time copy without being stale by design:

1. ✅ this PR — dual-write alongside the existing `OnePasswordItem`
2. ⏳ **`pulumi up --stack authentik`** — populates `secrets/clusters/_inventory/authentik-outputs`
3. ⏳ follow-up PR — switch the four consumers' read

Step 3 must not land before step 2 runs. A reader switched first gets an **empty object rather than an error**, which is exactly the failure mode this migration keeps having to detect after the fact.

## Verification

Preview delta is exactly additive:

```
+  pulumi:providers:vault openbao create
+  vault:kv:SecretV2 authentik-outputs-bao create
```

Nothing else in the stack changed. The write is gated on `globals.baoDualWriteEnabled` and warns rather than failing when credentials are absent, matching the Phase 8a sites.

## Not in this PR

`tailscale-export` and `backup-plan`, the other two inventory flows. Both are produced inside `TailscaleMonitor` and `BackupPlanOrchestrator`, neither of which has access to `globals` — and therefore to `baoProvider` — so wiring them means threading it through every construction site across five stacks. That is a mechanical but non-trivial refactor and deserves its own change rather than being rushed in alongside this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)