### PR TITLE
feat(openbao): dual-write backup plans and read them back through BaoStore

### DIFF
--- a/components/BackupPlanOrchestrator.ts
+++ b/components/BackupPlanOrchestrator.ts
@@ -1,7 +1,9 @@
 import { FullItem } from "@1password/connect";
 import { OnePasswordItem, TypeEnum } from "@dynamic/1password/OnePasswordItem.ts";
 import type { BackrestPlan, BackrestRepository } from "@openapi/backrest.js";
-import { all, ComponentResource, type ComponentResourceOptions, type Input, jsonStringify, type Output, output } from "@pulumi/pulumi";
+import { all, ComponentResource, type ComponentResourceOptions, type Input, jsonStringify, log, type Output, output } from "@pulumi/pulumi";
+import { baoKvSecret, baoProvenance, baoSlug } from "./bao.ts";
+import type { GlobalResources } from "./globals.ts";
 export interface PreSyncArgs {
   /** SFTP hostname of the host whose data should be staged before the backup */
   sftpHost: string;
@@ -26,7 +28,16 @@ export class BackupPlanOrchestrator extends ComponentResource {
   plans: Output<BackupPlanItem[]> = output([]);
   // sync?:; // what was this for?
 
-  constructor(name: string, opts?: ComponentResourceOptions) {
+  /**
+   * `globals` is here for `baoProvider`/`baoDualWriteEnabled` only — the plan
+   * is cross-stack inventory (PLAN §G-8), and the producing side owns the
+   * OpenBao write.
+   */
+  constructor(
+    name: string,
+    private readonly globals: GlobalResources,
+    opts?: ComponentResourceOptions,
+  ) {
     super("home:backups:BackupPlanOrchestrator", name, {}, opts);
   }
 
@@ -35,7 +46,11 @@ export class BackupPlanOrchestrator extends ComponentResource {
   }
 
   public savePlan(title: string) {
-    return new OnePasswordItem(
+    // One expression serializes for both stores, so the OpenBao copy is
+    // byte-identical to the 1Password field by construction.
+    const plan = jsonStringify({ plans: this.plans });
+
+    const item = new OnePasswordItem(
       `backup-plan`,
       {
         category: FullItem.CategoryEnum.SecureNote,
@@ -44,11 +59,41 @@ export class BackupPlanOrchestrator extends ComponentResource {
         fields: {
           plan: {
             type: TypeEnum.Concealed,
-            value: jsonStringify({ plans: this.plans }),
+            value: plan,
           },
         },
       },
       { parent: this },
     );
+
+    // Phase 8 dual-write (openbao-migration PLAN §G-8): the plan also lands at
+    // its reserved inventory path (`clusters/_inventory/<slug(title)>`, the
+    // tag:backup-plan rule in scripts/op-to-bao/mapping.ts). The 1Password
+    // field is Concealed, so `concealed_fields: plan` keeps the `secret()`
+    // marker on the read side. 1Password stays authoritative until Phase 11 —
+    // written ALONGSIDE the item, never instead of it; rollback is a plain
+    // `git revert`. `BaoStore.getBackupPlans` refuses to serve consumers until
+    // every producing stack has run this once.
+    if (this.globals.baoDualWriteEnabled) {
+      baoKvSecret(
+        `backup-plan-bao`,
+        {
+          mount: "secrets",
+          path: `clusters/_inventory/${baoSlug(title)}`,
+          data: { plan },
+          customMetadata: baoProvenance({
+            source_title: title,
+            source_tags: "backup-plan",
+            contains_secrets: "true",
+            concealed_fields: "plan",
+          }),
+        },
+        { parent: this, provider: this.globals.baoProvider },
+      );
+    } else {
+      log.warn(`No OpenBao credentials (BAO_TOKEN, or BAO_ROLE_ID + BAO_SECRET_ID) — skipping the backup-plan dual-write for '${title}'. 1Password stays authoritative; the inventory path stays stale until a credentialed run.`, this);
+    }
+
+    return item;
   }
 }

--- a/components/store/bao.test.ts
+++ b/components/store/bao.test.ts
@@ -15,8 +15,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { isSecret, runtime } from "@pulumi/pulumi";
-import { assertNotDirectory, BaoStore, baoStoreReadsEnabled, resolveBaoPath, shapeItem, tailscaleExportKeys } from "./bao.ts";
-import { shapeTailscaleExports } from "./index.ts";
+import { assertNotDirectory, backupPlanKeys, BaoStore, baoStoreReadsEnabled, resolveBaoPath, shapeItem, tailscaleExportKeys } from "./bao.ts";
+import { shapeBackupPlans, shapeTailscaleExports } from "./index.ts";
 
 runtime.setMocks({
   newResource: args => ({ id: `${args.name}-id`, state: args.inputs }),
@@ -187,10 +187,8 @@ describe("resolveBaoPath", () => {
     assert.match(r.reason ?? "", /INVENTORY §2/);
   });
 
-  it("keeps not-yet-migrated inventory and cluster definitions on 1Password for now", () => {
-    for (const title of ["Backup Plan", "Cluster: Alpha Site"]) {
-      assert.equal(resolveBaoPath(title).path, undefined, title);
-    }
+  it("keeps cluster-definition titles off OpenBao — they are checked-in code", () => {
+    assert.equal(resolveBaoPath("Cluster: Alpha Site").path, undefined);
   });
 
   it("serves Authentik Outputs from the _inventory path its producer dual-writes", () => {
@@ -198,6 +196,15 @@ describe("resolveBaoPath", () => {
     // merged — verified live 2026-08-11 before the route landed. A consumer
     // switched before that read an empty object rather than an error (§G-8).
     assert.equal(resolveBaoPath("Authentik Outputs").path, "clusters/_inventory/authentik-outputs");
+  });
+
+  it("routes the inventory families to their reserved _inventory paths, never shared/", () => {
+    assert.equal(resolveBaoPath("Backup Plan").path, "clusters/_inventory/backup-plan");
+    assert.equal(resolveBaoPath("Equestria Backup Plan").path, "clusters/_inventory/equestria-backup-plan");
+    assert.equal(resolveBaoPath("Stargate Command Backup Plan").path, "clusters/_inventory/stargate-command-backup-plan");
+    assert.equal(resolveBaoPath("Tailscale Export - home-operations").path, "clusters/_inventory/tailscale-export-home-operations");
+    // A title merely containing the words is not the family.
+    assert.equal(resolveBaoPath("Backup Plan Review Notes").path, "shared/backup-plan-review-notes");
   });
 
   it("does not slug a UUID-addressed item into a UUID-shaped path", () => {
@@ -258,6 +265,35 @@ describe("shapeTailscaleExports", () => {
   it("tolerates the pre-rename `ip` key", () => {
     const shaped = shapeTailscaleExports([item("home-operations", { node: { ip: "100.1.1.3", internalIp: "10.0.0.3", mac: "cc", nodeType: "pbs" } })]);
     assert.equal(shaped[0].hosts[0].externalIp, "100.1.1.3");
+  });
+});
+
+describe("backupPlanKeys", () => {
+  const complete = ["backup-plan", "equestria-backup-plan", "stargate-command-backup-plan"];
+
+  it("selects the bare key and the -backup-plan suffixed keys, nothing else", () => {
+    assert.deepEqual(backupPlanKeys(["authentik-outputs", "tailscale-export-ocracoke", ...complete]), complete);
+  });
+
+  it("refuses an empty or torn inventory, naming what is missing", () => {
+    // A smaller list here quietly shrinks what the directors back up — a
+    // failure with no symptom until a restore is needed.
+    assert.throws(() => backupPlanKeys([]), /missing backup-plan, equestria-backup-plan, stargate-command-backup-plan/);
+    assert.throws(() => backupPlanKeys(complete.filter(k => k !== "equestria-backup-plan")), /missing equestria-backup-plan/);
+  });
+
+  it("includes plans beyond the known set — a floor, not a ceiling", () => {
+    assert.deepEqual(backupPlanKeys([...complete, "luna-backup-plan"]), [...complete, "luna-backup-plan"]);
+  });
+});
+
+describe("shapeBackupPlans", () => {
+  it("flattens every item's plans into one list", () => {
+    const shaped = shapeBackupPlans<{ name: string }>([{ plan: JSON.stringify({ plans: [{ name: "a" }, { name: "b" }] }) }, { plan: JSON.stringify({ plans: [{ name: "c" }] }) }]);
+    assert.deepEqual(
+      shaped.map(p => p.name),
+      ["a", "b", "c"],
+    );
   });
 });
 

--- a/components/store/bao.ts
+++ b/components/store/bao.ts
@@ -19,8 +19,8 @@
  *
  * Still on 1Password after this file (each is a later slice):
  *
- *   getBackupPlans                 producer-side write-back moves to OpenBao
- *   proxmoxBackupServers           waits on the remaining inventory flows
+ *   proxmoxBackupServers           its items reference dockge/cluster items by
+ *                                  title; moves once those reads are proven
  *   replaceOnePasswordPlaceholders `vals` replaces it (PLAN §D.1)
  *
  * ## Field shapes carry over unchanged
@@ -48,7 +48,7 @@
 import { all, log, type Output, output, secret } from "@pulumi/pulumi";
 import { BaoClient, baoSlug } from "../bao.ts";
 import { CLUSTERS, type ClusterEntry, clusterBySourceTitle, clusterSecretPath } from "./clusters.ts";
-import { shapeTailscaleExports, VaultStore } from "./index.ts";
+import { shapeBackupPlans, shapeTailscaleExports, VaultStore } from "./index.ts";
 import type { Meta } from "./interfaces.ts";
 
 /** The KV v2 mount every credential lives in. `docs` holds reference material. */
@@ -69,6 +69,13 @@ const TAILSCALE_EXPORT_PREFIX = "tailscale-export-";
  * `getTailscaleExports` refuses a partial set — see the override for why.
  */
 const TAILSCALE_EXPORT_STACKS = ["gulf-of-mexico", "home-operations", "ocracoke"];
+
+/**
+ * The plans `BackupPlanOrchestrator.savePlan` produces today: `Backup Plan`
+ * from stacks/backups, `<Cluster Title> Backup Plan` from each applications
+ * stack. `getBackupPlans` refuses a partial set — see the override for why.
+ */
+const BACKUP_PLAN_KEYS = ["backup-plan", "equestria-backup-plan", "stargate-command-backup-plan"];
 
 /**
  * Whether stacks read secrets from OpenBao instead of 1Password.
@@ -201,6 +208,29 @@ export class BaoStore extends VaultStore {
       .apply(items => shapeTailscaleExports(items)) as ReturnType<VaultStore["getTailscaleExports"]>;
   }
 
+  /**
+   * `tag:backup-plan` became the `*backup-plan` keys under
+   * `clusters/_inventory/` — one per producing stack, dual-written by
+   * `BackupPlanOrchestrator.savePlan`.
+   *
+   * Same refusal as `getTailscaleExports`, same reason: the three
+   * `BackupPlanDirector`s create backrest plans from this list, so a torn
+   * inventory quietly shrinks the set of things being backed up — a failure
+   * with no symptom until a restore is needed. See `backupPlanKeys`.
+   */
+  public override getBackupPlans<T>() {
+    return output(this.bao.list(SECRETS_MOUNT, INVENTORY_PREFIX))
+      .apply(keys =>
+        all(
+          backupPlanKeys(keys).map(key => {
+            assertNotDirectory(INVENTORY_PREFIX, key);
+            return this.read(`${INVENTORY_PREFIX}/${key}`);
+          }),
+        ),
+      )
+      .apply(items => shapeBackupPlans<T>(items as unknown as { plan: string }[])) as ReturnType<VaultStore["getBackupPlans"]> & Output<T[]>;
+  }
+
   private listUnder(prefix: string): Output<BaoItem[]> {
     return output(this.bao.list(SECRETS_MOUNT, prefix)).apply(keys =>
       all(
@@ -238,7 +268,6 @@ const CLUSTER_KEYS = ["equestria", "sgc", "celestia", "luna", "skystar", "alpha-
  */
 const NOT_IN_OPENBAO: Record<string, string> = {
   "OpenBao Alpha Site Static Unseal": "seal-chain material; INVENTORY §2 forbids it from ever living in OpenBao",
-  "Backup Plan": "cross-stack inventory; moves to secrets/clusters/_inventory/ in a later Phase 8 slice",
 };
 
 /**
@@ -286,6 +315,15 @@ export function resolveBaoPath(title: string): { path: string; reason?: undefine
   const inventory = INVENTORY_IN_OPENBAO[title];
   if (inventory) return { path: inventory };
 
+  // The tag-shaped inventory families (`Backup Plan`, `<Title> Backup Plan`,
+  // `Tailscale Export - <stack>`). Every consumer reads these through
+  // `getBackupPlans`/`getTailscaleExports` rather than by title, but a title
+  // reaching this resolver must still land on the reserved _inventory path —
+  // the default rule below would derive `shared/…`, a path that never exists.
+  if (/(^| )Backup Plan$/.test(title) || /^Tailscale Export - .+$/.test(title)) {
+    return { path: `${INVENTORY_PREFIX}/${baoSlug(title)}` };
+  }
+
   if (title.startsWith("Cluster: ")) return { reason: "cluster definitions become checked-in code in a later Phase 8 slice" };
 
   // 1Password item ids are 26 lowercase base32 characters. A title that IS one
@@ -321,6 +359,23 @@ export function tailscaleExportKeys(keys: string[]): string[] {
     );
   }
   return exports;
+}
+
+/**
+ * The `*backup-plan` keys to read from an `_inventory` LIST — or an error
+ * when the set is not complete. Same floor-not-ceiling contract as
+ * `tailscaleExportKeys`; exported for its tests.
+ */
+export function backupPlanKeys(keys: string[]): string[] {
+  const plans = keys.filter(key => key === "backup-plan" || key.endsWith("-backup-plan"));
+  const missing = BACKUP_PLAN_KEYS.filter(key => !plans.includes(key));
+  if (missing.length > 0) {
+    throw new Error(
+      `backup-plan inventory is incomplete under ${SECRETS_MOUNT}/${INVENTORY_PREFIX}/ — missing ${missing.join(", ")}. ` +
+        `Each producing stack must run its dual-write before any consumer reads OpenBao (PLAN §G-8: dual-write, producer run, THEN the reader).`,
+    );
+  }
+  return plans;
 }
 
 /**

--- a/components/store/index.ts
+++ b/components/store/index.ts
@@ -48,8 +48,8 @@ export class VaultStore {
 
   public getBackupPlans<T>() {
     return output(op().findItemsByTag("backup-plan"))
-      .apply(items => all(items.map(getSecretItem<{ plan: string }>)).apply(items => items.map(item => JSON.parse(item.plan) as { plans: T[] })))
-      .apply(plans => plans.flatMap(z => z.plans));
+      .apply(items => all(items.map(getSecretItem<{ plan: string }>)))
+      .apply(items => shapeBackupPlans<T>(items));
   }
 
   public getTailscaleExports() {
@@ -154,6 +154,18 @@ export class VaultStore {
         return output(value).apply(v => v.replace(this.vaultRegex, fullMatch => items.get(fullMatch) || fullMatch));
       });
   }
+}
+
+/**
+ * Item-shaped backup plans → the flat plan list the directors consume.
+ *
+ * Shared between `VaultStore` (items found by `tag:backup-plan`) and
+ * `BaoStore` (paths listed under `clusters/_inventory/*backup-plan`) for the
+ * same reason as `shapeTailscaleExports` below: one transform, so the stores
+ * can only differ in data.
+ */
+export function shapeBackupPlans<T>(items: { plan: string }[]): T[] {
+  return items.map(item => JSON.parse(item.plan) as { plans: T[] }).flatMap(z => z.plans);
 }
 
 /**

--- a/scripts/bao-store-parity.ts
+++ b/scripts/bao-store-parity.ts
@@ -254,4 +254,29 @@ try {
   console.log(`FAIL  getTailscaleExports: ${error instanceof Error ? error.message : String(error)}`);
 }
 
+// Backup plans: produced by stacks/backups and both applications stacks,
+// consumed by the three BackupPlanDirectors. A wrong SET here silently shrinks
+// what gets backed up. Same gate semantics as getTailscaleExports: this
+// section FAILS until every producing stack has run its dual-write — do not
+// flip BAO_STORE_READS while it is red.
+try {
+  const [a, b] = await Promise.all([resolve(op.getBackupPlans<{ source: string; name: string }>()), resolve(bao.getBackupPlans<{ source: string; name: string }>())]);
+  const key = (plans: { source: string; name: string }[]) =>
+    plans
+      .map(p => `${p.source}/${p.name}`)
+      .sort()
+      .join(", ");
+  if (JSON.stringify([...a].sort((x, y) => `${x.source}/${x.name}`.localeCompare(`${y.source}/${y.name}`))) === JSON.stringify([...b].sort((x, y) => `${x.source}/${x.name}`.localeCompare(`${y.source}/${y.name}`)))) {
+    console.log(`OK    getBackupPlans (${a.length} plans)`);
+  } else {
+    failures++;
+    console.log("DIFF  getBackupPlans");
+    console.log(`        tag:backup-plan   ${key(a)}`);
+    console.log(`        _inventory/       ${key(b)}`);
+  }
+} catch (error) {
+  failures++;
+  console.log(`FAIL  getBackupPlans: ${error instanceof Error ? error.message : String(error)}`);
+}
+
 process.exit(failures === 0 ? 0 : 1);

--- a/stacks/applications/kubernetes.ts
+++ b/stacks/applications/kubernetes.ts
@@ -173,7 +173,7 @@ export async function kubernetesApplications(globals: GlobalResources, outputs: 
     },
     { parent: applicationManager.outpostsComponent, deleteBeforeReplace: true },
   );
-  const backupPlanOrchestrator = new BackupPlanOrchestrator("backup-plan-orchestrator");
+  const backupPlanOrchestrator = new BackupPlanOrchestrator("backup-plan-orchestrator", globals);
 
   await awaitOutput(
     pulumi.all([kubernetesBackups(globals, backupPlanOrchestrator, clusterDefinition)]).apply(() => {

--- a/stacks/backups/index.ts
+++ b/stacks/backups/index.ts
@@ -5,7 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 const globals = new GlobalResources({}, {});
 const dockgeDetails = globals.store.getDockgeInstances();
 
-const backupPlanOrchestrator = new BackupPlanOrchestrator("backup-plan-orchestrator");
+const backupPlanOrchestrator = new BackupPlanOrchestrator("backup-plan-orchestrator", globals);
 
 const dockgeInstances = dockgeDetails.apply(details => {
   return details.map(detail => {


### PR DESCRIPTION
Phase 8 of the OpenBao migration (vault repo: PLAN.md §G-8, STATUS.md "Slices left in Phase 8" item 1) — the `backup-plan` inventory flow, both halves. This completes all three inventory flows. **Stacked on #719** (which stacks on #718); merge in order.

## Producer

`BackupPlanOrchestrator.savePlan` dual-writes each plan to `secrets/clusters/_inventory/<slug(title)>` — `backup-plan` (stacks/backups), `equestria-backup-plan` / `stargate-command-backup-plan` (the applications stacks) — exactly the paths `mapping.yaml` reserves. Details worth reviewing:

- **One `jsonStringify` expression feeds both stores**, so the OpenBao copy is byte-identical to the 1Password `plan` field by construction.
- The 1Password field is `Concealed`, so the KV path carries `concealed_fields: plan` — the read side keeps the `secret()` marker, which is the failure mode the parity script exists to catch.
- The orchestrator takes `globals` in its constructor (two construction sites) for `baoProvider`/`baoDualWriteEnabled`, same threading as `TailscaleMonitor` in #719.

## Reader — refuses a torn inventory

`BaoStore.getBackupPlans` lists `clusters/_inventory/*backup-plan`. An incomplete set (including empty) is an **error**, never a smaller list: the three `BackupPlanDirector`s create backrest plans from this read, and a smaller list silently shrinks what gets backed up — a failure with no symptom until a restore is needed. `backupPlanKeys` names exactly which producer has not run; plans beyond the known three are picked up automatically (floor, not ceiling).

`resolveBaoPath` also now routes the whole inventory family (`Backup Plan`, `<Title> Backup Plan`, `Tailscale Export - <stack>`) to `_inventory` paths. Nothing reads these by title today, but the default rule would have derived `shared/…` paths that never exist.

Nothing changes behavior until `BAO_STORE_READS` is set (still unset everywhere).

## Parity gate

`bao-store-parity.ts` gains a `getBackupPlans` section comparing the flattened plan sets. **It fails until stacks/backups and both applications stacks have run their dual-write** — the §G-8 gate for the flip PR.

## Verification

- `npx tsx --test components/store/bao.test.ts` — 33/33 (key selection, torn-inventory refusal, floor-not-ceiling, flatten behavior, family routing incl. the near-miss title case)
- `tsc --noEmit` clean on `backups`, `applications`, `home`
- Live preview pending on the 1Password CLI session being unlocked (same as #719); expected diff per producing stack: one `+ create` (`backup-plan-bao`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)