### PR TITLE
Phase 8 consolidation 1/2: land the tailscale-export and backup-plan flows on main

### DIFF
--- a/components/BackupPlanOrchestrator.ts
+++ b/components/BackupPlanOrchestrator.ts
@@ -1,7 +1,9 @@
 import { FullItem } from "@1password/connect";
 import { OnePasswordItem, TypeEnum } from "@dynamic/1password/OnePasswordItem.ts";
 import type { BackrestPlan, BackrestRepository } from "@openapi/backrest.js";
-import { all, ComponentResource, type ComponentResourceOptions, type Input, jsonStringify, type Output, output } from "@pulumi/pulumi";
+import { all, ComponentResource, type ComponentResourceOptions, type Input, jsonStringify, log, type Output, output } from "@pulumi/pulumi";
+import { baoKvSecret, baoProvenance, baoSlug } from "./bao.ts";
+import type { GlobalResources } from "./globals.ts";
 export interface PreSyncArgs {
   /** SFTP hostname of the host whose data should be staged before the backup */
   sftpHost: string;
@@ -26,7 +28,16 @@ export class BackupPlanOrchestrator extends ComponentResource {
   plans: Output<BackupPlanItem[]> = output([]);
   // sync?:; // what was this for?
 
-  constructor(name: string, opts?: ComponentResourceOptions) {
+  /**
+   * `globals` is here for `baoProvider`/`baoDualWriteEnabled` only — the plan
+   * is cross-stack inventory (PLAN §G-8), and the producing side owns the
+   * OpenBao write.
+   */
+  constructor(
+    name: string,
+    private readonly globals: GlobalResources,
+    opts?: ComponentResourceOptions,
+  ) {
     super("home:backups:BackupPlanOrchestrator", name, {}, opts);
   }
 
@@ -35,7 +46,11 @@ export class BackupPlanOrchestrator extends ComponentResource {
   }
 
   public savePlan(title: string) {
-    return new OnePasswordItem(
+    // One expression serializes for both stores, so the OpenBao copy is
+    // byte-identical to the 1Password field by construction.
+    const plan = jsonStringify({ plans: this.plans });
+
+    const item = new OnePasswordItem(
       `backup-plan`,
       {
         category: FullItem.CategoryEnum.SecureNote,
@@ -44,11 +59,41 @@ export class BackupPlanOrchestrator extends ComponentResource {
         fields: {
           plan: {
             type: TypeEnum.Concealed,
-            value: jsonStringify({ plans: this.plans }),
+            value: plan,
           },
         },
       },
       { parent: this },
     );
+
+    // Phase 8 dual-write (openbao-migration PLAN §G-8): the plan also lands at
+    // its reserved inventory path (`clusters/_inventory/<slug(title)>`, the
+    // tag:backup-plan rule in scripts/op-to-bao/mapping.ts). The 1Password
+    // field is Concealed, so `concealed_fields: plan` keeps the `secret()`
+    // marker on the read side. 1Password stays authoritative until Phase 11 —
+    // written ALONGSIDE the item, never instead of it; rollback is a plain
+    // `git revert`. `BaoStore.getBackupPlans` refuses to serve consumers until
+    // every producing stack has run this once.
+    if (this.globals.baoDualWriteEnabled) {
+      baoKvSecret(
+        `backup-plan-bao`,
+        {
+          mount: "secrets",
+          path: `clusters/_inventory/${baoSlug(title)}`,
+          data: { plan },
+          customMetadata: baoProvenance({
+            source_title: title,
+            source_tags: "backup-plan",
+            contains_secrets: "true",
+            concealed_fields: "plan",
+          }),
+        },
+        { parent: this, provider: this.globals.baoProvider },
+      );
+    } else {
+      log.warn(`No OpenBao credentials (BAO_TOKEN, or BAO_ROLE_ID + BAO_SECRET_ID) — skipping the backup-plan dual-write for '${title}'. 1Password stays authoritative; the inventory path stays stale until a credentialed run.`, this);
+    }
+
+    return item;
   }
 }

--- a/components/store/bao.test.ts
+++ b/components/store/bao.test.ts
@@ -15,8 +15,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { isSecret, runtime } from "@pulumi/pulumi";
-import { assertNotDirectory, BaoStore, baoStoreReadsEnabled, resolveBaoPath, shapeItem, tailscaleExportKeys } from "./bao.ts";
-import { shapeTailscaleExports } from "./index.ts";
+import { assertNotDirectory, backupPlanKeys, BaoStore, baoStoreReadsEnabled, resolveBaoPath, shapeItem, tailscaleExportKeys } from "./bao.ts";
+import { shapeBackupPlans, shapeTailscaleExports } from "./index.ts";
 
 runtime.setMocks({
   newResource: args => ({ id: `${args.name}-id`, state: args.inputs }),
@@ -187,10 +187,8 @@ describe("resolveBaoPath", () => {
     assert.match(r.reason ?? "", /INVENTORY §2/);
   });
 
-  it("keeps not-yet-migrated inventory and cluster definitions on 1Password for now", () => {
-    for (const title of ["Backup Plan", "Cluster: Alpha Site"]) {
-      assert.equal(resolveBaoPath(title).path, undefined, title);
-    }
+  it("keeps cluster-definition titles off OpenBao — they are checked-in code", () => {
+    assert.equal(resolveBaoPath("Cluster: Alpha Site").path, undefined);
   });
 
   it("serves Authentik Outputs from the _inventory path its producer dual-writes", () => {
@@ -198,6 +196,15 @@ describe("resolveBaoPath", () => {
     // merged — verified live 2026-08-11 before the route landed. A consumer
     // switched before that read an empty object rather than an error (§G-8).
     assert.equal(resolveBaoPath("Authentik Outputs").path, "clusters/_inventory/authentik-outputs");
+  });
+
+  it("routes the inventory families to their reserved _inventory paths, never shared/", () => {
+    assert.equal(resolveBaoPath("Backup Plan").path, "clusters/_inventory/backup-plan");
+    assert.equal(resolveBaoPath("Equestria Backup Plan").path, "clusters/_inventory/equestria-backup-plan");
+    assert.equal(resolveBaoPath("Stargate Command Backup Plan").path, "clusters/_inventory/stargate-command-backup-plan");
+    assert.equal(resolveBaoPath("Tailscale Export - home-operations").path, "clusters/_inventory/tailscale-export-home-operations");
+    // A title merely containing the words is not the family.
+    assert.equal(resolveBaoPath("Backup Plan Review Notes").path, "shared/backup-plan-review-notes");
   });
 
   it("does not slug a UUID-addressed item into a UUID-shaped path", () => {
@@ -258,6 +265,35 @@ describe("shapeTailscaleExports", () => {
   it("tolerates the pre-rename `ip` key", () => {
     const shaped = shapeTailscaleExports([item("home-operations", { node: { ip: "100.1.1.3", internalIp: "10.0.0.3", mac: "cc", nodeType: "pbs" } })]);
     assert.equal(shaped[0].hosts[0].externalIp, "100.1.1.3");
+  });
+});
+
+describe("backupPlanKeys", () => {
+  const complete = ["backup-plan", "equestria-backup-plan", "stargate-command-backup-plan"];
+
+  it("selects the bare key and the -backup-plan suffixed keys, nothing else", () => {
+    assert.deepEqual(backupPlanKeys(["authentik-outputs", "tailscale-export-ocracoke", ...complete]), complete);
+  });
+
+  it("refuses an empty or torn inventory, naming what is missing", () => {
+    // A smaller list here quietly shrinks what the directors back up — a
+    // failure with no symptom until a restore is needed.
+    assert.throws(() => backupPlanKeys([]), /missing backup-plan, equestria-backup-plan, stargate-command-backup-plan/);
+    assert.throws(() => backupPlanKeys(complete.filter(k => k !== "equestria-backup-plan")), /missing equestria-backup-plan/);
+  });
+
+  it("includes plans beyond the known set — a floor, not a ceiling", () => {
+    assert.deepEqual(backupPlanKeys([...complete, "luna-backup-plan"]), [...complete, "luna-backup-plan"]);
+  });
+});
+
+describe("shapeBackupPlans", () => {
+  it("flattens every item's plans into one list", () => {
+    const shaped = shapeBackupPlans<{ name: string }>([{ plan: JSON.stringify({ plans: [{ name: "a" }, { name: "b" }] }) }, { plan: JSON.stringify({ plans: [{ name: "c" }] }) }]);
+    assert.deepEqual(
+      shaped.map(p => p.name),
+      ["a", "b", "c"],
+    );
   });
 });
 

--- a/components/store/bao.test.ts
+++ b/components/store/bao.test.ts
@@ -15,7 +15,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { isSecret, runtime } from "@pulumi/pulumi";
-import { assertNotDirectory, BaoStore, baoStoreReadsEnabled, resolveBaoPath, shapeItem } from "./bao.ts";
+import { assertNotDirectory, BaoStore, baoStoreReadsEnabled, resolveBaoPath, shapeItem, tailscaleExportKeys } from "./bao.ts";
+import { shapeTailscaleExports } from "./index.ts";
 
 runtime.setMocks({
   newResource: args => ({ id: `${args.name}-id`, state: args.inputs }),
@@ -205,6 +206,58 @@ describe("resolveBaoPath", () => {
     const r = resolveBaoPath("soz3lyvs6k24e5gh3udqp4sngi");
     assert.equal(r.path, undefined);
     assert.match(r.reason ?? "", /addressed by UUID/);
+  });
+});
+
+describe("tailscaleExportKeys", () => {
+  const complete = ["tailscale-export-gulf-of-mexico", "tailscale-export-home-operations", "tailscale-export-ocracoke"];
+
+  it("selects only the tailscale-export keys from an _inventory LIST", () => {
+    // The prefix also holds authentik-outputs and (later) the backup plans;
+    // neither is a tailscale export.
+    assert.deepEqual(tailscaleExportKeys(["authentik-outputs", ...complete]), complete);
+  });
+
+  it("refuses an EMPTY inventory rather than returning []", () => {
+    // [] here would flow into stacks/unifi-network as "the estate has no
+    // nodes" and start removing live ACL grants — the §G-8 failure, silent.
+    assert.throws(() => tailscaleExportKeys(["authentik-outputs"]), /incomplete .* missing tailscale-export-gulf-of-mexico, tailscale-export-home-operations, tailscale-export-ocracoke/);
+  });
+
+  it("refuses a TORN inventory, naming the stack that has not run", () => {
+    assert.throws(() => tailscaleExportKeys(complete.filter(k => k !== "tailscale-export-ocracoke")), /missing tailscale-export-ocracoke/);
+  });
+
+  it("includes exports beyond the known set — the list is a floor, not a ceiling", () => {
+    assert.deepEqual(tailscaleExportKeys([...complete, "tailscale-export-new-stack"]), [...complete, "tailscale-export-new-stack"]);
+  });
+});
+
+describe("shapeTailscaleExports", () => {
+  // One shaping function serves both stores; these pin the behaviors the
+  // unifi-network consumers depend on.
+  const item = (name: string, hosts: Record<string, unknown>, services?: string) => ({ name, ...(services === undefined ? {} : { services }), ...hosts });
+
+  it("splits node objects from flat fields and sorts at both levels", () => {
+    const shaped = shapeTailscaleExports([
+      item("ocracoke", { zebra: { externalIp: "100.1.1.2", internalIp: "10.0.0.2", mac: "bb", nodeType: "dockge" }, alpha: { externalIp: "100.1.1.1", internalIp: "10.0.0.1", mac: "aa", nodeType: "proxmox" } }),
+      item("gulf-of-mexico", {}, "[\"svc:llm\"]"),
+    ]);
+    assert.deepEqual(
+      shaped.map(z => z.name),
+      ["gulf-of-mexico", "ocracoke"],
+    );
+    assert.deepEqual(
+      shaped[1].hosts.map(h => h.name),
+      ["alpha", "zebra"],
+    );
+    assert.deepEqual(shaped[0].services, ["svc:llm"]);
+    assert.deepEqual(shaped[1].services, []);
+  });
+
+  it("tolerates the pre-rename `ip` key", () => {
+    const shaped = shapeTailscaleExports([item("home-operations", { node: { ip: "100.1.1.3", internalIp: "10.0.0.3", mac: "cc", nodeType: "pbs" } })]);
+    assert.equal(shaped[0].hosts[0].externalIp, "100.1.1.3");
   });
 });
 

--- a/components/store/bao.ts
+++ b/components/store/bao.ts
@@ -19,8 +19,8 @@
  *
  * Still on 1Password after this file (each is a later slice):
  *
- *   getBackupPlans                 producer-side write-back moves to OpenBao
- *   proxmoxBackupServers           waits on the remaining inventory flows
+ *   proxmoxBackupServers           its items reference dockge/cluster items by
+ *                                  title; moves once those reads are proven
  *   replaceOnePasswordPlaceholders `vals` replaces it (PLAN §D.1)
  *
  * ## Field shapes carry over unchanged
@@ -48,7 +48,7 @@
 import { all, log, type Output, output, secret } from "@pulumi/pulumi";
 import { BaoClient, baoSlug } from "../bao.ts";
 import { CLUSTERS, type ClusterEntry, clusterBySourceTitle, clusterSecretPath } from "./clusters.ts";
-import { shapeTailscaleExports, VaultStore } from "./index.ts";
+import { shapeBackupPlans, shapeTailscaleExports, VaultStore } from "./index.ts";
 import type { Meta } from "./interfaces.ts";
 
 /** The KV v2 mount every credential lives in. `docs` holds reference material. */
@@ -69,6 +69,13 @@ const TAILSCALE_EXPORT_PREFIX = "tailscale-export-";
  * `getTailscaleExports` refuses a partial set — see the override for why.
  */
 const TAILSCALE_EXPORT_STACKS = ["gulf-of-mexico", "home-operations", "ocracoke"];
+
+/**
+ * The plans `BackupPlanOrchestrator.savePlan` produces today: `Backup Plan`
+ * from stacks/backups, `<Cluster Title> Backup Plan` from each applications
+ * stack. `getBackupPlans` refuses a partial set — see the override for why.
+ */
+const BACKUP_PLAN_KEYS = ["backup-plan", "equestria-backup-plan", "stargate-command-backup-plan"];
 
 /**
  * Whether stacks read secrets from OpenBao instead of 1Password.
@@ -201,6 +208,29 @@ export class BaoStore extends VaultStore {
       .apply(items => shapeTailscaleExports(items)) as ReturnType<VaultStore["getTailscaleExports"]>;
   }
 
+  /**
+   * `tag:backup-plan` became the `*backup-plan` keys under
+   * `clusters/_inventory/` — one per producing stack, dual-written by
+   * `BackupPlanOrchestrator.savePlan`.
+   *
+   * Same refusal as `getTailscaleExports`, same reason: the three
+   * `BackupPlanDirector`s create backrest plans from this list, so a torn
+   * inventory quietly shrinks the set of things being backed up — a failure
+   * with no symptom until a restore is needed. See `backupPlanKeys`.
+   */
+  public override getBackupPlans<T>() {
+    return output(this.bao.list(SECRETS_MOUNT, INVENTORY_PREFIX))
+      .apply(keys =>
+        all(
+          backupPlanKeys(keys).map(key => {
+            assertNotDirectory(INVENTORY_PREFIX, key);
+            return this.read(`${INVENTORY_PREFIX}/${key}`);
+          }),
+        ),
+      )
+      .apply(items => shapeBackupPlans<T>(items as unknown as { plan: string }[])) as ReturnType<VaultStore["getBackupPlans"]> & Output<T[]>;
+  }
+
   private listUnder(prefix: string): Output<BaoItem[]> {
     return output(this.bao.list(SECRETS_MOUNT, prefix)).apply(keys =>
       all(
@@ -238,7 +268,6 @@ const CLUSTER_KEYS = ["equestria", "sgc", "celestia", "luna", "skystar", "alpha-
  */
 const NOT_IN_OPENBAO: Record<string, string> = {
   "OpenBao Alpha Site Static Unseal": "seal-chain material; INVENTORY §2 forbids it from ever living in OpenBao",
-  "Backup Plan": "cross-stack inventory; moves to secrets/clusters/_inventory/ in a later Phase 8 slice",
 };
 
 /**
@@ -286,6 +315,15 @@ export function resolveBaoPath(title: string): { path: string; reason?: undefine
   const inventory = INVENTORY_IN_OPENBAO[title];
   if (inventory) return { path: inventory };
 
+  // The tag-shaped inventory families (`Backup Plan`, `<Title> Backup Plan`,
+  // `Tailscale Export - <stack>`). Every consumer reads these through
+  // `getBackupPlans`/`getTailscaleExports` rather than by title, but a title
+  // reaching this resolver must still land on the reserved _inventory path —
+  // the default rule below would derive `shared/…`, a path that never exists.
+  if (/(^| )Backup Plan$/.test(title) || /^Tailscale Export - .+$/.test(title)) {
+    return { path: `${INVENTORY_PREFIX}/${baoSlug(title)}` };
+  }
+
   if (title.startsWith("Cluster: ")) return { reason: "cluster definitions become checked-in code in a later Phase 8 slice" };
 
   // 1Password item ids are 26 lowercase base32 characters. A title that IS one
@@ -321,6 +359,23 @@ export function tailscaleExportKeys(keys: string[]): string[] {
     );
   }
   return exports;
+}
+
+/**
+ * The `*backup-plan` keys to read from an `_inventory` LIST — or an error
+ * when the set is not complete. Same floor-not-ceiling contract as
+ * `tailscaleExportKeys`; exported for its tests.
+ */
+export function backupPlanKeys(keys: string[]): string[] {
+  const plans = keys.filter(key => key === "backup-plan" || key.endsWith("-backup-plan"));
+  const missing = BACKUP_PLAN_KEYS.filter(key => !plans.includes(key));
+  if (missing.length > 0) {
+    throw new Error(
+      `backup-plan inventory is incomplete under ${SECRETS_MOUNT}/${INVENTORY_PREFIX}/ — missing ${missing.join(", ")}. ` +
+        `Each producing stack must run its dual-write before any consumer reads OpenBao (PLAN §G-8: dual-write, producer run, THEN the reader).`,
+    );
+  }
+  return plans;
 }
 
 /**

--- a/components/store/bao.ts
+++ b/components/store/bao.ts
@@ -20,8 +20,7 @@
  * Still on 1Password after this file (each is a later slice):
  *
  *   getBackupPlans                 producer-side write-back moves to OpenBao
- *   getTailscaleExports            same
- *   proxmoxBackupServers           needs both of the above to resolve
+ *   proxmoxBackupServers           waits on the remaining inventory flows
  *   replaceOnePasswordPlaceholders `vals` replaces it (PLAN §D.1)
  *
  * ## Field shapes carry over unchanged
@@ -49,11 +48,27 @@
 import { all, log, type Output, output, secret } from "@pulumi/pulumi";
 import { BaoClient, baoSlug } from "../bao.ts";
 import { CLUSTERS, type ClusterEntry, clusterBySourceTitle, clusterSecretPath } from "./clusters.ts";
-import { VaultStore } from "./index.ts";
+import { shapeTailscaleExports, VaultStore } from "./index.ts";
 import type { Meta } from "./interfaces.ts";
 
 /** The KV v2 mount every credential lives in. `docs` holds reference material. */
 const SECRETS_MOUNT = "secrets";
+
+/**
+ * Where cross-stack inventory lives (PLAN §G-8) — values PRODUCED by one
+ * Pulumi stack and read by others, dual-written because `StackReference`
+ * cannot cross this repo's per-stack backends.
+ */
+const INVENTORY_PREFIX = "clusters/_inventory";
+
+/** Key prefix of one stack's tailscale export: `tailscale-export-<stack>`. */
+const TAILSCALE_EXPORT_PREFIX = "tailscale-export-";
+
+/**
+ * The stacks that call `TailscaleMonitor.exportNodeStateToOnePassword` today.
+ * `getTailscaleExports` refuses a partial set — see the override for why.
+ */
+const TAILSCALE_EXPORT_STACKS = ["gulf-of-mexico", "home-operations", "ocracoke"];
 
 /**
  * Whether stacks read secrets from OpenBao instead of 1Password.
@@ -162,6 +177,30 @@ export class BaoStore extends VaultStore {
     return this.listUnder("hosts/dockge") as ReturnType<VaultStore["getDockgeInstances"]>;
   }
 
+  /**
+   * `tag:tailscale-export` became the `tailscale-export-*` keys under
+   * `clusters/_inventory/` — one per producing stack, dual-written by
+   * `TailscaleMonitor` at the paths mapping.yaml reserves.
+   *
+   * An incomplete set (including an empty one) is an ERROR, never a smaller
+   * result — see `tailscaleExportKeys`. This feeds ACL grants and DHCP
+   * reservations in `stacks/unifi-network`; a reader switched before the
+   * producers ran would compute an empty estate and start REMOVING live
+   * config — the exact §G-8 failure, made loud.
+   */
+  public override getTailscaleExports() {
+    return output(this.bao.list(SECRETS_MOUNT, INVENTORY_PREFIX))
+      .apply(keys =>
+        all(
+          tailscaleExportKeys(keys).map(key => {
+            assertNotDirectory(INVENTORY_PREFIX, key);
+            return this.read(`${INVENTORY_PREFIX}/${key}`);
+          }),
+        ),
+      )
+      .apply(items => shapeTailscaleExports(items)) as ReturnType<VaultStore["getTailscaleExports"]>;
+  }
+
   private listUnder(prefix: string): Output<BaoItem[]> {
     return output(this.bao.list(SECRETS_MOUNT, prefix)).apply(keys =>
       all(
@@ -261,6 +300,27 @@ export function resolveBaoPath(title: string): { path: string; reason?: undefine
   }
 
   return { path: `shared/${baoSlug(title)}` };
+}
+
+/**
+ * The `tailscale-export-*` keys to read from an `_inventory` LIST — or an
+ * error when the set is not complete.
+ *
+ * Exported for its tests. A MISSING known stack is an error rather than a
+ * smaller result because two of three stacks having run is a torn inventory
+ * that shapes into a plausible, incomplete estate; stacks beyond the known set
+ * are included automatically, so the list is a floor, not a ceiling.
+ */
+export function tailscaleExportKeys(keys: string[]): string[] {
+  const exports = keys.filter(key => key.startsWith(TAILSCALE_EXPORT_PREFIX));
+  const missing = TAILSCALE_EXPORT_STACKS.filter(stack => !exports.includes(`${TAILSCALE_EXPORT_PREFIX}${stack}`));
+  if (missing.length > 0) {
+    throw new Error(
+      `tailscale-export inventory is incomplete under ${SECRETS_MOUNT}/${INVENTORY_PREFIX}/ — missing ${missing.map(stack => `${TAILSCALE_EXPORT_PREFIX}${stack}`).join(", ")}. ` +
+        `Each producing stack must run its dual-write before any consumer reads OpenBao (PLAN §G-8: dual-write, producer run, THEN the reader).`,
+    );
+  }
+  return exports;
 }
 
 /**

--- a/components/store/index.ts
+++ b/components/store/index.ts
@@ -68,33 +68,7 @@ export class VaultStore {
           ),
         ),
       )
-      .apply(items => {
-        // Sorted at both levels — the exported node name drives ACL tests/grant dsts, and the
-        // 1Password item title it is sorted by upstream can diverge from it.
-        return items
-          .map(item => {
-            return {
-              name: item.name as unknown as string,
-              services: item.services ? (JSON.parse(item.services as unknown as string) as string[]) : [],
-              hosts: Object.entries(item)
-                .filter(([_key, value]) => typeof value === "object" && !Array.isArray(value) && value !== null && ("externalIp" in value || "ip" in value))
-                .map(
-                  // `ip` fallback tolerates items written before the externalIp rename;
-                  // safe to drop once every exporting stack has redeployed.
-                  ([key, value]) =>
-                    ({ name: key, ...value, externalIp: (value as { externalIp?: string; ip?: string }).externalIp ?? (value as { ip?: string }).ip }) as {
-                      name: string;
-                      externalIp: string;
-                      internalIp: string;
-                      mac: string;
-                      nodeType: "dockge" | "proxmox" | "pbs" | "truenas";
-                    },
-                )
-                .sort((a, b) => a.name.localeCompare(b.name)),
-            };
-          })
-          .sort((a, b) => a.name.localeCompare(b.name));
-      });
+      .apply(shapeTailscaleExports);
   }
 
   public getKubeConfig(title: string) {
@@ -180,6 +154,50 @@ export class VaultStore {
         return output(value).apply(v => v.replace(this.vaultRegex, fullMatch => items.get(fullMatch) || fullMatch));
       });
   }
+}
+
+/**
+ * Item-shaped tailscale exports → the object every consumer reads.
+ *
+ * Shared between `VaultStore` (items found by `tag:tailscale-export`) and
+ * `BaoStore` (paths listed under `clusters/_inventory/tailscale-export-*`) so
+ * the two stores cannot drift in the TRANSFORM — the parity script compares the
+ * data, this function being singular is what makes the shaping identical.
+ */
+export function shapeTailscaleExports(
+  items: {
+    [key: string]: unknown;
+  }[],
+): {
+  name: string;
+  services: string[];
+  hosts: { name: string; externalIp: string; internalIp: string; mac: string; nodeType: "dockge" | "proxmox" | "pbs" | "truenas" }[];
+}[] {
+  // Sorted at both levels — the exported node name drives ACL tests/grant dsts, and the
+  // 1Password item title it is sorted by upstream can diverge from it.
+  return items
+    .map(item => {
+      return {
+        name: item.name as string,
+        services: item.services ? (JSON.parse(item.services as string) as string[]) : [],
+        hosts: Object.entries(item)
+          .filter(([_key, value]) => typeof value === "object" && !Array.isArray(value) && value !== null && ("externalIp" in value || "ip" in value))
+          .map(
+            // `ip` fallback tolerates items written before the externalIp rename;
+            // safe to drop once every exporting stack has redeployed.
+            ([key, value]) =>
+              ({ name: key, ...value, externalIp: (value as { externalIp?: string; ip?: string }).externalIp ?? (value as { ip?: string }).ip }) as {
+                name: string;
+                externalIp: string;
+                internalIp: string;
+                mac: string;
+                nodeType: "dockge" | "proxmox" | "pbs" | "truenas";
+              },
+          )
+          .sort((a, b) => a.name.localeCompare(b.name)),
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export function getSecretItem<T = { urls: { href: string; label?: string }[] }>(item: Pick<OnePasswordItem, "title" | "category" | "tags" | "urls" | "fields" | "files" | "sections">): Output<Unwrap<T & Meta>> {

--- a/components/store/index.ts
+++ b/components/store/index.ts
@@ -48,8 +48,8 @@ export class VaultStore {
 
   public getBackupPlans<T>() {
     return output(op().findItemsByTag("backup-plan"))
-      .apply(items => all(items.map(getSecretItem<{ plan: string }>)).apply(items => items.map(item => JSON.parse(item.plan) as { plans: T[] })))
-      .apply(plans => plans.flatMap(z => z.plans));
+      .apply(items => all(items.map(getSecretItem<{ plan: string }>)))
+      .apply(items => shapeBackupPlans<T>(items));
   }
 
   public getTailscaleExports() {
@@ -154,6 +154,18 @@ export class VaultStore {
         return output(value).apply(v => v.replace(this.vaultRegex, fullMatch => items.get(fullMatch) || fullMatch));
       });
   }
+}
+
+/**
+ * Item-shaped backup plans → the flat plan list the directors consume.
+ *
+ * Shared between `VaultStore` (items found by `tag:backup-plan`) and
+ * `BaoStore` (paths listed under `clusters/_inventory/*backup-plan`) for the
+ * same reason as `shapeTailscaleExports` below: one transform, so the stores
+ * can only differ in data.
+ */
+export function shapeBackupPlans<T>(items: { plan: string }[]): T[] {
+  return items.map(item => JSON.parse(item.plan) as { plans: T[] }).flatMap(z => z.plans);
 }
 
 /**

--- a/components/tailscale.ts
+++ b/components/tailscale.ts
@@ -1,6 +1,7 @@
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { FullItem } from "@1password/connect";
+import { baoKvSecret, baoProvenance, baoSlug } from "@components/bao.ts";
 import { OnePasswordItem, type OnePasswordItemSectionInput } from "@dynamic/1password/OnePasswordItem.ts";
 import type { TailscaleCidr } from "@openapi/tailscale-grants.js";
 import { remote, type types } from "@pulumi/command";
@@ -86,6 +87,13 @@ export function getTailscaleIp(name: pulumi.Input<string>, globals: GlobalResour
 
 export class TailscaleMonitor {
   private readonly services: string[] = [];
+  /**
+   * `globals` is here for `baoProvider`/`baoDualWriteEnabled` only — the
+   * monitor itself needs nothing else from it. Threading it through the
+   * construction sites is what PLAN §G-8 costs: the export is cross-stack
+   * inventory, and the producing side owns the OpenBao write.
+   */
+  constructor(private readonly globals: GlobalResources) {}
   public addService(name: string) {
     this.services.push(name);
   }
@@ -95,11 +103,13 @@ export class TailscaleMonitor {
       fields: Object.fromEntries(nodeState.map(z => [z.name, { value: z.externalIp }] as const)),
     };
 
-    return new OnePasswordItem(
-      `${pulumi.runtime.getStack()}-tailnet`,
+    const stack = pulumi.runtime.getStack();
+    const title = `Tailscale Export - ${stack}`;
+    const item = new OnePasswordItem(
+      `${stack}-tailnet`,
       {
         category: FullItem.CategoryEnum.SecureNote,
-        title: `Tailscale Export - ${pulumi.runtime.getStack()}`,
+        title: title,
         tags: ["tailscale-export"],
         sections: pulumi.output(nodeState).apply(nodes =>
           Object.fromEntries(
@@ -122,12 +132,56 @@ export class TailscaleMonitor {
           ),
         ),
         fields: {
-          name: { value: pulumi.runtime.getStack() },
+          name: { value: stack },
           services: { value: pulumi.jsonStringify(this.services) },
         },
       },
       cro,
     );
+
+    // Phase 8 dual-write (openbao-migration PLAN §G-8): the export also lands
+    // at its reserved inventory path (`clusters/_inventory/<slug(title)>`, the
+    // tag:tailscale-export rule in scripts/op-to-bao/mapping.ts) with the exact
+    // field shape of the OnePasswordItem above — `name`/`services` flat, one
+    // nested object per node. 1Password stays authoritative until Phase 11 —
+    // written ALONGSIDE the item, never instead of it; rollback is a plain
+    // `git revert`. `BaoStore.getTailscaleExports` refuses to serve consumers
+    // until every producing stack has run this once.
+    if (this.globals.baoDualWriteEnabled) {
+      baoKvSecret(
+        `${stack}-tailnet-bao`,
+        {
+          mount: "secrets",
+          path: `clusters/_inventory/${baoSlug(title)}`,
+          data: pulumi.output(nodeState).apply(nodes => ({
+            name: stack,
+            services: pulumi.jsonStringify(this.services),
+            ...Object.fromEntries(
+              [...nodes]
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map(
+                  z =>
+                    [
+                      z.name,
+                      {
+                        externalIp: z.externalIp,
+                        internalIp: z.internalIp,
+                        mac: z.mac,
+                        nodeType: z.nodeType ?? "unknown",
+                      },
+                    ] as const,
+                ),
+            ),
+          })),
+          customMetadata: baoProvenance({ source_title: title, source_tags: "tailscale-export" }),
+        },
+        pulumi.mergeOptions(cro, { provider: this.globals.baoProvider }) as pulumi.CustomResourceOptions,
+      );
+    } else {
+      pulumi.log.warn(`No OpenBao credentials (BAO_TOKEN, or BAO_ROLE_ID + BAO_SECRET_ID) — skipping the tailscale-export dual-write for ${stack}. 1Password stays authoritative; the inventory path stays stale until a credentialed run.`);
+    }
+
+    return item;
   }
 }
 

--- a/scripts/bao-store-parity.ts
+++ b/scripts/bao-store-parity.ts
@@ -221,4 +221,37 @@ try {
   console.log(`FAIL  Authentik Outputs (inventory): ${error instanceof Error ? error.message : String(error)}`);
 }
 
+// Tailscale exports: produced by three stacks, consumed by unifi-network's ACL
+// and DHCP generation — the read where a wrong SET quietly removes live
+// config. Both stores shape through the same function, so what is compared
+// here is the data each store found. This section FAILS until every producing
+// stack has run its dual-write; that failing is the §G-8 gate doing its job —
+// do not flip BAO_STORE_READS while it is red.
+try {
+  const [a, b] = await Promise.all([resolve(op.getTailscaleExports()), resolve(bao.getTailscaleExports())]);
+  const aJson = JSON.stringify(a);
+  const bJson = JSON.stringify(b);
+  if (aJson === bJson) {
+    console.log(`OK    getTailscaleExports (${a.length} stacks, ${a.reduce((n, e) => n + e.hosts.length, 0)} hosts)`);
+  } else {
+    failures++;
+    console.log("DIFF  getTailscaleExports");
+    console.log(`        tag:tailscale-export   ${a.map(e => `${e.name}(${e.hosts.length})`).join(", ")}`);
+    console.log(`        _inventory/            ${b.map(e => `${e.name}(${e.hosts.length})`).join(", ")}`);
+    // IPs and MACs are addressing, not credentials, but stay consistent with
+    // the rest of this script: name the hosts, never print field values.
+    for (const exp of a) {
+      const other = b.find(e => e.name === exp.name);
+      if (!other) continue;
+      const drifted = exp.hosts.filter(h => JSON.stringify(h) !== JSON.stringify(other.hosts.find(o => o.name === h.name)));
+      if (drifted.length || JSON.stringify(exp.services) !== JSON.stringify(other.services)) {
+        console.log(`        ${exp.name}: differing hosts: ${drifted.map(h => h.name).join(", ") || "none"}${JSON.stringify(exp.services) !== JSON.stringify(other.services) ? "; services differ" : ""}`);
+      }
+    }
+  }
+} catch (error) {
+  failures++;
+  console.log(`FAIL  getTailscaleExports: ${error instanceof Error ? error.message : String(error)}`);
+}
+
 process.exit(failures === 0 ? 0 : 1);

--- a/scripts/bao-store-parity.ts
+++ b/scripts/bao-store-parity.ts
@@ -254,4 +254,29 @@ try {
   console.log(`FAIL  getTailscaleExports: ${error instanceof Error ? error.message : String(error)}`);
 }
 
+// Backup plans: produced by stacks/backups and both applications stacks,
+// consumed by the three BackupPlanDirectors. A wrong SET here silently shrinks
+// what gets backed up. Same gate semantics as getTailscaleExports: this
+// section FAILS until every producing stack has run its dual-write — do not
+// flip BAO_STORE_READS while it is red.
+try {
+  const [a, b] = await Promise.all([resolve(op.getBackupPlans<{ source: string; name: string }>()), resolve(bao.getBackupPlans<{ source: string; name: string }>())]);
+  const key = (plans: { source: string; name: string }[]) =>
+    plans
+      .map(p => `${p.source}/${p.name}`)
+      .sort()
+      .join(", ");
+  if (JSON.stringify([...a].sort((x, y) => `${x.source}/${x.name}`.localeCompare(`${y.source}/${y.name}`))) === JSON.stringify([...b].sort((x, y) => `${x.source}/${x.name}`.localeCompare(`${y.source}/${y.name}`)))) {
+    console.log(`OK    getBackupPlans (${a.length} plans)`);
+  } else {
+    failures++;
+    console.log("DIFF  getBackupPlans");
+    console.log(`        tag:backup-plan   ${key(a)}`);
+    console.log(`        _inventory/       ${key(b)}`);
+  }
+} catch (error) {
+  failures++;
+  console.log(`FAIL  getBackupPlans: ${error instanceof Error ? error.message : String(error)}`);
+}
+
 process.exit(failures === 0 ? 0 : 1);

--- a/stacks/applications/kubernetes.ts
+++ b/stacks/applications/kubernetes.ts
@@ -173,7 +173,7 @@ export async function kubernetesApplications(globals: GlobalResources, outputs: 
     },
     { parent: applicationManager.outpostsComponent, deleteBeforeReplace: true },
   );
-  const backupPlanOrchestrator = new BackupPlanOrchestrator("backup-plan-orchestrator");
+  const backupPlanOrchestrator = new BackupPlanOrchestrator("backup-plan-orchestrator", globals);
 
   await awaitOutput(
     pulumi.all([kubernetesBackups(globals, backupPlanOrchestrator, clusterDefinition)]).apply(() => {

--- a/stacks/backups/index.ts
+++ b/stacks/backups/index.ts
@@ -5,7 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 const globals = new GlobalResources({}, {});
 const dockgeDetails = globals.store.getDockgeInstances();
 
-const backupPlanOrchestrator = new BackupPlanOrchestrator("backup-plan-orchestrator");
+const backupPlanOrchestrator = new BackupPlanOrchestrator("backup-plan-orchestrator", globals);
 
 const dockgeInstances = dockgeDetails.apply(details => {
   return details.map(detail => {

--- a/stacks/gulf-of-mexico/index.ts
+++ b/stacks/gulf-of-mexico/index.ts
@@ -11,7 +11,7 @@ import { ProxmoxBackupServerLxc } from "../../components/ProxmoxBackupServerLxc.
 import { getProxmoxProperties, ProxmoxHost } from "../../components/ProxmoxHost.ts";
 
 const globals = new GlobalResources({}, {});
-const monitor = new TailscaleMonitor();
+const monitor = new TailscaleMonitor(globals);
 const backupDirector = new BackupPlanDirector("backup-plan-director", {
   globals,
 });

--- a/stacks/home/index.ts
+++ b/stacks/home/index.ts
@@ -17,7 +17,7 @@ import { createGatusDnsUptime } from "../../components/StandardDns.ts";
 import { TruenasVm } from "../../components/TruenasVm.ts";
 
 const globals = new GlobalResources({}, {});
-const monitor = new TailscaleMonitor();
+const monitor = new TailscaleMonitor(globals);
 const backupDirector = new BackupPlanDirector("backup-plan-director", {
   globals,
 });

--- a/stacks/ocracoke/index.ts
+++ b/stacks/ocracoke/index.ts
@@ -12,7 +12,7 @@ import { ProxmoxBackupServerLxc } from "../../components/ProxmoxBackupServerLxc.
 import { getProxmoxProperties, ProxmoxHost } from "../../components/ProxmoxHost.ts";
 
 const globals = new GlobalResources({}, {});
-const monitor = new TailscaleMonitor();
+const monitor = new TailscaleMonitor(globals);
 const backupDirector = new BackupPlanDirector("backup-plan-director", {
   globals,
 });


### PR DESCRIPTION
**Why this PR exists:** #719, #720 and #721 were merged, but as stacked PRs their merges landed in their *base branches*, not `main` — GitHub only retargets a stacked PR to main when its base branch is deleted, and the branches were kept. `origin/main` HEAD is the #718 merge; the operator has been running exactly that (all nine stacks green, `BAO_STORE_READS` absent from the live Stack CRs — verified live).

This PR fast-forwards main with the already-reviewed, already-approved content of **#719 + #720** (this branch carries both merge commits). Zero new changes — compare the diff against those two PRs.

**Merge this one first.** The producing stacks then run their dual-writes on the next reconcile (BAO credentials are already on every Stack CR): home-operations / ocracoke / gulf-of-mexico write the three `tailscale-export-*` paths, backups / applications×2 write the three `*backup-plan` paths. `BAO_STORE_READS` is *not* in this PR, so reads stay on 1Password throughout — no consumer can hit the guarded reads yet.

Consolidation 2/2 (the #721 flip) follows once the six inventory paths exist and `scripts/bao-store-parity.ts` is fully green — the original merge gate, now restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)