### PR TITLE
feat(openbao)!: flip BAO_STORE_READS — stacks read secrets from OpenBao

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -52,6 +52,12 @@ CONNECT_VAULT = "Eris"
 CONNECT_TOKEN = "op://Eris/Eris 1Password Connect Access Token/credential"
 AUTHENTIK_TOKEN = "op://Eris/Authentik Token/credential"
 AUTHENTIK_URL = "op://Eris/Authentik Token/url"
+# Phase 8 cutover: local runs read secrets from OpenBao (BaoStore), matching
+# the operator's Stack CRs. Local runs now REQUIRE the OpenBao credentials —
+# eval "$(bootstrap/openbao/pulumi-env.sh)" from the vault repo first; without
+# them GlobalResources fails loudly at construction rather than silently
+# reading a different store than the operator does.
+BAO_STORE_READS = "1"
 # UNIFI_HOST = "unifi.driscoll.tech"
 # UNIFI_USERNAME = "op://Eris/unifipoller/username"
 # UNIFI_PASSWORD = "op://Eris/unifipoller/password"

--- a/kubernetes/apps/pulumi/applications/equestria.yaml
+++ b/kubernetes/apps/pulumi/applications/equestria.yaml
@@ -87,6 +87,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/applications/sgc.yaml
+++ b/kubernetes/apps/pulumi/applications/sgc.yaml
@@ -87,6 +87,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/authentik/stack.yaml
+++ b/kubernetes/apps/pulumi/authentik/stack.yaml
@@ -88,6 +88,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/backups/stack.yaml
+++ b/kubernetes/apps/pulumi/backups/stack.yaml
@@ -88,6 +88,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
+++ b/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
@@ -88,6 +88,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/home-operations/stack.yaml
+++ b/kubernetes/apps/pulumi/home-operations/stack.yaml
@@ -89,6 +89,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/ocracoke/stack.yaml
+++ b/kubernetes/apps/pulumi/ocracoke/stack.yaml
@@ -88,6 +88,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/unifi-network/stack.yaml
+++ b/kubernetes/apps/pulumi/unifi-network/stack.yaml
@@ -87,6 +87,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret


### PR DESCRIPTION
**The Phase 8 cutover switch.** Draft on purpose — the merge gate is at the bottom and is not yet satisfiable. Stacked on #720 (→ #719 → #718); merge in order.

## What flips

- **Operator runs:** `BAO_STORE_READS: "1"` on the eight home-operations Stack CRs (`home-operations`, `authentik`, `backups`, `unifi-network`, `ocracoke`, `gulf-of-mexico`, `applications/equestria`, `applications/sgc`).
- **Local runs:** the same var in `.config/mise.toml` `[env]`, so a laptop run reads the same store the operator does. Local runs now require `eval "$(bootstrap/openbao/pulumi-env.sh)"` (vault repo) first — without OpenBao credentials, `GlobalResources` fails loudly at construction instead of silently using a different store.
- **`vault/stack.yaml` deliberately untouched** — the vault repo's own store cutover is Phase 9; it has no `BaoStore` to flip yet, and pre-setting the var would arm a cutover that repo has not proven.

1Password is still **written** on every run (dual-write) and stays authoritative until Phase 11. This changes only which store reads come from. Rollback = revert this commit.

## Merge gate — all of these, in order

- [ ] #718, #719, #720 merged
- [ ] The producing stacks have RUN since #719/#720 merged (operator resync or manual `up`): `authentik` ✅ (already verified — `_inventory/authentik-outputs` v1), `home-operations`, `ocracoke`, `gulf-of-mexico` (tailscale exports), `backups`, `applications/equestria`, `applications/sgc` (backup plans)
- [ ] `scripts/bao-store-parity.ts` **fully green** — including the `getTailscaleExports` and `getBackupPlans` sections, which stay red until the line above is done
- [ ] Per STATUS.md's procedural rule: judge the first post-flip preview against a same-store control run, comparing resource-operation lines with `*-mkdir` excluded — an ordered-input diff is not a store diff

## After merging

Run one `pulumi preview` per stack and expect **no resource changes** attributable to the store (the eight-stack parity sweep of 2026-08-10 already proved identical previews under `BAO_STORE_READS=1`). The remaining 1Password reads (`proxmoxBackupServers`, the `op://` placeholder resolver) still go through the inherited implementations and warn where designed to — those are the `vals` slice (PLAN §D.1), not this switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)