### PR TITLE
feat(openbao): serve Authentik Outputs reads from the _inventory path

### DIFF
--- a/components/store/bao.test.ts
+++ b/components/store/bao.test.ts
@@ -186,10 +186,17 @@ describe("resolveBaoPath", () => {
     assert.match(r.reason ?? "", /INVENTORY §2/);
   });
 
-  it("keeps cross-stack inventory and cluster definitions on 1Password for now", () => {
-    for (const title of ["Authentik Outputs", "Backup Plan", "Cluster: Alpha Site"]) {
+  it("keeps not-yet-migrated inventory and cluster definitions on 1Password for now", () => {
+    for (const title of ["Backup Plan", "Cluster: Alpha Site"]) {
       assert.equal(resolveBaoPath(title).path, undefined, title);
     }
+  });
+
+  it("serves Authentik Outputs from the _inventory path its producer dual-writes", () => {
+    // The gate for this entry is that the authentik stack has RUN since #717
+    // merged — verified live 2026-08-11 before the route landed. A consumer
+    // switched before that read an empty object rather than an error (§G-8).
+    assert.equal(resolveBaoPath("Authentik Outputs").path, "clusters/_inventory/authentik-outputs");
   });
 
   it("does not slug a UUID-addressed item into a UUID-shaped path", () => {

--- a/components/store/bao.ts
+++ b/components/store/bao.ts
@@ -199,8 +199,24 @@ const CLUSTER_KEYS = ["equestria", "sgc", "celestia", "luna", "skystar", "alpha-
  */
 const NOT_IN_OPENBAO: Record<string, string> = {
   "OpenBao Alpha Site Static Unseal": "seal-chain material; INVENTORY §2 forbids it from ever living in OpenBao",
-  "Authentik Outputs": "cross-stack inventory; moves to secrets/clusters/_inventory/ in a later Phase 8 slice",
   "Backup Plan": "cross-stack inventory; moves to secrets/clusters/_inventory/ in a later Phase 8 slice",
+};
+
+/**
+ * Cross-stack inventory served from `clusters/_inventory/` — the paths
+ * `mapping.yaml` reserves and the PRODUCING stack dual-writes (PLAN §G-8:
+ * `StackReference` cannot cross this repo's per-stack backends, so OpenBao is
+ * the channel).
+ *
+ * An entry moves here only after its producer has BOTH merged the dual-write
+ * AND run — a consumer switched first reads an empty object rather than an
+ * error, which is exactly the failure §G-8 warns about. `Authentik Outputs`
+ * cleared that gate on 2026-08-11: `clusters/_inventory/authentik-outputs`
+ * version 1, written by the authentik stack (verified live before this entry
+ * landed).
+ */
+const INVENTORY_IN_OPENBAO: Record<string, string> = {
+  "Authentik Outputs": "clusters/_inventory/authentik-outputs",
 };
 
 /**
@@ -227,6 +243,9 @@ const NOT_IN_OPENBAO: Record<string, string> = {
 export function resolveBaoPath(title: string): { path: string; reason?: undefined } | { path?: undefined; reason: string } {
   const excluded = NOT_IN_OPENBAO[title];
   if (excluded) return { reason: excluded };
+
+  const inventory = INVENTORY_IN_OPENBAO[title];
+  if (inventory) return { path: inventory };
 
   if (title.startsWith("Cluster: ")) return { reason: "cluster definitions become checked-in code in a later Phase 8 slice" };
 

--- a/scripts/bao-store-parity.ts
+++ b/scripts/bao-store-parity.ts
@@ -188,4 +188,37 @@ try {
   console.log(`FAIL  getAllClusters: ${error instanceof Error ? error.message : String(error)}`);
 }
 
+// Cross-stack inventory: `Authentik Outputs` is produced by the authentik
+// stack (dual-write, #717) and read back through the _inventory path. The two
+// sides are compared section by section rather than through the generic TITLES
+// loop because the 1Password item carries a `notesPlain` field the KV path
+// deliberately does not — it is human commentary, `AuthentikOutputs` does not
+// declare it, and no code reads it.
+try {
+  const title = "Authentik Outputs";
+  const [a, b] = await Promise.all([resolve(op.getSecretByTitle<Record<string, unknown>>(title)), resolve(bao.getSecretByTitle<Record<string, unknown>>(title))]);
+  const drop = (o: Record<string, unknown>) => Object.fromEntries(Object.entries(o).filter(([k]) => k !== "notesPlain" && k !== "notePlain" && k !== "meta"));
+  const keysA = Object.keys(drop(a)).sort();
+  const keysB = Object.keys(drop(b)).sort();
+  const differing = keysA.filter(k => JSON.stringify(a[k]) !== JSON.stringify(b[k]));
+  const titleMatches = (a.meta as { title: string }).title === (b.meta as { title: string }).title;
+  if (keysA.join() === keysB.join() && differing.length === 0 && titleMatches) {
+    console.log(`OK    ${title} (inventory)`);
+  } else {
+    failures++;
+    console.log(`DIFF  ${title} (inventory)`);
+    if (keysA.join() !== keysB.join()) {
+      console.log(`        1Password keys: ${keysA.join(", ")}`);
+      console.log(`        OpenBao   keys: ${keysB.join(", ")}`);
+    }
+    // These are Authentik object IDs, not credentials, but stay consistent
+    // with the rest of this script: name the sections, never print values.
+    if (differing.length) console.log(`        differing sections: ${differing.join(", ")}`);
+    if (!titleMatches) console.log(`        meta.title differs`);
+  }
+} catch (error) {
+  failures++;
+  console.log(`FAIL  Authentik Outputs (inventory): ${error instanceof Error ? error.message : String(error)}`);
+}
+
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Phase 8 of the OpenBao migration (vault repo: `docs/openbao-migration/PLAN.md` §G-8, STATUS.md "Slices left in Phase 8" item 1) — the read half of the `Authentik Outputs` inventory flow.

## What this does

`BaoStore.getSecretByTitle("Authentik Outputs")` now resolves to `secrets/clusters/_inventory/authentik-outputs` instead of warning and falling back to 1Password. That covers all four consumers (`home`, `ocracoke`, `gulf-of-mexico`, `applications`) in one place, since every stack reads the title through `globals.store`.

The route lives in a new `INVENTORY_IN_OPENBAO` table, separate from `NOT_IN_OPENBAO`: `Backup Plan` and the tailscale exports keep their warn-and-read-1Password behavior until each clears the same producer-has-run gate.

Nothing changes behavior until `BAO_STORE_READS` is set — which is still unset everywhere, deliberately.

## The §G-8 ordering gate is satisfied

> dual-write, then `pulumi up` on the producer, THEN switch the reader

- dual-write merged: #717
- producer ran: verified live 2026-08-11 — `clusters/_inventory/authentik-outputs` exists at **version 1**, `custom_metadata.pulumi_stack: authentik`, with 11 flows / 6 groups / 6 roles / 16 scopeMappings

A reader switched before that read an empty object rather than an error; that is why this PR did not ship together with #717.

## Verification

- `npx tsx --test components/store/bao.test.ts` — 22/22 pass (route asserted, `Backup Plan` still excluded)
- `scripts/bao-store-parity.ts` gains an inventory section comparing the object each store hands a stack — keys, values, `meta.title` — with `notesPlain` dropped (human commentary; `AuthentikOutputs` does not declare it, no code reads it). Live run against both stores: **20/20 OK**, including `Authentik Outputs (inventory)`.

## Not in this PR

`tailscale-export` and `backup-plan` (their own producer+reader changes, next PRs in this series), and the `BAO_STORE_READS` flip itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)