### PR TITLE
fix(1password): value-only changes update items again; volsync plan names are identities

### DIFF
--- a/components/BackupPlanOrchestrator.ts
+++ b/components/BackupPlanOrchestrator.ts
@@ -16,7 +16,14 @@ export interface PreSyncArgs {
 
 export interface BackupPlanItem {
   source: "celestia" | "skystar" | "luna" | "volsync";
+  /**
+   * Identity: the backrest repo id, plan id, and backup path all derive from
+   * this. Must be id-safe and STABLE — renaming it re-roots the plan's restic
+   * history.
+   */
   name: string;
+  /** Display label (Gatus, dashboards). Safe to change; nothing derives from it. */
+  title?: string;
   planConfig?: Omit<BackrestPlan, "id" | "repo" | "paths">;
   repositoryConfig?: Omit<BackrestRepository, "guid" | "uri" | "id" | "autoUnlock" | "autoInitialize">;
   path: string;

--- a/dynamic/1password/OnePasswordItem.ts
+++ b/dynamic/1password/OnePasswordItem.ts
@@ -145,10 +145,18 @@ class OnePasswordItemProvider implements pulumi.dynamic.ResourceProvider {
     const compareOlds = await awaitOutput(getSecretItem(oldOutputs));
     const compareNews = await awaitOutput(getSecretItem(fullNewInputs));
     const delta = differ.diff(compareOlds, compareNews);
+    // Drop `move` noise and `add`s of null; KEEP replace/remove. The previous
+    // form (`z.op === "add" && z.value !== null`) kept ONLY adds, so a changed
+    // field VALUE reported "no changes detected" and the item never updated —
+    // silently, for months: the Backup Plan items froze on 2026-06-09 and the
+    // Tailscale Exports on 2026-07-27 (the last time something was ADDED),
+    // while Authentik Outputs kept updating because new scope mappings are
+    // adds. Found by the Phase 8 parity gate, which compared these items
+    // against the fresh OpenBao dual-writes from the very same runs.
     const patch = jsonpatch
       .format(delta)
       .filter(z => z.op !== "move")
-      .filter(z => z.op === "add" && z.value !== null);
+      .filter(z => !(z.op === "add" && z.value === null));
     // .filter((change) => {
     //   if (change.op === "remove" && (change.path.endsWith("/id") || change.path.endsWith("/section"))) return false;
     //   if (change.path.startsWith("/fields") && change.path.endsWith("/id")) return false;

--- a/stacks/applications/kubernetes-backups.ts
+++ b/stacks/applications/kubernetes-backups.ts
@@ -70,7 +70,16 @@ export async function kubernetesBackups(_globals: GlobalResources, planManager: 
           return planManager.addBackupPlan(
             pulumi.output({
               source: "volsync",
-              name: pulumi.interpolate`${clusterDefinition.title} ${relatedApp?.spec.name ?? job}`,
+              // `name` is an IDENTITY, not a label: BackupPlanDirector uses it
+              // as the backrest repo id, plan id, and the /data/backup/<name>/
+              // path — so it must stay the id-safe slug production backrest
+              // already carries, or every volsync backup re-roots into a new
+              // restic history. The display-cased form ("Equestria autobrr")
+              // lives in `title`. It shipped as `name` in ced3c316 but never
+              // took effect: the OnePasswordItem diff bug (fixed alongside
+              // this) meant the directors kept reading the pre-rename plans.
+              name: `${clusterDefinition.key}-volsync-${job}`,
+              title: pulumi.interpolate`${clusterDefinition.title} ${relatedApp?.spec.name ?? job}`,
               repository: `${clusterDefinition.key}-volsync-${job}`,
               path: `/spike/backup/${clusterDefinition.key}/volsync/${job}`,
             }),


### PR DESCRIPTION
The Phase 8 parity gate ran after #723's producers completed — and its two DIFFs turned out to be **the migration exposing a real, months-old estate bug**, not migration drift. This PR is the fix, and it must merge **before** the #724 flip.

## What the parity gate found

The fresh OpenBao inventory (written by yesterday's runs) did not match the 1Password items — because the 1Password items are **stale**, verified via Connect `updatedAt`:

| Item | last updated |
|---|---|
| Backup Plan / Equestria Backup Plan / Stargate Command Backup Plan | **2026-06-09** |
| Tailscale Export - {home-operations, ocracoke, gulf-of-mexico} | **2026-07-27** |
| Authentik Outputs | 2026-08-11 (today — kept working) |

The stale export items still list retired `svc:adguard-as` and know nothing of `svc:git`, `svc:bao-transit`, `svc:technitium-as`; the stale plans still contain the dead `adguard-home-0/1/2` volumes and miss every app added since June.

## Fix 1 — the `diff()` filter kept only `add` ops

```ts
.filter(z => z.op === "add" && z.value !== null)   // discards every replace/remove
```

A changed field **value** produced "no changes detected", so `update` never ran. That's why adds-heavy items (Authentik Outputs' new scope mappings) kept updating while value-only items froze. Now: drop `move` noise and null-adds, keep everything else.

## Fix 2 — the June rename was a loaded gun the diff bug kept holstered

`ced3c316` ("I like nice names") renamed volsync plans to `Equestria autobrr` style — but `BackupPlanDirector` uses `plan.name` as the **backrest repo id, plan id, and `/data/backup/<name>/` path**. Had the write-back worked, every volsync backup would have re-rooted into a fresh restic history under a space-containing id. `name` reverts to the id-safe slug production backrest actually carries; the nice name becomes a `title` field (display-only; celestia plans already ship one).

## Rollout expectations after merging

- First runs re-write the 1P items (via replace — the resource is `deleteBeforeReplace`; nothing references these items by UUID) and the KV inventory with identical, current content.
- The directors — still reading 1Password until #724 — finally receive June-onward reality: **new backrest plans** for `crowdsec-ui`, `technitium`, `tududi` (equestria), `matter`, `technitium`, `tsiam` (SGC), and the dead `adguard-home-0/1/2` plans drop out. Existing plan ids/paths are byte-identical, so no restic history moves.
- `scripts/bao-store-parity.ts` then goes **fully green for real**, which re-arms #724's original merge gate.

Verified: 33/33 store tests, tsc clean on `applications` and `backups`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)