### PR TITLE
Phase 8 consolidation 2/2: land the BAO_STORE_READS flip on main

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -52,6 +52,12 @@ CONNECT_VAULT = "Eris"
 CONNECT_TOKEN = "op://Eris/Eris 1Password Connect Access Token/credential"
 AUTHENTIK_TOKEN = "op://Eris/Authentik Token/credential"
 AUTHENTIK_URL = "op://Eris/Authentik Token/url"
+# Phase 8 cutover: local runs read secrets from OpenBao (BaoStore), matching
+# the operator's Stack CRs. Local runs now REQUIRE the OpenBao credentials —
+# eval "$(bootstrap/openbao/pulumi-env.sh)" from the vault repo first; without
+# them GlobalResources fails loudly at construction rather than silently
+# reading a different store than the operator does.
+BAO_STORE_READS = "1"
 # UNIFI_HOST = "unifi.driscoll.tech"
 # UNIFI_USERNAME = "op://Eris/unifipoller/username"
 # UNIFI_PASSWORD = "op://Eris/unifipoller/password"

--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -22,6 +22,10 @@ pulumi = "3.256.0"
 "github:eljulians/skillfile" = { version = "v1.9.1", bin = "skillfile" }
 "github:home-operations/flate" = "v0.5.0"
 dotnet = { version = "10.0.203" }
+# Secret-reference resolver for ref+openbao:// (PLAN §D.1). Keep this version
+# in step with the vals initContainer in kubernetes/apps/pulumi/*/stack.yaml —
+# the workspace pods install the same pin via mise.
+vals = "0.45.0"
 
 [tasks.update]
 description = 'Update all apps that have an update script'

--- a/components/BackupPlanOrchestrator.ts
+++ b/components/BackupPlanOrchestrator.ts
@@ -1,7 +1,9 @@
 import { FullItem } from "@1password/connect";
 import { OnePasswordItem, TypeEnum } from "@dynamic/1password/OnePasswordItem.ts";
 import type { BackrestPlan, BackrestRepository } from "@openapi/backrest.js";
-import { all, ComponentResource, type ComponentResourceOptions, type Input, jsonStringify, type Output, output } from "@pulumi/pulumi";
+import { all, ComponentResource, type ComponentResourceOptions, type Input, jsonStringify, log, type Output, output } from "@pulumi/pulumi";
+import { baoKvSecret, baoProvenance, baoSlug } from "./bao.ts";
+import type { GlobalResources } from "./globals.ts";
 export interface PreSyncArgs {
   /** SFTP hostname of the host whose data should be staged before the backup */
   sftpHost: string;
@@ -26,7 +28,16 @@ export class BackupPlanOrchestrator extends ComponentResource {
   plans: Output<BackupPlanItem[]> = output([]);
   // sync?:; // what was this for?
 
-  constructor(name: string, opts?: ComponentResourceOptions) {
+  /**
+   * `globals` is here for `baoProvider`/`baoDualWriteEnabled` only — the plan
+   * is cross-stack inventory (PLAN §G-8), and the producing side owns the
+   * OpenBao write.
+   */
+  constructor(
+    name: string,
+    private readonly globals: GlobalResources,
+    opts?: ComponentResourceOptions,
+  ) {
     super("home:backups:BackupPlanOrchestrator", name, {}, opts);
   }
 
@@ -35,7 +46,11 @@ export class BackupPlanOrchestrator extends ComponentResource {
   }
 
   public savePlan(title: string) {
-    return new OnePasswordItem(
+    // One expression serializes for both stores, so the OpenBao copy is
+    // byte-identical to the 1Password field by construction.
+    const plan = jsonStringify({ plans: this.plans });
+
+    const item = new OnePasswordItem(
       `backup-plan`,
       {
         category: FullItem.CategoryEnum.SecureNote,
@@ -44,11 +59,41 @@ export class BackupPlanOrchestrator extends ComponentResource {
         fields: {
           plan: {
             type: TypeEnum.Concealed,
-            value: jsonStringify({ plans: this.plans }),
+            value: plan,
           },
         },
       },
       { parent: this },
     );
+
+    // Phase 8 dual-write (openbao-migration PLAN §G-8): the plan also lands at
+    // its reserved inventory path (`clusters/_inventory/<slug(title)>`, the
+    // tag:backup-plan rule in scripts/op-to-bao/mapping.ts). The 1Password
+    // field is Concealed, so `concealed_fields: plan` keeps the `secret()`
+    // marker on the read side. 1Password stays authoritative until Phase 11 —
+    // written ALONGSIDE the item, never instead of it; rollback is a plain
+    // `git revert`. `BaoStore.getBackupPlans` refuses to serve consumers until
+    // every producing stack has run this once.
+    if (this.globals.baoDualWriteEnabled) {
+      baoKvSecret(
+        `backup-plan-bao`,
+        {
+          mount: "secrets",
+          path: `clusters/_inventory/${baoSlug(title)}`,
+          data: { plan },
+          customMetadata: baoProvenance({
+            source_title: title,
+            source_tags: "backup-plan",
+            contains_secrets: "true",
+            concealed_fields: "plan",
+          }),
+        },
+        { parent: this, provider: this.globals.baoProvider },
+      );
+    } else {
+      log.warn(`No OpenBao credentials (BAO_TOKEN, or BAO_ROLE_ID + BAO_SECRET_ID) — skipping the backup-plan dual-write for '${title}'. 1Password stays authoritative; the inventory path stays stale until a credentialed run.`, this);
+    }
+
+    return item;
   }
 }

--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -636,6 +636,13 @@ export class DockgeLxc extends ComponentResource {
       replaceVariable(/\$UPTIME_API_URL/g, interpolate`https://uptime.${this.args.globals.searchDomain}`),
       ...Object.entries(args.variables ?? {}).map(([key, value]) => replaceVariable(new RegExp(`\\$\\{${key}\\}`, "g"), value)),
       (input: Input<string>) => this.args.globals.store.replaceOnePasswordPlaceholders(input),
+      // Both secret-reference resolvers run last, after every ${VAR}
+      // substitution above and the ${APP}/${STACK_NAME} pair prepended in
+      // createStack — references are composed dynamically, so a resolver
+      // running before substitution would see a syntax that matches nothing.
+      // Each syntax names its store by construction (op:// is 1Password,
+      // ref+openbao:// is OpenBao), so the chain cannot cross-resolve.
+      (input: Input<string>) => this.args.globals.store.resolveSecretReferences(input),
     ];
 
     const stacks = all([output(readdir(resolve(dockerPath, "_common"))), output(readdir(resolve(dockerPath, this.args.host.name)))]).apply(([commonFiles, hostFiles]) =>

--- a/components/authentik.ts
+++ b/components/authentik.ts
@@ -533,7 +533,11 @@ export class AuthentikApplicationManager extends pulumi.ComponentResource {
           pulumi.log.info(`Adding Gatus endpoint ${endpoint.name} in cluster ${cluster.title} with group ${endpoint.group}`, this);
 
           const yamlString = yaml.stringify(endpoint, { lineWidth: 0 });
-          return pulumi.output(this.store.replaceOnePasswordPlaceholders(yamlString)).apply(y => yaml.parse(y) as GatusDefinition);
+          // Both resolvers, op:// then ref+openbao:// — application
+          // definitions live in the cluster repos and convert to the ref+
+          // syntax on their own schedule, so both must resolve here until no
+          // definition carries op://.
+          return pulumi.output(this.store.resolveSecretReferences(this.store.replaceOnePasswordPlaceholders(yamlString))).apply(y => yaml.parse(y) as GatusDefinition);
         }),
       );
     });

--- a/components/bao.ts
+++ b/components/bao.ts
@@ -100,6 +100,22 @@ export class BaoClient {
     return this.tokenPromise;
   }
 
+  /** The normalized server address, for handing to a child process. */
+  public get address(): string {
+    return this.addr;
+  }
+
+  /**
+   * The session token, for handing to a child process (the `vals` resolver
+   * spawns with VAULT_TOKEN set to this). Same trust domain — the child runs
+   * with this process's credentials either way — and minting here keeps every
+   * consumer on the one proven auth path instead of teaching each tool the
+   * AppRole dance separately.
+   */
+  public authToken(): Promise<string> {
+    return this.token();
+  }
+
   private async request(method: string, path: string, body?: unknown): Promise<unknown> {
     const res = await fetch(`${this.addr}/v1/${path}`, {
       method,

--- a/components/store/bao.test.ts
+++ b/components/store/bao.test.ts
@@ -15,8 +15,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { isSecret, runtime } from "@pulumi/pulumi";
-import { assertNotDirectory, BaoStore, baoStoreReadsEnabled, resolveBaoPath, shapeItem, tailscaleExportKeys } from "./bao.ts";
-import { shapeTailscaleExports } from "./index.ts";
+import { assertNotDirectory, backupPlanKeys, BaoStore, baoStoreReadsEnabled, resolveBaoPath, shapeItem, tailscaleExportKeys } from "./bao.ts";
+import { shapeBackupPlans, shapeTailscaleExports } from "./index.ts";
 
 runtime.setMocks({
   newResource: args => ({ id: `${args.name}-id`, state: args.inputs }),
@@ -187,10 +187,8 @@ describe("resolveBaoPath", () => {
     assert.match(r.reason ?? "", /INVENTORY §2/);
   });
 
-  it("keeps not-yet-migrated inventory and cluster definitions on 1Password for now", () => {
-    for (const title of ["Backup Plan", "Cluster: Alpha Site"]) {
-      assert.equal(resolveBaoPath(title).path, undefined, title);
-    }
+  it("keeps cluster-definition titles off OpenBao — they are checked-in code", () => {
+    assert.equal(resolveBaoPath("Cluster: Alpha Site").path, undefined);
   });
 
   it("serves Authentik Outputs from the _inventory path its producer dual-writes", () => {
@@ -198,6 +196,15 @@ describe("resolveBaoPath", () => {
     // merged — verified live 2026-08-11 before the route landed. A consumer
     // switched before that read an empty object rather than an error (§G-8).
     assert.equal(resolveBaoPath("Authentik Outputs").path, "clusters/_inventory/authentik-outputs");
+  });
+
+  it("routes the inventory families to their reserved _inventory paths, never shared/", () => {
+    assert.equal(resolveBaoPath("Backup Plan").path, "clusters/_inventory/backup-plan");
+    assert.equal(resolveBaoPath("Equestria Backup Plan").path, "clusters/_inventory/equestria-backup-plan");
+    assert.equal(resolveBaoPath("Stargate Command Backup Plan").path, "clusters/_inventory/stargate-command-backup-plan");
+    assert.equal(resolveBaoPath("Tailscale Export - home-operations").path, "clusters/_inventory/tailscale-export-home-operations");
+    // A title merely containing the words is not the family.
+    assert.equal(resolveBaoPath("Backup Plan Review Notes").path, "shared/backup-plan-review-notes");
   });
 
   it("does not slug a UUID-addressed item into a UUID-shaped path", () => {
@@ -258,6 +265,35 @@ describe("shapeTailscaleExports", () => {
   it("tolerates the pre-rename `ip` key", () => {
     const shaped = shapeTailscaleExports([item("home-operations", { node: { ip: "100.1.1.3", internalIp: "10.0.0.3", mac: "cc", nodeType: "pbs" } })]);
     assert.equal(shaped[0].hosts[0].externalIp, "100.1.1.3");
+  });
+});
+
+describe("backupPlanKeys", () => {
+  const complete = ["backup-plan", "equestria-backup-plan", "stargate-command-backup-plan"];
+
+  it("selects the bare key and the -backup-plan suffixed keys, nothing else", () => {
+    assert.deepEqual(backupPlanKeys(["authentik-outputs", "tailscale-export-ocracoke", ...complete]), complete);
+  });
+
+  it("refuses an empty or torn inventory, naming what is missing", () => {
+    // A smaller list here quietly shrinks what the directors back up — a
+    // failure with no symptom until a restore is needed.
+    assert.throws(() => backupPlanKeys([]), /missing backup-plan, equestria-backup-plan, stargate-command-backup-plan/);
+    assert.throws(() => backupPlanKeys(complete.filter(k => k !== "equestria-backup-plan")), /missing equestria-backup-plan/);
+  });
+
+  it("includes plans beyond the known set — a floor, not a ceiling", () => {
+    assert.deepEqual(backupPlanKeys([...complete, "luna-backup-plan"]), [...complete, "luna-backup-plan"]);
+  });
+});
+
+describe("shapeBackupPlans", () => {
+  it("flattens every item's plans into one list", () => {
+    const shaped = shapeBackupPlans<{ name: string }>([{ plan: JSON.stringify({ plans: [{ name: "a" }, { name: "b" }] }) }, { plan: JSON.stringify({ plans: [{ name: "c" }] }) }]);
+    assert.deepEqual(
+      shaped.map(p => p.name),
+      ["a", "b", "c"],
+    );
   });
 });
 

--- a/components/store/bao.test.ts
+++ b/components/store/bao.test.ts
@@ -15,7 +15,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { isSecret, runtime } from "@pulumi/pulumi";
-import { assertNotDirectory, BaoStore, baoStoreReadsEnabled, resolveBaoPath, shapeItem } from "./bao.ts";
+import { assertNotDirectory, BaoStore, baoStoreReadsEnabled, resolveBaoPath, shapeItem, tailscaleExportKeys } from "./bao.ts";
+import { shapeTailscaleExports } from "./index.ts";
 
 runtime.setMocks({
   newResource: args => ({ id: `${args.name}-id`, state: args.inputs }),
@@ -205,6 +206,58 @@ describe("resolveBaoPath", () => {
     const r = resolveBaoPath("soz3lyvs6k24e5gh3udqp4sngi");
     assert.equal(r.path, undefined);
     assert.match(r.reason ?? "", /addressed by UUID/);
+  });
+});
+
+describe("tailscaleExportKeys", () => {
+  const complete = ["tailscale-export-gulf-of-mexico", "tailscale-export-home-operations", "tailscale-export-ocracoke"];
+
+  it("selects only the tailscale-export keys from an _inventory LIST", () => {
+    // The prefix also holds authentik-outputs and (later) the backup plans;
+    // neither is a tailscale export.
+    assert.deepEqual(tailscaleExportKeys(["authentik-outputs", ...complete]), complete);
+  });
+
+  it("refuses an EMPTY inventory rather than returning []", () => {
+    // [] here would flow into stacks/unifi-network as "the estate has no
+    // nodes" and start removing live ACL grants — the §G-8 failure, silent.
+    assert.throws(() => tailscaleExportKeys(["authentik-outputs"]), /incomplete .* missing tailscale-export-gulf-of-mexico, tailscale-export-home-operations, tailscale-export-ocracoke/);
+  });
+
+  it("refuses a TORN inventory, naming the stack that has not run", () => {
+    assert.throws(() => tailscaleExportKeys(complete.filter(k => k !== "tailscale-export-ocracoke")), /missing tailscale-export-ocracoke/);
+  });
+
+  it("includes exports beyond the known set — the list is a floor, not a ceiling", () => {
+    assert.deepEqual(tailscaleExportKeys([...complete, "tailscale-export-new-stack"]), [...complete, "tailscale-export-new-stack"]);
+  });
+});
+
+describe("shapeTailscaleExports", () => {
+  // One shaping function serves both stores; these pin the behaviors the
+  // unifi-network consumers depend on.
+  const item = (name: string, hosts: Record<string, unknown>, services?: string) => ({ name, ...(services === undefined ? {} : { services }), ...hosts });
+
+  it("splits node objects from flat fields and sorts at both levels", () => {
+    const shaped = shapeTailscaleExports([
+      item("ocracoke", { zebra: { externalIp: "100.1.1.2", internalIp: "10.0.0.2", mac: "bb", nodeType: "dockge" }, alpha: { externalIp: "100.1.1.1", internalIp: "10.0.0.1", mac: "aa", nodeType: "proxmox" } }),
+      item("gulf-of-mexico", {}, "[\"svc:llm\"]"),
+    ]);
+    assert.deepEqual(
+      shaped.map(z => z.name),
+      ["gulf-of-mexico", "ocracoke"],
+    );
+    assert.deepEqual(
+      shaped[1].hosts.map(h => h.name),
+      ["alpha", "zebra"],
+    );
+    assert.deepEqual(shaped[0].services, ["svc:llm"]);
+    assert.deepEqual(shaped[1].services, []);
+  });
+
+  it("tolerates the pre-rename `ip` key", () => {
+    const shaped = shapeTailscaleExports([item("home-operations", { node: { ip: "100.1.1.3", internalIp: "10.0.0.3", mac: "cc", nodeType: "pbs" } })]);
+    assert.equal(shaped[0].hosts[0].externalIp, "100.1.1.3");
   });
 });
 

--- a/components/store/bao.ts
+++ b/components/store/bao.ts
@@ -19,8 +19,8 @@
  *
  * Still on 1Password after this file (each is a later slice):
  *
- *   getBackupPlans                 producer-side write-back moves to OpenBao
- *   proxmoxBackupServers           waits on the remaining inventory flows
+ *   proxmoxBackupServers           its items reference dockge/cluster items by
+ *                                  title; moves once those reads are proven
  *   replaceOnePasswordPlaceholders `vals` replaces it (PLAN §D.1)
  *
  * ## Field shapes carry over unchanged
@@ -48,7 +48,7 @@
 import { all, log, type Output, output, secret } from "@pulumi/pulumi";
 import { BaoClient, baoSlug } from "../bao.ts";
 import { CLUSTERS, type ClusterEntry, clusterBySourceTitle, clusterSecretPath } from "./clusters.ts";
-import { shapeTailscaleExports, VaultStore } from "./index.ts";
+import { shapeBackupPlans, shapeTailscaleExports, VaultStore } from "./index.ts";
 import type { Meta } from "./interfaces.ts";
 
 /** The KV v2 mount every credential lives in. `docs` holds reference material. */
@@ -69,6 +69,13 @@ const TAILSCALE_EXPORT_PREFIX = "tailscale-export-";
  * `getTailscaleExports` refuses a partial set — see the override for why.
  */
 const TAILSCALE_EXPORT_STACKS = ["gulf-of-mexico", "home-operations", "ocracoke"];
+
+/**
+ * The plans `BackupPlanOrchestrator.savePlan` produces today: `Backup Plan`
+ * from stacks/backups, `<Cluster Title> Backup Plan` from each applications
+ * stack. `getBackupPlans` refuses a partial set — see the override for why.
+ */
+const BACKUP_PLAN_KEYS = ["backup-plan", "equestria-backup-plan", "stargate-command-backup-plan"];
 
 /**
  * Whether stacks read secrets from OpenBao instead of 1Password.
@@ -201,6 +208,29 @@ export class BaoStore extends VaultStore {
       .apply(items => shapeTailscaleExports(items)) as ReturnType<VaultStore["getTailscaleExports"]>;
   }
 
+  /**
+   * `tag:backup-plan` became the `*backup-plan` keys under
+   * `clusters/_inventory/` — one per producing stack, dual-written by
+   * `BackupPlanOrchestrator.savePlan`.
+   *
+   * Same refusal as `getTailscaleExports`, same reason: the three
+   * `BackupPlanDirector`s create backrest plans from this list, so a torn
+   * inventory quietly shrinks the set of things being backed up — a failure
+   * with no symptom until a restore is needed. See `backupPlanKeys`.
+   */
+  public override getBackupPlans<T>() {
+    return output(this.bao.list(SECRETS_MOUNT, INVENTORY_PREFIX))
+      .apply(keys =>
+        all(
+          backupPlanKeys(keys).map(key => {
+            assertNotDirectory(INVENTORY_PREFIX, key);
+            return this.read(`${INVENTORY_PREFIX}/${key}`);
+          }),
+        ),
+      )
+      .apply(items => shapeBackupPlans<T>(items as unknown as { plan: string }[])) as ReturnType<VaultStore["getBackupPlans"]> & Output<T[]>;
+  }
+
   private listUnder(prefix: string): Output<BaoItem[]> {
     return output(this.bao.list(SECRETS_MOUNT, prefix)).apply(keys =>
       all(
@@ -238,7 +268,6 @@ const CLUSTER_KEYS = ["equestria", "sgc", "celestia", "luna", "skystar", "alpha-
  */
 const NOT_IN_OPENBAO: Record<string, string> = {
   "OpenBao Alpha Site Static Unseal": "seal-chain material; INVENTORY §2 forbids it from ever living in OpenBao",
-  "Backup Plan": "cross-stack inventory; moves to secrets/clusters/_inventory/ in a later Phase 8 slice",
 };
 
 /**
@@ -286,6 +315,15 @@ export function resolveBaoPath(title: string): { path: string; reason?: undefine
   const inventory = INVENTORY_IN_OPENBAO[title];
   if (inventory) return { path: inventory };
 
+  // The tag-shaped inventory families (`Backup Plan`, `<Title> Backup Plan`,
+  // `Tailscale Export - <stack>`). Every consumer reads these through
+  // `getBackupPlans`/`getTailscaleExports` rather than by title, but a title
+  // reaching this resolver must still land on the reserved _inventory path —
+  // the default rule below would derive `shared/…`, a path that never exists.
+  if (/(^| )Backup Plan$/.test(title) || /^Tailscale Export - .+$/.test(title)) {
+    return { path: `${INVENTORY_PREFIX}/${baoSlug(title)}` };
+  }
+
   if (title.startsWith("Cluster: ")) return { reason: "cluster definitions become checked-in code in a later Phase 8 slice" };
 
   // 1Password item ids are 26 lowercase base32 characters. A title that IS one
@@ -321,6 +359,23 @@ export function tailscaleExportKeys(keys: string[]): string[] {
     );
   }
   return exports;
+}
+
+/**
+ * The `*backup-plan` keys to read from an `_inventory` LIST — or an error
+ * when the set is not complete. Same floor-not-ceiling contract as
+ * `tailscaleExportKeys`; exported for its tests.
+ */
+export function backupPlanKeys(keys: string[]): string[] {
+  const plans = keys.filter(key => key === "backup-plan" || key.endsWith("-backup-plan"));
+  const missing = BACKUP_PLAN_KEYS.filter(key => !plans.includes(key));
+  if (missing.length > 0) {
+    throw new Error(
+      `backup-plan inventory is incomplete under ${SECRETS_MOUNT}/${INVENTORY_PREFIX}/ — missing ${missing.join(", ")}. ` +
+        `Each producing stack must run its dual-write before any consumer reads OpenBao (PLAN §G-8: dual-write, producer run, THEN the reader).`,
+    );
+  }
+  return plans;
 }
 
 /**

--- a/components/store/bao.ts
+++ b/components/store/bao.ts
@@ -20,8 +20,7 @@
  * Still on 1Password after this file (each is a later slice):
  *
  *   getBackupPlans                 producer-side write-back moves to OpenBao
- *   getTailscaleExports            same
- *   proxmoxBackupServers           needs both of the above to resolve
+ *   proxmoxBackupServers           waits on the remaining inventory flows
  *   replaceOnePasswordPlaceholders `vals` replaces it (PLAN §D.1)
  *
  * ## Field shapes carry over unchanged
@@ -49,11 +48,27 @@
 import { all, log, type Output, output, secret } from "@pulumi/pulumi";
 import { BaoClient, baoSlug } from "../bao.ts";
 import { CLUSTERS, type ClusterEntry, clusterBySourceTitle, clusterSecretPath } from "./clusters.ts";
-import { VaultStore } from "./index.ts";
+import { shapeTailscaleExports, VaultStore } from "./index.ts";
 import type { Meta } from "./interfaces.ts";
 
 /** The KV v2 mount every credential lives in. `docs` holds reference material. */
 const SECRETS_MOUNT = "secrets";
+
+/**
+ * Where cross-stack inventory lives (PLAN §G-8) — values PRODUCED by one
+ * Pulumi stack and read by others, dual-written because `StackReference`
+ * cannot cross this repo's per-stack backends.
+ */
+const INVENTORY_PREFIX = "clusters/_inventory";
+
+/** Key prefix of one stack's tailscale export: `tailscale-export-<stack>`. */
+const TAILSCALE_EXPORT_PREFIX = "tailscale-export-";
+
+/**
+ * The stacks that call `TailscaleMonitor.exportNodeStateToOnePassword` today.
+ * `getTailscaleExports` refuses a partial set — see the override for why.
+ */
+const TAILSCALE_EXPORT_STACKS = ["gulf-of-mexico", "home-operations", "ocracoke"];
 
 /**
  * Whether stacks read secrets from OpenBao instead of 1Password.
@@ -162,6 +177,30 @@ export class BaoStore extends VaultStore {
     return this.listUnder("hosts/dockge") as ReturnType<VaultStore["getDockgeInstances"]>;
   }
 
+  /**
+   * `tag:tailscale-export` became the `tailscale-export-*` keys under
+   * `clusters/_inventory/` — one per producing stack, dual-written by
+   * `TailscaleMonitor` at the paths mapping.yaml reserves.
+   *
+   * An incomplete set (including an empty one) is an ERROR, never a smaller
+   * result — see `tailscaleExportKeys`. This feeds ACL grants and DHCP
+   * reservations in `stacks/unifi-network`; a reader switched before the
+   * producers ran would compute an empty estate and start REMOVING live
+   * config — the exact §G-8 failure, made loud.
+   */
+  public override getTailscaleExports() {
+    return output(this.bao.list(SECRETS_MOUNT, INVENTORY_PREFIX))
+      .apply(keys =>
+        all(
+          tailscaleExportKeys(keys).map(key => {
+            assertNotDirectory(INVENTORY_PREFIX, key);
+            return this.read(`${INVENTORY_PREFIX}/${key}`);
+          }),
+        ),
+      )
+      .apply(items => shapeTailscaleExports(items)) as ReturnType<VaultStore["getTailscaleExports"]>;
+  }
+
   private listUnder(prefix: string): Output<BaoItem[]> {
     return output(this.bao.list(SECRETS_MOUNT, prefix)).apply(keys =>
       all(
@@ -261,6 +300,27 @@ export function resolveBaoPath(title: string): { path: string; reason?: undefine
   }
 
   return { path: `shared/${baoSlug(title)}` };
+}
+
+/**
+ * The `tailscale-export-*` keys to read from an `_inventory` LIST — or an
+ * error when the set is not complete.
+ *
+ * Exported for its tests. A MISSING known stack is an error rather than a
+ * smaller result because two of three stacks having run is a torn inventory
+ * that shapes into a plausible, incomplete estate; stacks beyond the known set
+ * are included automatically, so the list is a floor, not a ceiling.
+ */
+export function tailscaleExportKeys(keys: string[]): string[] {
+  const exports = keys.filter(key => key.startsWith(TAILSCALE_EXPORT_PREFIX));
+  const missing = TAILSCALE_EXPORT_STACKS.filter(stack => !exports.includes(`${TAILSCALE_EXPORT_PREFIX}${stack}`));
+  if (missing.length > 0) {
+    throw new Error(
+      `tailscale-export inventory is incomplete under ${SECRETS_MOUNT}/${INVENTORY_PREFIX}/ — missing ${missing.map(stack => `${TAILSCALE_EXPORT_PREFIX}${stack}`).join(", ")}. ` +
+        `Each producing stack must run its dual-write before any consumer reads OpenBao (PLAN §G-8: dual-write, producer run, THEN the reader).`,
+    );
+  }
+  return exports;
 }
 
 /**

--- a/components/store/index.ts
+++ b/components/store/index.ts
@@ -1,6 +1,7 @@
 import { all, type Input, interpolate, jsonStringify, log, type Output, output, secret, type Unwrap } from "@pulumi/pulumi";
 import { OPClient, TypeEnum } from "../op.ts";
 import type { ClusterDefinition, DockgeClusterDefinition, DockgeLxcDefinition, KubernetesClusterDefinition, Meta, ProxmoxBackupServerLxcDefinition } from "./interfaces.ts";
+import { SecretRefResolver } from "./refs.ts";
 
 /**
  * Lazy, not module-scope. `new OPClient()` constructs a 1Password Connect
@@ -118,6 +119,23 @@ export class VaultStore {
    */
   protected getOnePasswordItemByTitle<T>(title: string) {
     return output(op().getItemByTitle(title)).apply(getSecretItem<T>);
+  }
+
+  /**
+   * `ref+openbao://secrets/<path>#/<field>` resolution (PLAN §D.1), the
+   * OpenBao counterpart of `replaceOnePasswordPlaceholders` below. Both run
+   * during the transition: each syntax names its store by construction, so
+   * chaining them cannot cross-resolve. `op://` disappears file by file; when
+   * no file carries it, the 1Password resolver below goes with it (that is the
+   * `dynamic/1password` retirement slice, deliberately last).
+   *
+   * On the base class rather than per-store because the reference itself picks
+   * the backend — `BAO_STORE_READS` has no bearing here, exactly as it has
+   * none on `op://`.
+   */
+  private readonly refResolver = new SecretRefResolver();
+  public resolveSecretReferences(value: Input<string>): Output<string> {
+    return this.refResolver.resolve(value);
   }
 
   private readonly vaultRegex = /op:\/\/Eris\/([\w| -]+)\/([\w| -]+)/g;

--- a/components/store/index.ts
+++ b/components/store/index.ts
@@ -68,33 +68,7 @@ export class VaultStore {
           ),
         ),
       )
-      .apply(items => {
-        // Sorted at both levels — the exported node name drives ACL tests/grant dsts, and the
-        // 1Password item title it is sorted by upstream can diverge from it.
-        return items
-          .map(item => {
-            return {
-              name: item.name as unknown as string,
-              services: item.services ? (JSON.parse(item.services as unknown as string) as string[]) : [],
-              hosts: Object.entries(item)
-                .filter(([_key, value]) => typeof value === "object" && !Array.isArray(value) && value !== null && ("externalIp" in value || "ip" in value))
-                .map(
-                  // `ip` fallback tolerates items written before the externalIp rename;
-                  // safe to drop once every exporting stack has redeployed.
-                  ([key, value]) =>
-                    ({ name: key, ...value, externalIp: (value as { externalIp?: string; ip?: string }).externalIp ?? (value as { ip?: string }).ip }) as {
-                      name: string;
-                      externalIp: string;
-                      internalIp: string;
-                      mac: string;
-                      nodeType: "dockge" | "proxmox" | "pbs" | "truenas";
-                    },
-                )
-                .sort((a, b) => a.name.localeCompare(b.name)),
-            };
-          })
-          .sort((a, b) => a.name.localeCompare(b.name));
-      });
+      .apply(shapeTailscaleExports);
   }
 
   public getKubeConfig(title: string) {
@@ -180,6 +154,50 @@ export class VaultStore {
         return output(value).apply(v => v.replace(this.vaultRegex, fullMatch => items.get(fullMatch) || fullMatch));
       });
   }
+}
+
+/**
+ * Item-shaped tailscale exports → the object every consumer reads.
+ *
+ * Shared between `VaultStore` (items found by `tag:tailscale-export`) and
+ * `BaoStore` (paths listed under `clusters/_inventory/tailscale-export-*`) so
+ * the two stores cannot drift in the TRANSFORM — the parity script compares the
+ * data, this function being singular is what makes the shaping identical.
+ */
+export function shapeTailscaleExports(
+  items: {
+    [key: string]: unknown;
+  }[],
+): {
+  name: string;
+  services: string[];
+  hosts: { name: string; externalIp: string; internalIp: string; mac: string; nodeType: "dockge" | "proxmox" | "pbs" | "truenas" }[];
+}[] {
+  // Sorted at both levels — the exported node name drives ACL tests/grant dsts, and the
+  // 1Password item title it is sorted by upstream can diverge from it.
+  return items
+    .map(item => {
+      return {
+        name: item.name as string,
+        services: item.services ? (JSON.parse(item.services as string) as string[]) : [],
+        hosts: Object.entries(item)
+          .filter(([_key, value]) => typeof value === "object" && !Array.isArray(value) && value !== null && ("externalIp" in value || "ip" in value))
+          .map(
+            // `ip` fallback tolerates items written before the externalIp rename;
+            // safe to drop once every exporting stack has redeployed.
+            ([key, value]) =>
+              ({ name: key, ...value, externalIp: (value as { externalIp?: string; ip?: string }).externalIp ?? (value as { ip?: string }).ip }) as {
+                name: string;
+                externalIp: string;
+                internalIp: string;
+                mac: string;
+                nodeType: "dockge" | "proxmox" | "pbs" | "truenas";
+              },
+          )
+          .sort((a, b) => a.name.localeCompare(b.name)),
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export function getSecretItem<T = { urls: { href: string; label?: string }[] }>(item: Pick<OnePasswordItem, "title" | "category" | "tags" | "urls" | "fields" | "files" | "sections">): Output<Unwrap<T & Meta>> {

--- a/components/store/index.ts
+++ b/components/store/index.ts
@@ -48,8 +48,8 @@ export class VaultStore {
 
   public getBackupPlans<T>() {
     return output(op().findItemsByTag("backup-plan"))
-      .apply(items => all(items.map(getSecretItem<{ plan: string }>)).apply(items => items.map(item => JSON.parse(item.plan) as { plans: T[] })))
-      .apply(plans => plans.flatMap(z => z.plans));
+      .apply(items => all(items.map(getSecretItem<{ plan: string }>)))
+      .apply(items => shapeBackupPlans<T>(items));
   }
 
   public getTailscaleExports() {
@@ -154,6 +154,18 @@ export class VaultStore {
         return output(value).apply(v => v.replace(this.vaultRegex, fullMatch => items.get(fullMatch) || fullMatch));
       });
   }
+}
+
+/**
+ * Item-shaped backup plans → the flat plan list the directors consume.
+ *
+ * Shared between `VaultStore` (items found by `tag:backup-plan`) and
+ * `BaoStore` (paths listed under `clusters/_inventory/*backup-plan`) for the
+ * same reason as `shapeTailscaleExports` below: one transform, so the stores
+ * can only differ in data.
+ */
+export function shapeBackupPlans<T>(items: { plan: string }[]): T[] {
+  return items.map(item => JSON.parse(item.plan) as { plans: T[] }).flatMap(z => z.plans);
 }
 
 /**

--- a/components/store/refs.test.ts
+++ b/components/store/refs.test.ts
@@ -1,12 +1,12 @@
 /**
  * npx tsx --test components/store/refs.test.ts
  *
- * Covers ref+openbao:// resolution: syntax matching, batching into one vals
- * invocation, per-reference memoization, the secret() marker, and the
- * fail-loud contract. No network and no vals binary — the exec and the
- * BaoClient are counting fakes. The real binary is exercised by the live
- * smoke run recorded in the PR (and any `pulumi preview` of a stack with
- * references).
+ * Covers ref+openbao:// resolution: the wrapped-document contract with vals,
+ * per-document memoization, the secret() marker, and the fail-loud paths. No
+ * network and no vals binary — the exec and the BaoClient are fakes. The real
+ * binary's behaviors this design leans on (inline expansion mid-string,
+ * quote/line delimiting, block-scalar fidelity, the empty-output trap for
+ * unwrapped non-YAML) were verified live and are documented in refs.ts.
  */
 
 import assert from "node:assert/strict";
@@ -24,22 +24,26 @@ runtime.setMocks({
 const fakeBao = { address: "http://bao.test:8200", authToken: async () => "test-token" } as unknown as BaoClient;
 
 /**
- * A vals fake: resolves each `rN: ref` entry against `paths`, or fails the
- * whole batch like the real binary does when any reference cannot be read.
+ * A vals fake mirroring the real contract: receives the wrapped `{content}`
+ * doc, expands every ref present in `refs` INSIDE the content string, and
+ * fails the whole eval when a ref+openbao reference is not in the map (the
+ * real binary errors on an unreadable path). Unsupported providers pass
+ * through untouched, exactly like the real vals with an unconfigured backend
+ * would leave nothing behind for — that is what the residue guard is for.
  */
-function fakeVals(paths: Record<string, Record<string, string>>) {
-  const calls: { refs: string[]; env: Record<string, string> }[] = [];
+function fakeVals(refs: Record<string, string>) {
+  const calls: { content: string; env: Record<string, string> }[] = [];
   const exec: ValsExec = async (doc, env) => {
-    const parsed = yaml.parse(doc) as Record<string, string>;
-    calls.push({ refs: Object.values(parsed), env });
-    const out: Record<string, string> = {};
-    for (const [key, ref] of Object.entries(parsed)) {
-      const m = /^ref\+openbao:\/\/([\w-]+\/[\w./-]+)#\/([\w.-]+)$/.exec(ref);
-      const value = m && paths[m[1]]?.[m[2]];
-      if (!value) throw new Error(`vals eval failed (exit status 1): expand openbao refs: get string: key "${ref}" does not exist`);
-      out[key] = value;
+    const parsed = yaml.parse(doc) as { content: string };
+    assert.equal(typeof parsed.content, "string", "resolver must wrap the document as {content: string}");
+    calls.push({ content: parsed.content, env });
+    let content = parsed.content;
+    for (const [ref, value] of Object.entries(refs)) {
+      content = content.replaceAll(ref, value);
     }
-    return yaml.stringify(out);
+    const unresolved = content.match(/ref\+openbao:\/\/[^\s"']+/);
+    if (unresolved) throw new Error(`vals eval failed (exit status 1): expand openbao refs: get string: key "${unresolved[0]}" does not exist`);
+    return yaml.stringify({ content });
   };
   return { exec, calls };
 }
@@ -61,7 +65,7 @@ describe("SecretRefResolver", () => {
   });
 
   it("resolves a reference and marks the whole content secret", async () => {
-    const fake = fakeVals({ "secrets/shared/pdm-root": { password: "s3cret" } });
+    const fake = fakeVals({ "ref+openbao://secrets/shared/pdm-root#/password": "s3cret" });
     const { value, isSecret } = await settle(resolver(fake).resolve('PASSWORD: "ref+openbao://secrets/shared/pdm-root#/password"'));
     assert.equal(value, 'PASSWORD: "s3cret"');
     // The resolved value is a credential by construction; the containing file
@@ -69,27 +73,22 @@ describe("SecretRefResolver", () => {
     assert.equal(isSecret, true);
   });
 
-  it("hands the client's address and token to the subprocess env", async () => {
-    const fake = fakeVals({ "secrets/shared/pdm-root": { password: "x" } });
-    await resolver(fake).resolveText("a: ref+openbao://secrets/shared/pdm-root#/password");
+  it("hands vals the ENTIRE document, refs in place, with the client's env", async () => {
+    const fake = fakeVals({ "ref+openbao://secrets/shared/pdm-root#/password": "x" });
+    const doc = ["# a comment survives", 'PASSWORD: "ref+openbao://secrets/shared/pdm-root#/password"', "OTHER: plain"].join("\n");
+    const { value } = await settle(resolver(fake).resolve(doc));
+    assert.equal(fake.calls[0].content, doc);
+    assert.equal(value, ["# a comment survives", 'PASSWORD: "x"', "OTHER: plain"].join("\n"));
     assert.equal(fake.calls[0].env.VAULT_ADDR, "http://bao.test:8200");
     assert.equal(fake.calls[0].env.VAULT_TOKEN, "test-token");
   });
 
-  it("batches a document's references into ONE vals run, deduplicated", async () => {
-    const fake = fakeVals({ "secrets/shared/gatus-pushover-key": { credential: "tok", username: "usr" } });
-    const doc = ["a: ref+openbao://secrets/shared/gatus-pushover-key#/credential", "b: ref+openbao://secrets/shared/gatus-pushover-key#/username", "c: ref+openbao://secrets/shared/gatus-pushover-key#/credential"].join("\n");
-    const { value } = await settle(resolver(fake).resolve(doc));
-    assert.equal(value, ["a: tok", "b: usr", "c: tok"].join("\n"));
-    assert.equal(fake.calls.length, 1);
-    assert.equal(fake.calls[0].refs.length, 2);
-  });
-
-  it("memoizes across documents — a later file with the same reference runs nothing", async () => {
-    const fake = fakeVals({ "secrets/shared/pdm-root": { password: "x" } });
+  it("runs vals once per distinct document, however often it recurs", async () => {
+    const fake = fakeVals({ "ref+openbao://secrets/shared/pdm-root#/password": "x" });
     const r = resolver(fake);
-    await r.resolveText("a: ref+openbao://secrets/shared/pdm-root#/password");
-    await r.resolveText("b: ref+openbao://secrets/shared/pdm-root#/password");
+    const doc = "a: ref+openbao://secrets/shared/pdm-root#/password";
+    await r.resolveText(doc);
+    await r.resolveText(doc);
     assert.equal(fake.calls.length, 1);
   });
 
@@ -111,6 +110,32 @@ describe("SecretRefResolver", () => {
     assert.equal(fake.calls.length, 2);
   });
 
+  it("fails on a surviving reference scheme, naming the scheme and never the content", async () => {
+    // An unsupported provider rides along with a resolvable openbao ref; vals
+    // leaves it untouched and the residue guard must catch it.
+    const fake = fakeVals({ "ref+openbao://secrets/shared/pdm-root#/password": "x" });
+    const doc = ["a: ref+openbao://secrets/shared/pdm-root#/password", "b: ref+sops://bootstrap/thing.sops.yaml#/key"].join("\n");
+    await assert.rejects(
+      () => resolver(fake).resolveText(doc),
+      (error: Error) => {
+        assert.match(error.message, /unresolved secret-reference scheme/);
+        assert.match(error.message, /ref\+sops:\/\//);
+        assert.doesNotMatch(error.message, /bootstrap\/thing/);
+        return true;
+      },
+    );
+  });
+
+  it("does not trip the residue guard on ref+ prose or shell globs", async () => {
+    // provision.sh carries `ref+*)` and comments saying "ref+..." — scheme
+    // shapes only (`ref+x://`) count as residue.
+    const fake = fakeVals({ "ref+openbao://secrets/shared/pdm-root#/password": "x" });
+    const doc = ['case "$pw" in op://* | ref+*) echo guarded ;; esac # catches "ref+..." literals', "PASSWORD=ref+openbao://secrets/shared/pdm-root#/password"].join("\n");
+    const { value } = await settle(resolver(fake).resolve(doc));
+    assert.match(value, /ref\+\*\)/);
+    assert.match(value, /PASSWORD=x/);
+  });
+
   it("leaves op:// references for the 1Password resolver", async () => {
     // The two resolvers chain during the transition; each syntax names its
     // store by construction, so this one must never touch the other's.
@@ -120,10 +145,13 @@ describe("SecretRefResolver", () => {
     assert.equal(fake.calls.length, 0);
   });
 
-  it("resolves a reference embedded in a URL", async () => {
-    const fake = fakeVals({ "secrets/shared/media-management-secrets": { plex_token: "PLEX" } });
-    const { value } = await settle(resolver(fake).resolve("url: https://plex.example/connections?X-Plex-Token=ref+openbao://secrets/shared/media-management-secrets#/plex_token"));
-    assert.equal(value, "url: https://plex.example/connections?X-Plex-Token=PLEX");
+  it("fails loudly if vals returns no content for the wrapped document", async () => {
+    // The real binary does exactly this for raw non-YAML input (exit 0, empty
+    // stdout) — the wrapping prevents it, and this guard proves we would
+    // notice rather than write out an empty file if it ever regressed.
+    const exec: ValsExec = async () => "";
+    const r = new SecretRefResolver(exec, () => fakeBao);
+    await assert.rejects(() => r.resolveText("a: ref+openbao://secrets/shared/pdm-root#/password"), /returned no content/);
   });
 
   it("does not build a client when nothing references OpenBao", async () => {

--- a/components/store/refs.test.ts
+++ b/components/store/refs.test.ts
@@ -1,72 +1,96 @@
 /**
  * npx tsx --test components/store/refs.test.ts
  *
- * Covers ref+openbao:// resolution: syntax matching, batched reads, the
- * secret() marker, and the fail-loud contract. No network — the BaoClient is
- * a counting fake.
+ * Covers ref+openbao:// resolution: syntax matching, batching into one vals
+ * invocation, per-reference memoization, the secret() marker, and the
+ * fail-loud contract. No network and no vals binary — the exec and the
+ * BaoClient are counting fakes. The real binary is exercised by the live
+ * smoke run recorded in the PR (and any `pulumi preview` of a stack with
+ * references).
  */
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { isSecret, type Output, runtime } from "@pulumi/pulumi";
+import * as yaml from "yaml";
 import type { BaoClient } from "../bao.ts";
-import { SecretRefResolver } from "./refs.ts";
+import { SecretRefResolver, type ValsExec } from "./refs.ts";
 
 runtime.setMocks({
   newResource: args => ({ id: `${args.name}-id`, state: args.inputs }),
   call: args => args.inputs,
 });
 
-
-function fakeClient(paths: Record<string, Record<string, unknown>>) {
-  const reads: string[] = [];
-  const client = {
-    read: async (mount: string, path: string) => {
-      reads.push(`${mount}/${path}`);
-      const data = paths[`${mount}/${path}`];
-      return data ? { data, metadata: { version: 1, created_time: "", custom_metadata: null } } : undefined;
-    },
-  } as unknown as BaoClient;
-  return { client, reads };
-}
+const fakeBao = { address: "http://bao.test:8200", authToken: async () => "test-token" } as unknown as BaoClient;
 
 /**
- * Await an Output through its internal promise, so a rejected resolution
- * REJECTS here (assert.rejects can catch it) instead of hanging an apply
- * callback that never runs.
+ * A vals fake: resolves each `rN: ref` entry against `paths`, or fails the
+ * whole batch like the real binary does when any reference cannot be read.
  */
+function fakeVals(paths: Record<string, Record<string, string>>) {
+  const calls: { refs: string[]; env: Record<string, string> }[] = [];
+  const exec: ValsExec = async (doc, env) => {
+    const parsed = yaml.parse(doc) as Record<string, string>;
+    calls.push({ refs: Object.values(parsed), env });
+    const out: Record<string, string> = {};
+    for (const [key, ref] of Object.entries(parsed)) {
+      const m = /^ref\+openbao:\/\/([\w-]+\/[\w./-]+)#\/([\w.-]+)$/.exec(ref);
+      const value = m && paths[m[1]]?.[m[2]];
+      if (!value) throw new Error(`vals eval failed (exit status 1): expand openbao refs: get string: key "${ref}" does not exist`);
+      out[key] = value;
+    }
+    return yaml.stringify(out);
+  };
+  return { exec, calls };
+}
+
+const resolver = (fake: ReturnType<typeof fakeVals>) => new SecretRefResolver(fake.exec, () => fakeBao);
+
 async function settle(o: Output<string>) {
   const value = await (o as unknown as { promise(): Promise<string> }).promise();
   return { value, isSecret: await isSecret(o) };
 }
 
 describe("SecretRefResolver", () => {
-  it("passes through content with no references, unmarked", async () => {
-    const { client } = fakeClient({});
-    const { value, isSecret } = await settle(new SecretRefResolver(() => client).resolve("PASSWORD: hunter2\n"));
+  it("passes through content with no references, unmarked, without running vals", async () => {
+    const fake = fakeVals({});
+    const { value, isSecret } = await settle(resolver(fake).resolve("PASSWORD: hunter2\n"));
     assert.equal(value, "PASSWORD: hunter2\n");
     assert.equal(isSecret, false);
+    assert.equal(fake.calls.length, 0);
   });
 
   it("resolves a reference and marks the whole content secret", async () => {
-    const { client } = fakeClient({ "secrets/shared/pdm-root": { password: "s3cret", username: "root" } });
-    const { value, isSecret } = await settle(new SecretRefResolver(() => client).resolve('PASSWORD: "ref+openbao://secrets/shared/pdm-root#/password"'));
+    const fake = fakeVals({ "secrets/shared/pdm-root": { password: "s3cret" } });
+    const { value, isSecret } = await settle(resolver(fake).resolve('PASSWORD: "ref+openbao://secrets/shared/pdm-root#/password"'));
     assert.equal(value, 'PASSWORD: "s3cret"');
     // The resolved value is a credential by construction; the containing file
     // content must not reach Pulumi state in the clear.
     assert.equal(isSecret, true);
   });
 
-  it("reads each path once, however many fields and occurrences use it", async () => {
-    const { client, reads } = fakeClient({ "secrets/shared/gatus-pushover-key": { credential: "tok", username: "usr" } });
-    const resolver = new SecretRefResolver(() => client);
+  it("hands the client's address and token to the subprocess env", async () => {
+    const fake = fakeVals({ "secrets/shared/pdm-root": { password: "x" } });
+    await resolver(fake).resolveText("a: ref+openbao://secrets/shared/pdm-root#/password");
+    assert.equal(fake.calls[0].env.VAULT_ADDR, "http://bao.test:8200");
+    assert.equal(fake.calls[0].env.VAULT_TOKEN, "test-token");
+  });
+
+  it("batches a document's references into ONE vals run, deduplicated", async () => {
+    const fake = fakeVals({ "secrets/shared/gatus-pushover-key": { credential: "tok", username: "usr" } });
     const doc = ["a: ref+openbao://secrets/shared/gatus-pushover-key#/credential", "b: ref+openbao://secrets/shared/gatus-pushover-key#/username", "c: ref+openbao://secrets/shared/gatus-pushover-key#/credential"].join("\n");
-    const { value } = await settle(resolver.resolve(doc));
+    const { value } = await settle(resolver(fake).resolve(doc));
     assert.equal(value, ["a: tok", "b: usr", "c: tok"].join("\n"));
-    assert.deepEqual(reads, ["secrets/shared/gatus-pushover-key"]);
-    // ...and the memo survives into the next document.
-    await settle(resolver.resolve("d: ref+openbao://secrets/shared/gatus-pushover-key#/username"));
-    assert.deepEqual(reads, ["secrets/shared/gatus-pushover-key"]);
+    assert.equal(fake.calls.length, 1);
+    assert.equal(fake.calls[0].refs.length, 2);
+  });
+
+  it("memoizes across documents — a later file with the same reference runs nothing", async () => {
+    const fake = fakeVals({ "secrets/shared/pdm-root": { password: "x" } });
+    const r = resolver(fake);
+    await r.resolveText("a: ref+openbao://secrets/shared/pdm-root#/password");
+    await r.resolveText("b: ref+openbao://secrets/shared/pdm-root#/password");
+    assert.equal(fake.calls.length, 1);
   });
 
   // The failure contract is asserted on `resolveText`, the async core that
@@ -74,36 +98,40 @@ describe("SecretRefResolver", () => {
   // the SDK's internal sibling promises, which only the real engine observes
   // — under node:test each sibling reports as unhandled activity.
 
-  it("fails the run on a missing path, naming the reference", async () => {
-    const { client } = fakeClient({});
-    await assert.rejects(() => new SecretRefResolver(() => client).resolveText("x: ref+openbao://secrets/shared/nope#/password"), /ref\+openbao:\/\/secrets\/shared\/nope#\/password: secrets\/shared\/nope does not exist/);
+  it("fails the run when vals cannot resolve, carrying vals' own diagnosis", async () => {
+    const fake = fakeVals({});
+    await assert.rejects(() => resolver(fake).resolveText("x: ref+openbao://secrets/shared/nope#/password"), /does not exist/);
   });
 
-  it("fails the run on a missing field, naming what exists", async () => {
-    const { client } = fakeClient({ "secrets/shared/pdm-root": { password: "x", username: "root" } });
-    await assert.rejects(() => new SecretRefResolver(() => client).resolveText("x: ref+openbao://secrets/shared/pdm-root#/apikey"), /no string field 'apikey' \(fields: password, username\)/);
+  it("does not poison the memo on failure — a retry runs vals again", async () => {
+    const fake = fakeVals({});
+    const r = resolver(fake);
+    await assert.rejects(() => r.resolveText("x: ref+openbao://secrets/shared/nope#/password"));
+    await assert.rejects(() => r.resolveText("x: ref+openbao://secrets/shared/nope#/password"));
+    assert.equal(fake.calls.length, 2);
   });
 
   it("leaves op:// references for the 1Password resolver", async () => {
     // The two resolvers chain during the transition; each syntax names its
     // store by construction, so this one must never touch the other's.
-    const { client, reads } = fakeClient({});
-    const { value } = await settle(new SecretRefResolver(() => client).resolve('token: "op://Eris/Gatus Pushover Key/credential"'));
+    const fake = fakeVals({});
+    const { value } = await settle(resolver(fake).resolve('token: "op://Eris/Gatus Pushover Key/credential"'));
     assert.equal(value, 'token: "op://Eris/Gatus Pushover Key/credential"');
-    assert.deepEqual(reads, []);
+    assert.equal(fake.calls.length, 0);
   });
 
   it("resolves a reference embedded in a URL", async () => {
-    const { client } = fakeClient({ "secrets/shared/media-management-secrets": { plex_token: "PLEX" } });
-    const { value } = await settle(new SecretRefResolver(() => client).resolve("url: https://plex.example/connections?X-Plex-Token=ref+openbao://secrets/shared/media-management-secrets#/plex_token"));
+    const fake = fakeVals({ "secrets/shared/media-management-secrets": { plex_token: "PLEX" } });
+    const { value } = await settle(resolver(fake).resolve("url: https://plex.example/connections?X-Plex-Token=ref+openbao://secrets/shared/media-management-secrets#/plex_token"));
     assert.equal(value, "url: https://plex.example/connections?X-Plex-Token=PLEX");
   });
 
   it("does not build a client when nothing references OpenBao", async () => {
-    const resolver = new SecretRefResolver(() => {
+    const fake = fakeVals({});
+    const r = new SecretRefResolver(fake.exec, () => {
       throw new Error("client constructed on a stack with no references");
     });
-    const { value } = await settle(resolver.resolve("plain: yaml\n"));
+    const { value } = await settle(r.resolve("plain: yaml\n"));
     assert.equal(value, "plain: yaml\n");
   });
 });

--- a/components/store/refs.test.ts
+++ b/components/store/refs.test.ts
@@ -1,0 +1,109 @@
+/**
+ * npx tsx --test components/store/refs.test.ts
+ *
+ * Covers ref+openbao:// resolution: syntax matching, batched reads, the
+ * secret() marker, and the fail-loud contract. No network — the BaoClient is
+ * a counting fake.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { isSecret, type Output, runtime } from "@pulumi/pulumi";
+import type { BaoClient } from "../bao.ts";
+import { SecretRefResolver } from "./refs.ts";
+
+runtime.setMocks({
+  newResource: args => ({ id: `${args.name}-id`, state: args.inputs }),
+  call: args => args.inputs,
+});
+
+
+function fakeClient(paths: Record<string, Record<string, unknown>>) {
+  const reads: string[] = [];
+  const client = {
+    read: async (mount: string, path: string) => {
+      reads.push(`${mount}/${path}`);
+      const data = paths[`${mount}/${path}`];
+      return data ? { data, metadata: { version: 1, created_time: "", custom_metadata: null } } : undefined;
+    },
+  } as unknown as BaoClient;
+  return { client, reads };
+}
+
+/**
+ * Await an Output through its internal promise, so a rejected resolution
+ * REJECTS here (assert.rejects can catch it) instead of hanging an apply
+ * callback that never runs.
+ */
+async function settle(o: Output<string>) {
+  const value = await (o as unknown as { promise(): Promise<string> }).promise();
+  return { value, isSecret: await isSecret(o) };
+}
+
+describe("SecretRefResolver", () => {
+  it("passes through content with no references, unmarked", async () => {
+    const { client } = fakeClient({});
+    const { value, isSecret } = await settle(new SecretRefResolver(() => client).resolve("PASSWORD: hunter2\n"));
+    assert.equal(value, "PASSWORD: hunter2\n");
+    assert.equal(isSecret, false);
+  });
+
+  it("resolves a reference and marks the whole content secret", async () => {
+    const { client } = fakeClient({ "secrets/shared/pdm-root": { password: "s3cret", username: "root" } });
+    const { value, isSecret } = await settle(new SecretRefResolver(() => client).resolve('PASSWORD: "ref+openbao://secrets/shared/pdm-root#/password"'));
+    assert.equal(value, 'PASSWORD: "s3cret"');
+    // The resolved value is a credential by construction; the containing file
+    // content must not reach Pulumi state in the clear.
+    assert.equal(isSecret, true);
+  });
+
+  it("reads each path once, however many fields and occurrences use it", async () => {
+    const { client, reads } = fakeClient({ "secrets/shared/gatus-pushover-key": { credential: "tok", username: "usr" } });
+    const resolver = new SecretRefResolver(() => client);
+    const doc = ["a: ref+openbao://secrets/shared/gatus-pushover-key#/credential", "b: ref+openbao://secrets/shared/gatus-pushover-key#/username", "c: ref+openbao://secrets/shared/gatus-pushover-key#/credential"].join("\n");
+    const { value } = await settle(resolver.resolve(doc));
+    assert.equal(value, ["a: tok", "b: usr", "c: tok"].join("\n"));
+    assert.deepEqual(reads, ["secrets/shared/gatus-pushover-key"]);
+    // ...and the memo survives into the next document.
+    await settle(resolver.resolve("d: ref+openbao://secrets/shared/gatus-pushover-key#/username"));
+    assert.deepEqual(reads, ["secrets/shared/gatus-pushover-key"]);
+  });
+
+  // The failure contract is asserted on `resolveText`, the async core that
+  // `resolve` wraps: a rejected Output fans the same rejection out through
+  // the SDK's internal sibling promises, which only the real engine observes
+  // — under node:test each sibling reports as unhandled activity.
+
+  it("fails the run on a missing path, naming the reference", async () => {
+    const { client } = fakeClient({});
+    await assert.rejects(() => new SecretRefResolver(() => client).resolveText("x: ref+openbao://secrets/shared/nope#/password"), /ref\+openbao:\/\/secrets\/shared\/nope#\/password: secrets\/shared\/nope does not exist/);
+  });
+
+  it("fails the run on a missing field, naming what exists", async () => {
+    const { client } = fakeClient({ "secrets/shared/pdm-root": { password: "x", username: "root" } });
+    await assert.rejects(() => new SecretRefResolver(() => client).resolveText("x: ref+openbao://secrets/shared/pdm-root#/apikey"), /no string field 'apikey' \(fields: password, username\)/);
+  });
+
+  it("leaves op:// references for the 1Password resolver", async () => {
+    // The two resolvers chain during the transition; each syntax names its
+    // store by construction, so this one must never touch the other's.
+    const { client, reads } = fakeClient({});
+    const { value } = await settle(new SecretRefResolver(() => client).resolve('token: "op://Eris/Gatus Pushover Key/credential"'));
+    assert.equal(value, 'token: "op://Eris/Gatus Pushover Key/credential"');
+    assert.deepEqual(reads, []);
+  });
+
+  it("resolves a reference embedded in a URL", async () => {
+    const { client } = fakeClient({ "secrets/shared/media-management-secrets": { plex_token: "PLEX" } });
+    const { value } = await settle(new SecretRefResolver(() => client).resolve("url: https://plex.example/connections?X-Plex-Token=ref+openbao://secrets/shared/media-management-secrets#/plex_token"));
+    assert.equal(value, "url: https://plex.example/connections?X-Plex-Token=PLEX");
+  });
+
+  it("does not build a client when nothing references OpenBao", async () => {
+    const resolver = new SecretRefResolver(() => {
+      throw new Error("client constructed on a stack with no references");
+    });
+    const { value } = await settle(resolver.resolve("plain: yaml\n"));
+    assert.equal(value, "plain: yaml\n");
+  });
+});

--- a/components/store/refs.test.ts
+++ b/components/store/refs.test.ts
@@ -126,6 +126,15 @@ describe("SecretRefResolver", () => {
     );
   });
 
+  it("a document with ONLY an unsupported provider still fails loudly", async () => {
+    // The gate matches any scheme-shaped reference, not just openbao — a
+    // sops-only file must enter resolution and die in the residue guard, not
+    // skip vals and ship the literal into a container.
+    const fake = fakeVals({});
+    await assert.rejects(() => resolver(fake).resolveText("b: ref+sops://bootstrap/thing.sops.yaml#/key"), /unresolved secret-reference scheme.*ref\+sops:\/\//);
+    assert.equal(fake.calls.length, 1);
+  });
+
   it("does not trip the residue guard on ref+ prose or shell globs", async () => {
     // provision.sh carries `ref+*)` and comments saying "ref+..." — scheme
     // shapes only (`ref+x://`) count as residue.

--- a/components/store/refs.ts
+++ b/components/store/refs.ts
@@ -13,29 +13,34 @@
  * out of OpenBao when virtual dispatch once sent `op://` lookups there
  * (STATUS.md, "the read seam").
  *
- * ## Why in-process, not the `vals` binary
+ * ## Resolution is `vals eval`, batched
  *
- * PLAN §D.1 sketched shelling out to `vals eval`. The stacks that resolve
- * these references run under the Pulumi Kubernetes Operator in stock
- * `ghcr.io/pulumi/pulumi-nodejs` workspace pods, where no `vals` binary exists
- * and no mise is available to install one — a subprocess pass would fail on
- * every operator run, and shipping the binary means initContainer surgery on
- * every Stack CR plus an image to keep patched. `BaoClient` is already here,
- * already tested, and authenticates exactly like the provider and the
- * migration tooling (BAO_TOKEN, or the AppRole pair). What is kept from the
- * plan is everything observable: the reference syntax, batched reads, values
- * wrapped in `secret()`, and unresolved references failing the run loudly.
+ * The unresolved references of a document are collected into one YAML doc and
+ * resolved by a single `vals eval` subprocess (helmfile/vals ≥0.45 speaks
+ * `ref+openbao://` natively — verified against the live server); results are
+ * memoized per reference for the life of the process, so however many files
+ * share a credential, vals runs once for it. `vals` comes from mise locally
+ * (`.config/mise.toml [tools]`) and from the `vals` initContainer on the
+ * operator's workspace pods, which exports its path as `VALS_BIN` — see
+ * `kubernetes/apps/pulumi/<stack>/stack.yaml`.
+ *
+ * Authentication is NOT delegated to vals: `BaoClient` mints the token
+ * (BAO_TOKEN, or the AppRole pair — the same two ways in as everything else)
+ * and the child gets VAULT_ADDR/VAULT_TOKEN. One auth path, everywhere.
  *
  * ## Failure is an error, not a passthrough
  *
  * The `op://` resolver logs and passes the literal through, relying on the
  * `provision.sh` guard to catch it at container runtime. Here a missing path
- * or field throws during the Pulumi run instead — the guard stays as
- * defense-in-depth, but the failure belongs to the run that caused it, not to
- * the container that later boots with a literal `ref+…` as its password.
+ * or field fails the `vals eval` and therefore the Pulumi run — the guard
+ * stays as defense-in-depth, but the failure belongs to the run that caused
+ * it, not to the container that later boots with a literal `ref+…` as its
+ * password.
  */
 
+import { execFile } from "node:child_process";
 import { type Input, type Output, output, secret } from "@pulumi/pulumi";
+import * as yaml from "yaml";
 import { BaoClient } from "../bao.ts";
 
 /**
@@ -48,16 +53,22 @@ import { BaoClient } from "../bao.ts";
  */
 const REF_PATTERN = /ref\+openbao:\/\/([\w-]+)\/([\w./-]+)#\/([\w.-]+)/g;
 
+/** How a batch of references reaches vals. Injectable for the tests. */
+export type ValsExec = (doc: string, env: Record<string, string>) => Promise<string>;
+
 export class SecretRefResolver {
   /**
    * Constructed lazily on the first reference actually seen, so building a
    * store never demands BAO_ADDR on a stack that resolves no references.
    */
   private client?: BaoClient;
-  /** One read per KV path per process, however many fields or files use it. */
-  private readonly reads = new Map<string, Promise<Record<string, unknown>>>();
+  /** One vals resolution per reference per process, however many files use it. */
+  private readonly resolved = new Map<string, Promise<string>>();
 
-  constructor(private readonly makeClient: () => BaoClient = () => new BaoClient()) {}
+  constructor(
+    private readonly exec: ValsExec = execVals,
+    private readonly makeClient: () => BaoClient = () => new BaoClient(),
+  ) {}
 
   /**
    * Replace every `ref+openbao://` reference in `value` with its secret value.
@@ -75,39 +86,78 @@ export class SecretRefResolver {
 
   /**
    * The async core `resolve` wraps: every reference in `v` replaced, or a
-   * thrown error for the first one that cannot be. Public so the failure
+   * thrown error for the first batch that cannot be. Public so the failure
    * contract is testable as a plain promise — a rejected Output fans out
    * through the SDK's internal sibling promises, which only the engine
    * observes.
    */
   public async resolveText(v: string): Promise<string> {
-    const refs = unique(Array.from(v.matchAll(REF_PATTERN)));
-    const entries = await Promise.all(refs.map(async ([full, mount, path, field]) => [full, await this.field(full, mount, path, field)] as const));
+    const refs = unique(Array.from(v.matchAll(REF_PATTERN))).map(m => m[0]);
+    const pending = refs.filter(ref => !this.resolved.has(ref));
+    if (pending.length > 0) this.register(pending);
+    const entries = await Promise.all(refs.map(async ref => [ref, await this.resolved.get(ref)!] as const));
     const byRef = new Map(entries);
     // matchAll found every occurrence, so the replace cannot miss: every full
     // match is a key in the map.
     return v.replace(REF_PATTERN, match => byRef.get(match) as string);
   }
 
-  private async field(full: string, mount: string, path: string, field: string): Promise<string> {
-    const key = `${mount}/${path}`;
-    let read = this.reads.get(key);
-    if (!read) {
-      read = (async () => {
-        this.client ??= this.makeClient();
-        const result = await this.client.read(mount, path);
-        if (!result) throw new Error(`${full}: ${key} does not exist in OpenBao`);
-        return result.data;
-      })();
-      this.reads.set(key, read);
-    }
-    const data = await read;
-    const value = data[field];
-    if (typeof value !== "string") {
-      throw new Error(`${full}: ${key} has no string field '${field}' (fields: ${Object.keys(data).sort().join(", ")})`);
-    }
-    return value;
+  /**
+   * One `vals eval` for a batch of references: `{r0: ref, r1: ref, …}` in,
+   * the same keys with values out. Every reference in the batch settles from
+   * the one subprocess; if vals fails, they all reject with its stderr, which
+   * names the path it could not read.
+   */
+  private register(refs: string[]): void {
+    const batch = (async () => {
+      this.client ??= this.makeClient();
+      const doc = yaml.stringify(Object.fromEntries(refs.map((ref, i) => [`r${i}`, ref])));
+      const resolvedDoc = await this.exec(doc, {
+        VAULT_ADDR: this.client.address,
+        VAULT_TOKEN: await this.client.authToken(),
+      });
+      const parsed = yaml.parse(resolvedDoc) as Record<string, unknown>;
+      return refs.map((ref, i) => {
+        const value = parsed[`r${i}`];
+        // vals resolved it or errored the whole eval, so a non-string here is
+        // a shape surprise (a nested object from a directory-style path).
+        if (typeof value !== "string") throw new Error(`${ref}: vals returned ${value === undefined ? "nothing" : typeof value} rather than a string`);
+        return value;
+      });
+    })();
+    refs.forEach((ref, i) => this.resolved.set(ref, batch.then(values => values[i])));
+    // A failed batch must not poison the memo forever — a retry (the operator
+    // reconciles on backoff) should re-run vals, not replay the rejection.
+    batch.catch(() => refs.forEach(ref => this.resolved.delete(ref)));
   }
+}
+
+/**
+ * Spawn the real vals binary: `VALS_BIN` when set (the operator workspace
+ * pods point it at the initContainer-installed copy), otherwise `vals` from
+ * PATH (mise, locally). The batch goes in on stdin and comes back on stdout,
+ * so no secret value ever touches argv or a file.
+ */
+function execVals(doc: string, env: Record<string, string>): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      process.env.VALS_BIN || "vals",
+      ["eval", "-f", "-"],
+      // PATH is deliberately inherited: locally that is what carries mise's
+      // shims; in the workspace pod VALS_BIN is absolute and PATH is inert.
+      { env: { ...process.env, ...env }, maxBuffer: 16 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        if (error) {
+          // stderr carries vals' own diagnosis (which path failed); stdout may
+          // carry resolved secrets and must never reach an error message.
+          reject(new Error(`vals eval failed (${error.message.split("\n")[0]}): ${stderr.trim() || "no stderr"}`));
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+    child.stdin?.end(doc);
+  });
 }
 
 function hasRefs(v: string): boolean {

--- a/components/store/refs.ts
+++ b/components/store/refs.ts
@@ -1,0 +1,123 @@
+/**
+ * `ref+openbao://` resolution for file content — Phase 8's PLAN §D.1 slice of
+ * the 1Password→OpenBao migration (vault repo: docs/openbao-migration/PLAN.md).
+ *
+ * Reference syntax, exactly as PLAN §D specifies:
+ *
+ *     ref+openbao://secrets/<path>#/<field>
+ *
+ * replacing `op://Eris/<Item>/<field>`. One reference names one store by
+ * construction — `op://` can only mean 1Password, `ref+openbao://` can only
+ * mean OpenBao — which is what makes the two resolvers safe to run side by
+ * side during the transition and is the property that kept the seal-chain key
+ * out of OpenBao when virtual dispatch once sent `op://` lookups there
+ * (STATUS.md, "the read seam").
+ *
+ * ## Why in-process, not the `vals` binary
+ *
+ * PLAN §D.1 sketched shelling out to `vals eval`. The stacks that resolve
+ * these references run under the Pulumi Kubernetes Operator in stock
+ * `ghcr.io/pulumi/pulumi-nodejs` workspace pods, where no `vals` binary exists
+ * and no mise is available to install one — a subprocess pass would fail on
+ * every operator run, and shipping the binary means initContainer surgery on
+ * every Stack CR plus an image to keep patched. `BaoClient` is already here,
+ * already tested, and authenticates exactly like the provider and the
+ * migration tooling (BAO_TOKEN, or the AppRole pair). What is kept from the
+ * plan is everything observable: the reference syntax, batched reads, values
+ * wrapped in `secret()`, and unresolved references failing the run loudly.
+ *
+ * ## Failure is an error, not a passthrough
+ *
+ * The `op://` resolver logs and passes the literal through, relying on the
+ * `provision.sh` guard to catch it at container runtime. Here a missing path
+ * or field throws during the Pulumi run instead — the guard stays as
+ * defense-in-depth, but the failure belongs to the run that caused it, not to
+ * the container that later boots with a literal `ref+…` as its password.
+ */
+
+import { type Input, type Output, output, secret } from "@pulumi/pulumi";
+import { BaoClient } from "../bao.ts";
+
+/**
+ * One reference: mount, path within the mount, field name.
+ *
+ * The field charset has no space on purpose: OpenBao stores 1Password field
+ * names verbatim (`known hosts`), but a space savagely complicates parsing
+ * inside URLs and env files, and no file-resolved reference needs one today.
+ * Reference a spaced field by renaming the field, not by widening this.
+ */
+const REF_PATTERN = /ref\+openbao:\/\/([\w-]+)\/([\w./-]+)#\/([\w.-]+)/g;
+
+export class SecretRefResolver {
+  /**
+   * Constructed lazily on the first reference actually seen, so building a
+   * store never demands BAO_ADDR on a stack that resolves no references.
+   */
+  private client?: BaoClient;
+  /** One read per KV path per process, however many fields or files use it. */
+  private readonly reads = new Map<string, Promise<Record<string, unknown>>>();
+
+  constructor(private readonly makeClient: () => BaoClient = () => new BaoClient()) {}
+
+  /**
+   * Replace every `ref+openbao://` reference in `value` with its secret value.
+   *
+   * The result is marked `secret()` whenever at least one reference resolved —
+   * every resolved value is a credential by construction, and the containing
+   * file content must not reach Pulumi state in the clear.
+   */
+  public resolve(value: Input<string>): Output<string> {
+    return output(value).apply(v => {
+      if (!hasRefs(v)) return output(v);
+      return secret(output(this.resolveText(v)));
+    });
+  }
+
+  /**
+   * The async core `resolve` wraps: every reference in `v` replaced, or a
+   * thrown error for the first one that cannot be. Public so the failure
+   * contract is testable as a plain promise — a rejected Output fans out
+   * through the SDK's internal sibling promises, which only the engine
+   * observes.
+   */
+  public async resolveText(v: string): Promise<string> {
+    const refs = unique(Array.from(v.matchAll(REF_PATTERN)));
+    const entries = await Promise.all(refs.map(async ([full, mount, path, field]) => [full, await this.field(full, mount, path, field)] as const));
+    const byRef = new Map(entries);
+    // matchAll found every occurrence, so the replace cannot miss: every full
+    // match is a key in the map.
+    return v.replace(REF_PATTERN, match => byRef.get(match) as string);
+  }
+
+  private async field(full: string, mount: string, path: string, field: string): Promise<string> {
+    const key = `${mount}/${path}`;
+    let read = this.reads.get(key);
+    if (!read) {
+      read = (async () => {
+        this.client ??= this.makeClient();
+        const result = await this.client.read(mount, path);
+        if (!result) throw new Error(`${full}: ${key} does not exist in OpenBao`);
+        return result.data;
+      })();
+      this.reads.set(key, read);
+    }
+    const data = await read;
+    const value = data[field];
+    if (typeof value !== "string") {
+      throw new Error(`${full}: ${key} has no string field '${field}' (fields: ${Object.keys(data).sort().join(", ")})`);
+    }
+    return value;
+  }
+}
+
+function hasRefs(v: string): boolean {
+  // `search`, not `test`: the pattern is /g and `test` advances its
+  // lastIndex, which `matchAll` in resolveText would then inherit and skip
+  // the first reference. `search` neither reads nor writes lastIndex.
+  return v.search(REF_PATTERN) !== -1;
+}
+
+function unique(matches: RegExpMatchArray[]): RegExpMatchArray[] {
+  const seen = new Set<string>();
+  return matches.filter(m => (seen.has(m[0]) ? false : (seen.add(m[0]), true)));
+}

--- a/components/store/refs.ts
+++ b/components/store/refs.ts
@@ -13,13 +13,25 @@
  * out of OpenBao when virtual dispatch once sent `op://` lookups there
  * (STATUS.md, "the read seam").
  *
- * ## Resolution is `vals eval`, batched
+ * ## vals is the only parser of the reference syntax
  *
- * The unresolved references of a document are collected into one YAML doc and
- * resolved by a single `vals eval` subprocess (helmfile/vals ≥0.45 speaks
- * `ref+openbao://` natively — verified against the live server); results are
- * memoized per reference for the life of the process, so however many files
- * share a credential, vals runs once for it. `vals` comes from mise locally
+ * There is deliberately NO reference regex here. The whole document is handed
+ * to `vals eval` as one YAML value (`content: <file>`), and vals expands every
+ * embedded reference inside the string — helmfile/vals ≥0.45 resolves
+ * `ref+openbao://` natively and expands refs mid-string, delimiting correctly
+ * at quotes and line ends (verified live: a plex-style URL query, a dotenv
+ * `KEY="ref+…"` line inside a block scalar, and surrounding text all survive
+ * byte-for-byte). Matching the syntax ourselves would make this file a second
+ * implementation of vals' grammar that silently skips whatever it gets wrong
+ * — a `?version=` query, an exotic field name — and a skipped reference
+ * becomes a literal credential-shaped string in a running container.
+ *
+ * Do NOT hand vals a raw non-YAML file instead of wrapping it: `vals eval` of
+ * a bare dotenv line exits 0 with EMPTY output, which a pipeline would write
+ * out as an empty file.
+ *
+ * One `vals eval` per document that contains references, memoized by content
+ * for the life of the process. `vals` comes from mise locally
  * (`.config/mise.toml [tools]`) and from the `vals` initContainer on the
  * operator's workspace pods, which exports its path as `VALS_BIN` — see
  * `kubernetes/apps/pulumi/<stack>/stack.yaml`.
@@ -32,10 +44,12 @@
  *
  * The `op://` resolver logs and passes the literal through, relying on the
  * `provision.sh` guard to catch it at container runtime. Here a missing path
- * or field fails the `vals eval` and therefore the Pulumi run — the guard
- * stays as defense-in-depth, but the failure belongs to the run that caused
- * it, not to the container that later boots with a literal `ref+…` as its
- * password.
+ * or field fails the `vals eval` — and any `ref+` string that SURVIVES
+ * resolution (an unsupported provider like `ref+sops://`, or a reference vals
+ * did not recognize) fails the run too, naming the scheme but never echoing
+ * content. The guard stays as defense-in-depth, but the failure belongs to
+ * the run that caused it, not to the container that later boots with a
+ * literal `ref+…` as its password.
  */
 
 import { execFile } from "node:child_process";
@@ -43,17 +57,7 @@ import { type Input, type Output, output, secret } from "@pulumi/pulumi";
 import * as yaml from "yaml";
 import { BaoClient } from "../bao.ts";
 
-/**
- * One reference: mount, path within the mount, field name.
- *
- * The field charset has no space on purpose: OpenBao stores 1Password field
- * names verbatim (`known hosts`), but a space savagely complicates parsing
- * inside URLs and env files, and no file-resolved reference needs one today.
- * Reference a spaced field by renaming the field, not by widening this.
- */
-const REF_PATTERN = /ref\+openbao:\/\/([\w-]+)\/([\w./-]+)#\/([\w.-]+)/g;
-
-/** How a batch of references reaches vals. Injectable for the tests. */
+/** How a wrapped document reaches vals. Injectable for the tests. */
 export type ValsExec = (doc: string, env: Record<string, string>) => Promise<string>;
 
 export class SecretRefResolver {
@@ -62,7 +66,7 @@ export class SecretRefResolver {
    * store never demands BAO_ADDR on a stack that resolves no references.
    */
   private client?: BaoClient;
-  /** One vals resolution per reference per process, however many files use it. */
+  /** One vals run per distinct document per process, however often it recurs. */
   private readonly resolved = new Map<string, Promise<string>>();
 
   constructor(
@@ -79,64 +83,60 @@ export class SecretRefResolver {
    */
   public resolve(value: Input<string>): Output<string> {
     return output(value).apply(v => {
-      if (!hasRefs(v)) return output(v);
+      if (!v.includes("ref+openbao://")) return output(v);
       return secret(output(this.resolveText(v)));
     });
   }
 
   /**
-   * The async core `resolve` wraps: every reference in `v` replaced, or a
-   * thrown error for the first batch that cannot be. Public so the failure
-   * contract is testable as a plain promise — a rejected Output fans out
-   * through the SDK's internal sibling promises, which only the engine
-   * observes.
+   * The async core `resolve` wraps: the document with every reference
+   * expanded, or a thrown error. Public so the failure contract is testable
+   * as a plain promise — a rejected Output fans out through the SDK's
+   * internal sibling promises, which only the engine observes.
    */
-  public async resolveText(v: string): Promise<string> {
-    const refs = unique(Array.from(v.matchAll(REF_PATTERN))).map(m => m[0]);
-    const pending = refs.filter(ref => !this.resolved.has(ref));
-    if (pending.length > 0) this.register(pending);
-    const entries = await Promise.all(refs.map(async ref => [ref, await this.resolved.get(ref)!] as const));
-    const byRef = new Map(entries);
-    // matchAll found every occurrence, so the replace cannot miss: every full
-    // match is a key in the map.
-    return v.replace(REF_PATTERN, match => byRef.get(match) as string);
+  public resolveText(v: string): Promise<string> {
+    let pending = this.resolved.get(v);
+    if (!pending) {
+      pending = this.evaluate(v);
+      this.resolved.set(v, pending);
+      // A failed eval must not poison the memo forever — a retry (the
+      // operator reconciles on backoff) should re-run vals, not replay the
+      // rejection.
+      pending.catch(() => this.resolved.delete(v));
+    }
+    return pending;
   }
 
-  /**
-   * One `vals eval` for a batch of references: `{r0: ref, r1: ref, …}` in,
-   * the same keys with values out. Every reference in the batch settles from
-   * the one subprocess; if vals fails, they all reject with its stderr, which
-   * names the path it could not read.
-   */
-  private register(refs: string[]): void {
-    const batch = (async () => {
-      this.client ??= this.makeClient();
-      const doc = yaml.stringify(Object.fromEntries(refs.map((ref, i) => [`r${i}`, ref])));
-      const resolvedDoc = await this.exec(doc, {
-        VAULT_ADDR: this.client.address,
-        VAULT_TOKEN: await this.client.authToken(),
-      });
-      const parsed = yaml.parse(resolvedDoc) as Record<string, unknown>;
-      return refs.map((ref, i) => {
-        const value = parsed[`r${i}`];
-        // vals resolved it or errored the whole eval, so a non-string here is
-        // a shape surprise (a nested object from a directory-style path).
-        if (typeof value !== "string") throw new Error(`${ref}: vals returned ${value === undefined ? "nothing" : typeof value} rather than a string`);
-        return value;
-      });
-    })();
-    refs.forEach((ref, i) => this.resolved.set(ref, batch.then(values => values[i])));
-    // A failed batch must not poison the memo forever — a retry (the operator
-    // reconciles on backoff) should re-run vals, not replay the rejection.
-    batch.catch(() => refs.forEach(ref => this.resolved.delete(ref)));
+  private async evaluate(v: string): Promise<string> {
+    this.client ??= this.makeClient();
+    const doc = yaml.stringify({ content: v });
+    const resolvedDoc = await this.exec(doc, {
+      VAULT_ADDR: this.client.address,
+      VAULT_TOKEN: await this.client.authToken(),
+    });
+    const parsed = yaml.parse(resolvedDoc) as { content?: unknown } | null;
+    const content = parsed?.content;
+    if (typeof content !== "string") {
+      throw new Error(`vals eval returned ${content === undefined ? "no content" : typeof content} for a ${v.length}-byte document — expected the wrapped string back`);
+    }
+    // Scheme-shaped only (`ref+x://`): the provision.sh guard's `ref+*)` glob
+    // and prose mentioning "ref+" must not trip this when they share a file
+    // with a real reference.
+    const residue = Array.from(new Set(Array.from(content.matchAll(/ref\+[a-z0-9]+:\/\//g), m => m[0])));
+    if (residue.length > 0) {
+      // Schemes only, never spans: the surrounding content is resolved
+      // secrets by now, and an error message must not carry any of it.
+      throw new Error(`document still contains ${residue.length} unresolved secret-reference scheme(s) after vals eval: ${residue.join(", ")} — an unsupported provider, or a reference vals did not recognize`);
+    }
+    return content;
   }
 }
 
 /**
  * Spawn the real vals binary: `VALS_BIN` when set (the operator workspace
  * pods point it at the initContainer-installed copy), otherwise `vals` from
- * PATH (mise, locally). The batch goes in on stdin and comes back on stdout,
- * so no secret value ever touches argv or a file.
+ * PATH (mise, locally). The document goes in on stdin and comes back on
+ * stdout, so no secret value ever touches argv or a file.
  */
 function execVals(doc: string, env: Record<string, string>): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -158,16 +158,4 @@ function execVals(doc: string, env: Record<string, string>): Promise<string> {
     );
     child.stdin?.end(doc);
   });
-}
-
-function hasRefs(v: string): boolean {
-  // `search`, not `test`: the pattern is /g and `test` advances its
-  // lastIndex, which `matchAll` in resolveText would then inherit and skip
-  // the first reference. `search` neither reads nor writes lastIndex.
-  return v.search(REF_PATTERN) !== -1;
-}
-
-function unique(matches: RegExpMatchArray[]): RegExpMatchArray[] {
-  const seen = new Set<string>();
-  return matches.filter(m => (seen.has(m[0]) ? false : (seen.add(m[0]), true)));
 }

--- a/components/store/refs.ts
+++ b/components/store/refs.ts
@@ -60,6 +60,18 @@ import { BaoClient } from "../bao.ts";
 /** How a wrapped document reaches vals. Injectable for the tests. */
 export type ValsExec = (doc: string, env: Record<string, string>) => Promise<string>;
 
+/**
+ * Any scheme-shaped reference (`ref+x://`), NOT just openbao. The gate and
+ * the residue guard share this on purpose: a document whose only references
+ * use a not-yet-wired provider (`ref+sops://` is next, PLAN §D.2) must enter
+ * resolution and FAIL there — a gate that only knew openbao would skip vals
+ * for that document and ship the literal into a container, silently, with
+ * the residue guard never running. Deliberately loose on the provider name
+ * and strict on the shape, so the provision.sh guard's `ref+*)` glob and
+ * prose saying "ref+..." never match.
+ */
+const REF_SCHEME = /ref\+[a-z0-9]+:\/\//g;
+
 export class SecretRefResolver {
   /**
    * Constructed lazily on the first reference actually seen, so building a
@@ -83,7 +95,9 @@ export class SecretRefResolver {
    */
   public resolve(value: Input<string>): Output<string> {
     return output(value).apply(v => {
-      if (!v.includes("ref+openbao://")) return output(v);
+      // `search`, not `test`: the shared pattern is /g and `test` advances
+      // its lastIndex; `search` neither reads nor writes it.
+      if (v.search(REF_SCHEME) === -1) return output(v);
       return secret(output(this.resolveText(v)));
     });
   }
@@ -119,10 +133,7 @@ export class SecretRefResolver {
     if (typeof content !== "string") {
       throw new Error(`vals eval returned ${content === undefined ? "no content" : typeof content} for a ${v.length}-byte document — expected the wrapped string back`);
     }
-    // Scheme-shaped only (`ref+x://`): the provision.sh guard's `ref+*)` glob
-    // and prose mentioning "ref+" must not trip this when they share a file
-    // with a real reference.
-    const residue = Array.from(new Set(Array.from(content.matchAll(/ref\+[a-z0-9]+:\/\//g), m => m[0])));
+    const residue = Array.from(new Set(Array.from(content.matchAll(REF_SCHEME), m => m[0])));
     if (residue.length > 0) {
       // Schemes only, never spans: the surrounding content is resolved
       // secrets by now, and an error message must not carry any of it.

--- a/components/tailscale.ts
+++ b/components/tailscale.ts
@@ -1,6 +1,7 @@
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { FullItem } from "@1password/connect";
+import { baoKvSecret, baoProvenance, baoSlug } from "@components/bao.ts";
 import { OnePasswordItem, type OnePasswordItemSectionInput } from "@dynamic/1password/OnePasswordItem.ts";
 import type { TailscaleCidr } from "@openapi/tailscale-grants.js";
 import { remote, type types } from "@pulumi/command";
@@ -86,6 +87,13 @@ export function getTailscaleIp(name: pulumi.Input<string>, globals: GlobalResour
 
 export class TailscaleMonitor {
   private readonly services: string[] = [];
+  /**
+   * `globals` is here for `baoProvider`/`baoDualWriteEnabled` only — the
+   * monitor itself needs nothing else from it. Threading it through the
+   * construction sites is what PLAN §G-8 costs: the export is cross-stack
+   * inventory, and the producing side owns the OpenBao write.
+   */
+  constructor(private readonly globals: GlobalResources) {}
   public addService(name: string) {
     this.services.push(name);
   }
@@ -95,11 +103,13 @@ export class TailscaleMonitor {
       fields: Object.fromEntries(nodeState.map(z => [z.name, { value: z.externalIp }] as const)),
     };
 
-    return new OnePasswordItem(
-      `${pulumi.runtime.getStack()}-tailnet`,
+    const stack = pulumi.runtime.getStack();
+    const title = `Tailscale Export - ${stack}`;
+    const item = new OnePasswordItem(
+      `${stack}-tailnet`,
       {
         category: FullItem.CategoryEnum.SecureNote,
-        title: `Tailscale Export - ${pulumi.runtime.getStack()}`,
+        title: title,
         tags: ["tailscale-export"],
         sections: pulumi.output(nodeState).apply(nodes =>
           Object.fromEntries(
@@ -122,12 +132,56 @@ export class TailscaleMonitor {
           ),
         ),
         fields: {
-          name: { value: pulumi.runtime.getStack() },
+          name: { value: stack },
           services: { value: pulumi.jsonStringify(this.services) },
         },
       },
       cro,
     );
+
+    // Phase 8 dual-write (openbao-migration PLAN §G-8): the export also lands
+    // at its reserved inventory path (`clusters/_inventory/<slug(title)>`, the
+    // tag:tailscale-export rule in scripts/op-to-bao/mapping.ts) with the exact
+    // field shape of the OnePasswordItem above — `name`/`services` flat, one
+    // nested object per node. 1Password stays authoritative until Phase 11 —
+    // written ALONGSIDE the item, never instead of it; rollback is a plain
+    // `git revert`. `BaoStore.getTailscaleExports` refuses to serve consumers
+    // until every producing stack has run this once.
+    if (this.globals.baoDualWriteEnabled) {
+      baoKvSecret(
+        `${stack}-tailnet-bao`,
+        {
+          mount: "secrets",
+          path: `clusters/_inventory/${baoSlug(title)}`,
+          data: pulumi.output(nodeState).apply(nodes => ({
+            name: stack,
+            services: pulumi.jsonStringify(this.services),
+            ...Object.fromEntries(
+              [...nodes]
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map(
+                  z =>
+                    [
+                      z.name,
+                      {
+                        externalIp: z.externalIp,
+                        internalIp: z.internalIp,
+                        mac: z.mac,
+                        nodeType: z.nodeType ?? "unknown",
+                      },
+                    ] as const,
+                ),
+            ),
+          })),
+          customMetadata: baoProvenance({ source_title: title, source_tags: "tailscale-export" }),
+        },
+        pulumi.mergeOptions(cro, { provider: this.globals.baoProvider }) as pulumi.CustomResourceOptions,
+      );
+    } else {
+      pulumi.log.warn(`No OpenBao credentials (BAO_TOKEN, or BAO_ROLE_ID + BAO_SECRET_ID) — skipping the tailscale-export dual-write for ${stack}. 1Password stays authoritative; the inventory path stays stale until a credentialed run.`);
+    }
+
+    return item;
   }
 }
 

--- a/docker/_common/postgres/provision.sh
+++ b/docker/_common/postgres/provision.sh
@@ -45,12 +45,14 @@ for var_name in $(env | sed -n 's/^\(PGAPP_[A-Za-z0-9_]*_PASSWORD\)=.*/\1/p'); d
     continue
   fi
 
-  # An unresolved 1Password reference means the item or field is missing and
-  # the placeholder was passed through verbatim. Creating a role whose password
-  # is the literal string "op://..." would be worse than failing loudly.
+  # An unresolved secret reference means the item or field is missing and the
+  # placeholder was passed through verbatim. Creating a role whose password is
+  # the literal string "op://..." or "ref+..." would be worse than failing
+  # loudly. Both syntaxes are guarded during the 1Password->OpenBao dual-run:
+  # op:// is the 1Password resolver, ref+ is the OpenBao one (PLAN section D.1).
   case "$app_pw" in
-    op://*)
-      echo "[provision] SKIP ${var_name}: 1Password reference did not resolve" >&2
+    op://* | ref+*)
+      echo "[provision] SKIP ${var_name}: secret reference did not resolve" >&2
       continue
       ;;
   esac

--- a/docker/alpha-site/arcane-agent/token.env
+++ b/docker/alpha-site/arcane-agent/token.env
@@ -1,1 +1,1 @@
-AGENT_TOKEN="op://Eris/soz3lyvs6k24e5gh3udqp4sngi/arcane_token"
+AGENT_TOKEN="ref+openbao://secrets/clusters/alpha-site/arcane-agent#/arcane_token"

--- a/docker/alpha-site/uptime/config/default.yaml
+++ b/docker/alpha-site/uptime/config/default.yaml
@@ -10,8 +10,8 @@ concurrency: 2
 
 alerting:
   pushover:
-    application-token: "op://Eris/Gatus Pushover Key/credential"
-    user-key: "op://Eris/Gatus Pushover Key/username"
+    application-token: "ref+openbao://secrets/shared/gatus-pushover-key#/credential"
+    user-key: "ref+openbao://secrets/shared/gatus-pushover-key#/username"
     priority: 1
     resolved-priority: -1
     default-alert:

--- a/docker/celestia/pdm/compose.yaml
+++ b/docker/celestia/pdm/compose.yaml
@@ -10,7 +10,7 @@ services:
     cap_add:
       - ALL
     environment:
-      PASSWORD: "op://Eris/pdm-root/password"
+      PASSWORD: "ref+openbao://secrets/shared/pdm-root#/password"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup
       - /opt/stacks-data/pdm:/etc/proxmox-datacenter-manager

--- a/docker/luna/arcane-agent/token.env
+++ b/docker/luna/arcane-agent/token.env
@@ -1,1 +1,1 @@
-AGENT_TOKEN="op://Eris/723isf7wjflcgvccwygmkaillm/arcane_token"
+AGENT_TOKEN="ref+openbao://secrets/clusters/luna/arcane-agent#/arcane_token"

--- a/docker/skystar/arcane-agent/token.env
+++ b/docker/skystar/arcane-agent/token.env
@@ -1,1 +1,1 @@
-AGENT_TOKEN="op://Eris/akxrrdbgw3qcyomvuu5x74b7je/arcane_token"
+AGENT_TOKEN="ref+openbao://secrets/clusters/skystar/arcane-agent#/arcane_token"

--- a/kubernetes/apps/pulumi/applications/equestria.yaml
+++ b/kubernetes/apps/pulumi/applications/equestria.yaml
@@ -87,6 +87,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/applications/equestria.yaml
+++ b/kubernetes/apps/pulumi/applications/equestria.yaml
@@ -125,6 +125,11 @@ spec:
         # instead of ballooning until the kernel OOM-kills the whole process tree.
         - name: NODE_OPTIONS
           value: "--max-old-space-size=4096"
+        # Where the vals initContainer put the binary; the ref+openbao://
+        # resolver spawns it (components/store/refs.ts). Locally VALS_BIN is
+        # unset and vals comes from mise's PATH.
+        - name: VALS_BIN
+          value: /opt/vals/vals
       resources:
         requests:
           cpu: 200m
@@ -139,9 +144,43 @@ spec:
               hostPath:
                 path: /var/lib/pulumi-npm-cache
                 type: DirectoryOrCreate
+            - name: vals-bin
+              emptyDir: {}
+            - name: mise-data
+              hostPath:
+                path: /var/lib/pulumi-mise-data
+                type: DirectoryOrCreate
+          # Installs the vals binary for the ref+openbao:// resolver
+          # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
+          # the pin lives in the mise ecosystem — keep the version in step
+          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
+          # cache mirroring npm-cache, so after the first run on a node this
+          # is a copy, not a download. Kubernetes `command:` replaces the
+          # image's `mise` entrypoint, deliberately.
+          initContainers:
+            - name: vals
+              # renovate: datasource=docker depName=jdxcode/mise
+              image: jdxcode/mise:2026.8.3
+              command: ["/bin/sh", "-ec"]
+              args:
+                - |
+                  mise install vals@0.45.0
+                  mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
+              env:
+                - name: MISE_DATA_DIR
+                  value: /mise-data
+                - name: MISE_YES
+                  value: "1"
+              volumeMounts:
+                - name: vals-bin
+                  mountPath: /opt/vals
+                - name: mise-data
+                  mountPath: /mise-data
           containers:
             - name: pulumi
               volumeMounts:
                 - name: npm-cache
                   mountPath: /root/.npm
+                - name: vals-bin
+                  mountPath: /opt/vals
       # pulumiLogLevel: 11

--- a/kubernetes/apps/pulumi/applications/sgc.yaml
+++ b/kubernetes/apps/pulumi/applications/sgc.yaml
@@ -87,6 +87,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/applications/sgc.yaml
+++ b/kubernetes/apps/pulumi/applications/sgc.yaml
@@ -125,6 +125,11 @@ spec:
         # instead of ballooning until the kernel OOM-kills the whole process tree.
         - name: NODE_OPTIONS
           value: "--max-old-space-size=4096"
+        # Where the vals initContainer put the binary; the ref+openbao://
+        # resolver spawns it (components/store/refs.ts). Locally VALS_BIN is
+        # unset and vals comes from mise's PATH.
+        - name: VALS_BIN
+          value: /opt/vals/vals
       resources:
         requests:
           cpu: 200m
@@ -139,9 +144,43 @@ spec:
               hostPath:
                 path: /var/lib/pulumi-npm-cache
                 type: DirectoryOrCreate
+            - name: vals-bin
+              emptyDir: {}
+            - name: mise-data
+              hostPath:
+                path: /var/lib/pulumi-mise-data
+                type: DirectoryOrCreate
+          # Installs the vals binary for the ref+openbao:// resolver
+          # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
+          # the pin lives in the mise ecosystem — keep the version in step
+          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
+          # cache mirroring npm-cache, so after the first run on a node this
+          # is a copy, not a download. Kubernetes `command:` replaces the
+          # image's `mise` entrypoint, deliberately.
+          initContainers:
+            - name: vals
+              # renovate: datasource=docker depName=jdxcode/mise
+              image: jdxcode/mise:2026.8.3
+              command: ["/bin/sh", "-ec"]
+              args:
+                - |
+                  mise install vals@0.45.0
+                  mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
+              env:
+                - name: MISE_DATA_DIR
+                  value: /mise-data
+                - name: MISE_YES
+                  value: "1"
+              volumeMounts:
+                - name: vals-bin
+                  mountPath: /opt/vals
+                - name: mise-data
+                  mountPath: /mise-data
           containers:
             - name: pulumi
               volumeMounts:
                 - name: npm-cache
                   mountPath: /root/.npm
+                - name: vals-bin
+                  mountPath: /opt/vals
       # pulumiLogLevel: 11

--- a/kubernetes/apps/pulumi/authentik/stack.yaml
+++ b/kubernetes/apps/pulumi/authentik/stack.yaml
@@ -126,6 +126,11 @@ spec:
         # instead of ballooning until the kernel OOM-kills the whole process tree.
         - name: NODE_OPTIONS
           value: "--max-old-space-size=4096"
+        # Where the vals initContainer put the binary; the ref+openbao://
+        # resolver spawns it (components/store/refs.ts). Locally VALS_BIN is
+        # unset and vals comes from mise's PATH.
+        - name: VALS_BIN
+          value: /opt/vals/vals
       resources:
         requests:
           cpu: 200m
@@ -140,6 +145,38 @@ spec:
               hostPath:
                 path: /var/lib/pulumi-npm-cache
                 type: DirectoryOrCreate
+            - name: vals-bin
+              emptyDir: {}
+            - name: mise-data
+              hostPath:
+                path: /var/lib/pulumi-mise-data
+                type: DirectoryOrCreate
+          # Installs the vals binary for the ref+openbao:// resolver
+          # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
+          # the pin lives in the mise ecosystem — keep the version in step
+          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
+          # cache mirroring npm-cache, so after the first run on a node this
+          # is a copy, not a download. Kubernetes `command:` replaces the
+          # image's `mise` entrypoint, deliberately.
+          initContainers:
+            - name: vals
+              # renovate: datasource=docker depName=jdxcode/mise
+              image: jdxcode/mise:2026.8.3
+              command: ["/bin/sh", "-ec"]
+              args:
+                - |
+                  mise install vals@0.45.0
+                  mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
+              env:
+                - name: MISE_DATA_DIR
+                  value: /mise-data
+                - name: MISE_YES
+                  value: "1"
+              volumeMounts:
+                - name: vals-bin
+                  mountPath: /opt/vals
+                - name: mise-data
+                  mountPath: /mise-data
           containers:
             - name: pulumi
               resources:
@@ -151,4 +188,6 @@ spec:
               volumeMounts:
                 - name: npm-cache
                   mountPath: /root/.npm
+                - name: vals-bin
+                  mountPath: /opt/vals
       # pulumiLogLevel: 11

--- a/kubernetes/apps/pulumi/authentik/stack.yaml
+++ b/kubernetes/apps/pulumi/authentik/stack.yaml
@@ -88,6 +88,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/backups/stack.yaml
+++ b/kubernetes/apps/pulumi/backups/stack.yaml
@@ -126,6 +126,11 @@ spec:
         # instead of ballooning until the kernel OOM-kills the whole process tree.
         - name: NODE_OPTIONS
           value: "--max-old-space-size=4096"
+        # Where the vals initContainer put the binary; the ref+openbao://
+        # resolver spawns it (components/store/refs.ts). Locally VALS_BIN is
+        # unset and vals comes from mise's PATH.
+        - name: VALS_BIN
+          value: /opt/vals/vals
       resources:
         requests:
           cpu: 200m
@@ -140,6 +145,38 @@ spec:
               hostPath:
                 path: /var/lib/pulumi-npm-cache
                 type: DirectoryOrCreate
+            - name: vals-bin
+              emptyDir: {}
+            - name: mise-data
+              hostPath:
+                path: /var/lib/pulumi-mise-data
+                type: DirectoryOrCreate
+          # Installs the vals binary for the ref+openbao:// resolver
+          # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
+          # the pin lives in the mise ecosystem — keep the version in step
+          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
+          # cache mirroring npm-cache, so after the first run on a node this
+          # is a copy, not a download. Kubernetes `command:` replaces the
+          # image's `mise` entrypoint, deliberately.
+          initContainers:
+            - name: vals
+              # renovate: datasource=docker depName=jdxcode/mise
+              image: jdxcode/mise:2026.8.3
+              command: ["/bin/sh", "-ec"]
+              args:
+                - |
+                  mise install vals@0.45.0
+                  mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
+              env:
+                - name: MISE_DATA_DIR
+                  value: /mise-data
+                - name: MISE_YES
+                  value: "1"
+              volumeMounts:
+                - name: vals-bin
+                  mountPath: /opt/vals
+                - name: mise-data
+                  mountPath: /mise-data
           containers:
             - name: pulumi
               resources:
@@ -151,4 +188,6 @@ spec:
               volumeMounts:
                 - name: npm-cache
                   mountPath: /root/.npm
+                - name: vals-bin
+                  mountPath: /opt/vals
       # pulumiLogLevel: 11

--- a/kubernetes/apps/pulumi/backups/stack.yaml
+++ b/kubernetes/apps/pulumi/backups/stack.yaml
@@ -88,6 +88,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
+++ b/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
@@ -126,6 +126,11 @@ spec:
         # instead of ballooning until the kernel OOM-kills the whole process tree.
         - name: NODE_OPTIONS
           value: "--max-old-space-size=4096"
+        # Where the vals initContainer put the binary; the ref+openbao://
+        # resolver spawns it (components/store/refs.ts). Locally VALS_BIN is
+        # unset and vals comes from mise's PATH.
+        - name: VALS_BIN
+          value: /opt/vals/vals
       resources:
         requests:
           cpu: 200m
@@ -140,6 +145,38 @@ spec:
               hostPath:
                 path: /var/lib/pulumi-npm-cache
                 type: DirectoryOrCreate
+            - name: vals-bin
+              emptyDir: {}
+            - name: mise-data
+              hostPath:
+                path: /var/lib/pulumi-mise-data
+                type: DirectoryOrCreate
+          # Installs the vals binary for the ref+openbao:// resolver
+          # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
+          # the pin lives in the mise ecosystem — keep the version in step
+          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
+          # cache mirroring npm-cache, so after the first run on a node this
+          # is a copy, not a download. Kubernetes `command:` replaces the
+          # image's `mise` entrypoint, deliberately.
+          initContainers:
+            - name: vals
+              # renovate: datasource=docker depName=jdxcode/mise
+              image: jdxcode/mise:2026.8.3
+              command: ["/bin/sh", "-ec"]
+              args:
+                - |
+                  mise install vals@0.45.0
+                  mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
+              env:
+                - name: MISE_DATA_DIR
+                  value: /mise-data
+                - name: MISE_YES
+                  value: "1"
+              volumeMounts:
+                - name: vals-bin
+                  mountPath: /opt/vals
+                - name: mise-data
+                  mountPath: /mise-data
           containers:
             - name: pulumi
               resources:
@@ -151,3 +188,5 @@ spec:
               volumeMounts:
                 - name: npm-cache
                   mountPath: /root/.npm
+                - name: vals-bin
+                  mountPath: /opt/vals

--- a/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
+++ b/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
@@ -88,6 +88,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/home-operations/stack.yaml
+++ b/kubernetes/apps/pulumi/home-operations/stack.yaml
@@ -127,6 +127,11 @@ spec:
         # instead of ballooning until the kernel OOM-kills the whole process tree.
         - name: NODE_OPTIONS
           value: "--max-old-space-size=4096"
+        # Where the vals initContainer put the binary; the ref+openbao://
+        # resolver spawns it (components/store/refs.ts). Locally VALS_BIN is
+        # unset and vals comes from mise's PATH.
+        - name: VALS_BIN
+          value: /opt/vals/vals
       resources:
         requests:
           cpu: 200m
@@ -141,6 +146,38 @@ spec:
               hostPath:
                 path: /var/lib/pulumi-npm-cache
                 type: DirectoryOrCreate
+            - name: vals-bin
+              emptyDir: {}
+            - name: mise-data
+              hostPath:
+                path: /var/lib/pulumi-mise-data
+                type: DirectoryOrCreate
+          # Installs the vals binary for the ref+openbao:// resolver
+          # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
+          # the pin lives in the mise ecosystem — keep the version in step
+          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
+          # cache mirroring npm-cache, so after the first run on a node this
+          # is a copy, not a download. Kubernetes `command:` replaces the
+          # image's `mise` entrypoint, deliberately.
+          initContainers:
+            - name: vals
+              # renovate: datasource=docker depName=jdxcode/mise
+              image: jdxcode/mise:2026.8.3
+              command: ["/bin/sh", "-ec"]
+              args:
+                - |
+                  mise install vals@0.45.0
+                  mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
+              env:
+                - name: MISE_DATA_DIR
+                  value: /mise-data
+                - name: MISE_YES
+                  value: "1"
+              volumeMounts:
+                - name: vals-bin
+                  mountPath: /opt/vals
+                - name: mise-data
+                  mountPath: /mise-data
           containers:
             - name: pulumi
               resources:
@@ -152,4 +189,6 @@ spec:
               volumeMounts:
                 - name: npm-cache
                   mountPath: /root/.npm
+                - name: vals-bin
+                  mountPath: /opt/vals
       # pulumiLogLevel: 11

--- a/kubernetes/apps/pulumi/home-operations/stack.yaml
+++ b/kubernetes/apps/pulumi/home-operations/stack.yaml
@@ -89,6 +89,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/ocracoke/stack.yaml
+++ b/kubernetes/apps/pulumi/ocracoke/stack.yaml
@@ -126,6 +126,11 @@ spec:
         # instead of ballooning until the kernel OOM-kills the whole process tree.
         - name: NODE_OPTIONS
           value: "--max-old-space-size=4096"
+        # Where the vals initContainer put the binary; the ref+openbao://
+        # resolver spawns it (components/store/refs.ts). Locally VALS_BIN is
+        # unset and vals comes from mise's PATH.
+        - name: VALS_BIN
+          value: /opt/vals/vals
       resources:
         requests:
           cpu: 200m
@@ -140,6 +145,38 @@ spec:
               hostPath:
                 path: /var/lib/pulumi-npm-cache
                 type: DirectoryOrCreate
+            - name: vals-bin
+              emptyDir: {}
+            - name: mise-data
+              hostPath:
+                path: /var/lib/pulumi-mise-data
+                type: DirectoryOrCreate
+          # Installs the vals binary for the ref+openbao:// resolver
+          # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
+          # the pin lives in the mise ecosystem — keep the version in step
+          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
+          # cache mirroring npm-cache, so after the first run on a node this
+          # is a copy, not a download. Kubernetes `command:` replaces the
+          # image's `mise` entrypoint, deliberately.
+          initContainers:
+            - name: vals
+              # renovate: datasource=docker depName=jdxcode/mise
+              image: jdxcode/mise:2026.8.3
+              command: ["/bin/sh", "-ec"]
+              args:
+                - |
+                  mise install vals@0.45.0
+                  mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
+              env:
+                - name: MISE_DATA_DIR
+                  value: /mise-data
+                - name: MISE_YES
+                  value: "1"
+              volumeMounts:
+                - name: vals-bin
+                  mountPath: /opt/vals
+                - name: mise-data
+                  mountPath: /mise-data
           containers:
             - name: pulumi
               resources:
@@ -151,3 +188,5 @@ spec:
               volumeMounts:
                 - name: npm-cache
                   mountPath: /root/.npm
+                - name: vals-bin
+                  mountPath: /opt/vals

--- a/kubernetes/apps/pulumi/ocracoke/stack.yaml
+++ b/kubernetes/apps/pulumi/ocracoke/stack.yaml
@@ -88,6 +88,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/unifi-network/stack.yaml
+++ b/kubernetes/apps/pulumi/unifi-network/stack.yaml
@@ -87,6 +87,14 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password. Explicit, never inferred from credential presence — see
+    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
+    # this was scripts/bao-store-parity.ts fully green, inventory included.
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/unifi-network/stack.yaml
+++ b/kubernetes/apps/pulumi/unifi-network/stack.yaml
@@ -125,6 +125,11 @@ spec:
         # instead of ballooning until the kernel OOM-kills the whole process tree.
         - name: NODE_OPTIONS
           value: "--max-old-space-size=4096"
+        # Where the vals initContainer put the binary; the ref+openbao://
+        # resolver spawns it (components/store/refs.ts). Locally VALS_BIN is
+        # unset and vals comes from mise's PATH.
+        - name: VALS_BIN
+          value: /opt/vals/vals
       resources:
         requests:
           cpu: 200m
@@ -139,6 +144,38 @@ spec:
               hostPath:
                 path: /var/lib/pulumi-npm-cache
                 type: DirectoryOrCreate
+            - name: vals-bin
+              emptyDir: {}
+            - name: mise-data
+              hostPath:
+                path: /var/lib/pulumi-mise-data
+                type: DirectoryOrCreate
+          # Installs the vals binary for the ref+openbao:// resolver
+          # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
+          # the pin lives in the mise ecosystem — keep the version in step
+          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
+          # cache mirroring npm-cache, so after the first run on a node this
+          # is a copy, not a download. Kubernetes `command:` replaces the
+          # image's `mise` entrypoint, deliberately.
+          initContainers:
+            - name: vals
+              # renovate: datasource=docker depName=jdxcode/mise
+              image: jdxcode/mise:2026.8.3
+              command: ["/bin/sh", "-ec"]
+              args:
+                - |
+                  mise install vals@0.45.0
+                  mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
+              env:
+                - name: MISE_DATA_DIR
+                  value: /mise-data
+                - name: MISE_YES
+                  value: "1"
+              volumeMounts:
+                - name: vals-bin
+                  mountPath: /opt/vals
+                - name: mise-data
+                  mountPath: /mise-data
           containers:
             - name: pulumi
               resources:
@@ -150,4 +187,6 @@ spec:
               volumeMounts:
                 - name: npm-cache
                   mountPath: /root/.npm
+                - name: vals-bin
+                  mountPath: /opt/vals
       # pulumiLogLevel: 11

--- a/scripts/bao-store-parity.ts
+++ b/scripts/bao-store-parity.ts
@@ -221,4 +221,37 @@ try {
   console.log(`FAIL  Authentik Outputs (inventory): ${error instanceof Error ? error.message : String(error)}`);
 }
 
+// Tailscale exports: produced by three stacks, consumed by unifi-network's ACL
+// and DHCP generation — the read where a wrong SET quietly removes live
+// config. Both stores shape through the same function, so what is compared
+// here is the data each store found. This section FAILS until every producing
+// stack has run its dual-write; that failing is the §G-8 gate doing its job —
+// do not flip BAO_STORE_READS while it is red.
+try {
+  const [a, b] = await Promise.all([resolve(op.getTailscaleExports()), resolve(bao.getTailscaleExports())]);
+  const aJson = JSON.stringify(a);
+  const bJson = JSON.stringify(b);
+  if (aJson === bJson) {
+    console.log(`OK    getTailscaleExports (${a.length} stacks, ${a.reduce((n, e) => n + e.hosts.length, 0)} hosts)`);
+  } else {
+    failures++;
+    console.log("DIFF  getTailscaleExports");
+    console.log(`        tag:tailscale-export   ${a.map(e => `${e.name}(${e.hosts.length})`).join(", ")}`);
+    console.log(`        _inventory/            ${b.map(e => `${e.name}(${e.hosts.length})`).join(", ")}`);
+    // IPs and MACs are addressing, not credentials, but stay consistent with
+    // the rest of this script: name the hosts, never print field values.
+    for (const exp of a) {
+      const other = b.find(e => e.name === exp.name);
+      if (!other) continue;
+      const drifted = exp.hosts.filter(h => JSON.stringify(h) !== JSON.stringify(other.hosts.find(o => o.name === h.name)));
+      if (drifted.length || JSON.stringify(exp.services) !== JSON.stringify(other.services)) {
+        console.log(`        ${exp.name}: differing hosts: ${drifted.map(h => h.name).join(", ") || "none"}${JSON.stringify(exp.services) !== JSON.stringify(other.services) ? "; services differ" : ""}`);
+      }
+    }
+  }
+} catch (error) {
+  failures++;
+  console.log(`FAIL  getTailscaleExports: ${error instanceof Error ? error.message : String(error)}`);
+}
+
 process.exit(failures === 0 ? 0 : 1);

--- a/scripts/bao-store-parity.ts
+++ b/scripts/bao-store-parity.ts
@@ -254,4 +254,29 @@ try {
   console.log(`FAIL  getTailscaleExports: ${error instanceof Error ? error.message : String(error)}`);
 }
 
+// Backup plans: produced by stacks/backups and both applications stacks,
+// consumed by the three BackupPlanDirectors. A wrong SET here silently shrinks
+// what gets backed up. Same gate semantics as getTailscaleExports: this
+// section FAILS until every producing stack has run its dual-write — do not
+// flip BAO_STORE_READS while it is red.
+try {
+  const [a, b] = await Promise.all([resolve(op.getBackupPlans<{ source: string; name: string }>()), resolve(bao.getBackupPlans<{ source: string; name: string }>())]);
+  const key = (plans: { source: string; name: string }[]) =>
+    plans
+      .map(p => `${p.source}/${p.name}`)
+      .sort()
+      .join(", ");
+  if (JSON.stringify([...a].sort((x, y) => `${x.source}/${x.name}`.localeCompare(`${y.source}/${y.name}`))) === JSON.stringify([...b].sort((x, y) => `${x.source}/${x.name}`.localeCompare(`${y.source}/${y.name}`)))) {
+    console.log(`OK    getBackupPlans (${a.length} plans)`);
+  } else {
+    failures++;
+    console.log("DIFF  getBackupPlans");
+    console.log(`        tag:backup-plan   ${key(a)}`);
+    console.log(`        _inventory/       ${key(b)}`);
+  }
+} catch (error) {
+  failures++;
+  console.log(`FAIL  getBackupPlans: ${error instanceof Error ? error.message : String(error)}`);
+}
+
 process.exit(failures === 0 ? 0 : 1);

--- a/stacks/applications/kubernetes.ts
+++ b/stacks/applications/kubernetes.ts
@@ -173,7 +173,7 @@ export async function kubernetesApplications(globals: GlobalResources, outputs: 
     },
     { parent: applicationManager.outpostsComponent, deleteBeforeReplace: true },
   );
-  const backupPlanOrchestrator = new BackupPlanOrchestrator("backup-plan-orchestrator");
+  const backupPlanOrchestrator = new BackupPlanOrchestrator("backup-plan-orchestrator", globals);
 
   await awaitOutput(
     pulumi.all([kubernetesBackups(globals, backupPlanOrchestrator, clusterDefinition)]).apply(() => {

--- a/stacks/backups/index.ts
+++ b/stacks/backups/index.ts
@@ -5,7 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 const globals = new GlobalResources({}, {});
 const dockgeDetails = globals.store.getDockgeInstances();
 
-const backupPlanOrchestrator = new BackupPlanOrchestrator("backup-plan-orchestrator");
+const backupPlanOrchestrator = new BackupPlanOrchestrator("backup-plan-orchestrator", globals);
 
 const dockgeInstances = dockgeDetails.apply(details => {
   return details.map(detail => {

--- a/stacks/gulf-of-mexico/index.ts
+++ b/stacks/gulf-of-mexico/index.ts
@@ -11,7 +11,7 @@ import { ProxmoxBackupServerLxc } from "../../components/ProxmoxBackupServerLxc.
 import { getProxmoxProperties, ProxmoxHost } from "../../components/ProxmoxHost.ts";
 
 const globals = new GlobalResources({}, {});
-const monitor = new TailscaleMonitor();
+const monitor = new TailscaleMonitor(globals);
 const backupDirector = new BackupPlanDirector("backup-plan-director", {
   globals,
 });

--- a/stacks/home/index.ts
+++ b/stacks/home/index.ts
@@ -17,7 +17,7 @@ import { createGatusDnsUptime } from "../../components/StandardDns.ts";
 import { TruenasVm } from "../../components/TruenasVm.ts";
 
 const globals = new GlobalResources({}, {});
-const monitor = new TailscaleMonitor();
+const monitor = new TailscaleMonitor(globals);
 const backupDirector = new BackupPlanDirector("backup-plan-director", {
   globals,
 });

--- a/stacks/ocracoke/index.ts
+++ b/stacks/ocracoke/index.ts
@@ -12,7 +12,7 @@ import { ProxmoxBackupServerLxc } from "../../components/ProxmoxBackupServerLxc.
 import { getProxmoxProperties, ProxmoxHost } from "../../components/ProxmoxHost.ts";
 
 const globals = new GlobalResources({}, {});
-const monitor = new TailscaleMonitor();
+const monitor = new TailscaleMonitor(globals);
 const backupDirector = new BackupPlanDirector("backup-plan-director", {
   globals,
 });


### PR DESCRIPTION
The second half of the consolidation described in #723 — this branch carries the already-approved **#721** merge (the `BAO_STORE_READS` flip). Once #723 merged, this PR's diff shrank to exactly the flip.

**Draft until the gate below is satisfied, in order:**

- [x] #723 merged — producers ran, all six `_inventory` paths verified live 2026-08-11
- [ ] **#725 merged** — the parity gate caught that the 1Password write-back has been silently dead since June (`OnePasswordItem.diff` discarded every replace/remove op) and that the June volsync rename would have re-rooted every restic history had it ever applied. Both fixed there; the DIFFs parity reported were stale-1Password, not bad KV.
- [ ] The producing stacks have re-run since #725 (backups, applications×2, home-operations, ocracoke, gulf-of-mexico) — 1P items refresh, KV inventory carries id-safe plan names
- [ ] `scripts/bao-store-parity.ts` **fully green** — now genuinely achievable
- [ ] Per STATUS.md's procedural rule: judge the first post-flip preview against a same-store control run, comparing resource-operation lines with `*-mkdir` excluded

Expected choreography after *this* PR merges: nothing — the eight-stack parity sweep already proved identical previews under the flag, and the guarded reads only error if the inventory regresses. If a consumer run fails naming a missing `_inventory` key, that is the §G-8 guard doing its job; check which producer has not run rather than reverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)