### PR TITLE
fix(pulumi): vals initContainer installs into a pod-local dir, shares only the download cache

### DIFF
--- a/kubernetes/apps/pulumi/applications/equestria.yaml
+++ b/kubernetes/apps/pulumi/applications/equestria.yaml
@@ -147,16 +147,24 @@ spec:
             - name: vals-bin
               emptyDir: {}
             - name: mise-data
+              emptyDir: {}
+            - name: mise-cache
               hostPath:
-                path: /var/lib/pulumi-mise-data
+                path: /var/lib/pulumi-mise-cache
                 type: DirectoryOrCreate
           # Installs the vals binary for the ref+openbao:// resolver
           # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
           # the pin lives in the mise ecosystem — keep the version in step
-          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
-          # cache mirroring npm-cache, so after the first run on a node this
-          # is a copy, not a download. Kubernetes `command:` replaces the
+          # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
+          #
+          # The INSTALL dir is pod-local on purpose: concurrent installs into
+          # a shared hostPath wedge it permanently — observed live, five
+          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
+          # after racing a cold node cache. Only the DOWNLOAD cache is shared
+          # (the expensive part); the extract is cheap. Any node's old
+          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
+          # delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -164,11 +172,19 @@ spec:
               command: ["/bin/sh", "-ec"]
               args:
                 - |
-                  mise install vals@0.45.0
+                  ok=""
+                  for attempt in 1 2 3; do
+                    if mise install vals@0.45.0; then ok=1; break; fi
+                    echo "mise install failed (attempt $attempt); retrying" >&2
+                    sleep 3
+                  done
+                  [ -n "$ok" ]
                   mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
               env:
                 - name: MISE_DATA_DIR
                   value: /mise-data
+                - name: MISE_CACHE_DIR
+                  value: /mise-cache
                 - name: MISE_YES
                   value: "1"
               volumeMounts:
@@ -176,6 +192,8 @@ spec:
                   mountPath: /opt/vals
                 - name: mise-data
                   mountPath: /mise-data
+                - name: mise-cache
+                  mountPath: /mise-cache
           containers:
             - name: pulumi
               volumeMounts:

--- a/kubernetes/apps/pulumi/applications/sgc.yaml
+++ b/kubernetes/apps/pulumi/applications/sgc.yaml
@@ -147,16 +147,24 @@ spec:
             - name: vals-bin
               emptyDir: {}
             - name: mise-data
+              emptyDir: {}
+            - name: mise-cache
               hostPath:
-                path: /var/lib/pulumi-mise-data
+                path: /var/lib/pulumi-mise-cache
                 type: DirectoryOrCreate
           # Installs the vals binary for the ref+openbao:// resolver
           # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
           # the pin lives in the mise ecosystem — keep the version in step
-          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
-          # cache mirroring npm-cache, so after the first run on a node this
-          # is a copy, not a download. Kubernetes `command:` replaces the
+          # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
+          #
+          # The INSTALL dir is pod-local on purpose: concurrent installs into
+          # a shared hostPath wedge it permanently — observed live, five
+          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
+          # after racing a cold node cache. Only the DOWNLOAD cache is shared
+          # (the expensive part); the extract is cheap. Any node's old
+          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
+          # delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -164,11 +172,19 @@ spec:
               command: ["/bin/sh", "-ec"]
               args:
                 - |
-                  mise install vals@0.45.0
+                  ok=""
+                  for attempt in 1 2 3; do
+                    if mise install vals@0.45.0; then ok=1; break; fi
+                    echo "mise install failed (attempt $attempt); retrying" >&2
+                    sleep 3
+                  done
+                  [ -n "$ok" ]
                   mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
               env:
                 - name: MISE_DATA_DIR
                   value: /mise-data
+                - name: MISE_CACHE_DIR
+                  value: /mise-cache
                 - name: MISE_YES
                   value: "1"
               volumeMounts:
@@ -176,6 +192,8 @@ spec:
                   mountPath: /opt/vals
                 - name: mise-data
                   mountPath: /mise-data
+                - name: mise-cache
+                  mountPath: /mise-cache
           containers:
             - name: pulumi
               volumeMounts:

--- a/kubernetes/apps/pulumi/authentik/stack.yaml
+++ b/kubernetes/apps/pulumi/authentik/stack.yaml
@@ -148,16 +148,24 @@ spec:
             - name: vals-bin
               emptyDir: {}
             - name: mise-data
+              emptyDir: {}
+            - name: mise-cache
               hostPath:
-                path: /var/lib/pulumi-mise-data
+                path: /var/lib/pulumi-mise-cache
                 type: DirectoryOrCreate
           # Installs the vals binary for the ref+openbao:// resolver
           # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
           # the pin lives in the mise ecosystem — keep the version in step
-          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
-          # cache mirroring npm-cache, so after the first run on a node this
-          # is a copy, not a download. Kubernetes `command:` replaces the
+          # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
+          #
+          # The INSTALL dir is pod-local on purpose: concurrent installs into
+          # a shared hostPath wedge it permanently — observed live, five
+          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
+          # after racing a cold node cache. Only the DOWNLOAD cache is shared
+          # (the expensive part); the extract is cheap. Any node's old
+          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
+          # delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -165,11 +173,19 @@ spec:
               command: ["/bin/sh", "-ec"]
               args:
                 - |
-                  mise install vals@0.45.0
+                  ok=""
+                  for attempt in 1 2 3; do
+                    if mise install vals@0.45.0; then ok=1; break; fi
+                    echo "mise install failed (attempt $attempt); retrying" >&2
+                    sleep 3
+                  done
+                  [ -n "$ok" ]
                   mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
               env:
                 - name: MISE_DATA_DIR
                   value: /mise-data
+                - name: MISE_CACHE_DIR
+                  value: /mise-cache
                 - name: MISE_YES
                   value: "1"
               volumeMounts:
@@ -177,6 +193,8 @@ spec:
                   mountPath: /opt/vals
                 - name: mise-data
                   mountPath: /mise-data
+                - name: mise-cache
+                  mountPath: /mise-cache
           containers:
             - name: pulumi
               resources:

--- a/kubernetes/apps/pulumi/backups/stack.yaml
+++ b/kubernetes/apps/pulumi/backups/stack.yaml
@@ -148,16 +148,24 @@ spec:
             - name: vals-bin
               emptyDir: {}
             - name: mise-data
+              emptyDir: {}
+            - name: mise-cache
               hostPath:
-                path: /var/lib/pulumi-mise-data
+                path: /var/lib/pulumi-mise-cache
                 type: DirectoryOrCreate
           # Installs the vals binary for the ref+openbao:// resolver
           # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
           # the pin lives in the mise ecosystem — keep the version in step
-          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
-          # cache mirroring npm-cache, so after the first run on a node this
-          # is a copy, not a download. Kubernetes `command:` replaces the
+          # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
+          #
+          # The INSTALL dir is pod-local on purpose: concurrent installs into
+          # a shared hostPath wedge it permanently — observed live, five
+          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
+          # after racing a cold node cache. Only the DOWNLOAD cache is shared
+          # (the expensive part); the extract is cheap. Any node's old
+          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
+          # delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -165,11 +173,19 @@ spec:
               command: ["/bin/sh", "-ec"]
               args:
                 - |
-                  mise install vals@0.45.0
+                  ok=""
+                  for attempt in 1 2 3; do
+                    if mise install vals@0.45.0; then ok=1; break; fi
+                    echo "mise install failed (attempt $attempt); retrying" >&2
+                    sleep 3
+                  done
+                  [ -n "$ok" ]
                   mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
               env:
                 - name: MISE_DATA_DIR
                   value: /mise-data
+                - name: MISE_CACHE_DIR
+                  value: /mise-cache
                 - name: MISE_YES
                   value: "1"
               volumeMounts:
@@ -177,6 +193,8 @@ spec:
                   mountPath: /opt/vals
                 - name: mise-data
                   mountPath: /mise-data
+                - name: mise-cache
+                  mountPath: /mise-cache
           containers:
             - name: pulumi
               resources:

--- a/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
+++ b/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
@@ -148,16 +148,24 @@ spec:
             - name: vals-bin
               emptyDir: {}
             - name: mise-data
+              emptyDir: {}
+            - name: mise-cache
               hostPath:
-                path: /var/lib/pulumi-mise-data
+                path: /var/lib/pulumi-mise-cache
                 type: DirectoryOrCreate
           # Installs the vals binary for the ref+openbao:// resolver
           # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
           # the pin lives in the mise ecosystem — keep the version in step
-          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
-          # cache mirroring npm-cache, so after the first run on a node this
-          # is a copy, not a download. Kubernetes `command:` replaces the
+          # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
+          #
+          # The INSTALL dir is pod-local on purpose: concurrent installs into
+          # a shared hostPath wedge it permanently — observed live, five
+          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
+          # after racing a cold node cache. Only the DOWNLOAD cache is shared
+          # (the expensive part); the extract is cheap. Any node's old
+          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
+          # delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -165,11 +173,19 @@ spec:
               command: ["/bin/sh", "-ec"]
               args:
                 - |
-                  mise install vals@0.45.0
+                  ok=""
+                  for attempt in 1 2 3; do
+                    if mise install vals@0.45.0; then ok=1; break; fi
+                    echo "mise install failed (attempt $attempt); retrying" >&2
+                    sleep 3
+                  done
+                  [ -n "$ok" ]
                   mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
               env:
                 - name: MISE_DATA_DIR
                   value: /mise-data
+                - name: MISE_CACHE_DIR
+                  value: /mise-cache
                 - name: MISE_YES
                   value: "1"
               volumeMounts:
@@ -177,6 +193,8 @@ spec:
                   mountPath: /opt/vals
                 - name: mise-data
                   mountPath: /mise-data
+                - name: mise-cache
+                  mountPath: /mise-cache
           containers:
             - name: pulumi
               resources:

--- a/kubernetes/apps/pulumi/home-operations/stack.yaml
+++ b/kubernetes/apps/pulumi/home-operations/stack.yaml
@@ -149,16 +149,24 @@ spec:
             - name: vals-bin
               emptyDir: {}
             - name: mise-data
+              emptyDir: {}
+            - name: mise-cache
               hostPath:
-                path: /var/lib/pulumi-mise-data
+                path: /var/lib/pulumi-mise-cache
                 type: DirectoryOrCreate
           # Installs the vals binary for the ref+openbao:// resolver
           # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
           # the pin lives in the mise ecosystem — keep the version in step
-          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
-          # cache mirroring npm-cache, so after the first run on a node this
-          # is a copy, not a download. Kubernetes `command:` replaces the
+          # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
+          #
+          # The INSTALL dir is pod-local on purpose: concurrent installs into
+          # a shared hostPath wedge it permanently — observed live, five
+          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
+          # after racing a cold node cache. Only the DOWNLOAD cache is shared
+          # (the expensive part); the extract is cheap. Any node's old
+          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
+          # delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -166,11 +174,19 @@ spec:
               command: ["/bin/sh", "-ec"]
               args:
                 - |
-                  mise install vals@0.45.0
+                  ok=""
+                  for attempt in 1 2 3; do
+                    if mise install vals@0.45.0; then ok=1; break; fi
+                    echo "mise install failed (attempt $attempt); retrying" >&2
+                    sleep 3
+                  done
+                  [ -n "$ok" ]
                   mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
               env:
                 - name: MISE_DATA_DIR
                   value: /mise-data
+                - name: MISE_CACHE_DIR
+                  value: /mise-cache
                 - name: MISE_YES
                   value: "1"
               volumeMounts:
@@ -178,6 +194,8 @@ spec:
                   mountPath: /opt/vals
                 - name: mise-data
                   mountPath: /mise-data
+                - name: mise-cache
+                  mountPath: /mise-cache
           containers:
             - name: pulumi
               resources:

--- a/kubernetes/apps/pulumi/ocracoke/stack.yaml
+++ b/kubernetes/apps/pulumi/ocracoke/stack.yaml
@@ -148,16 +148,24 @@ spec:
             - name: vals-bin
               emptyDir: {}
             - name: mise-data
+              emptyDir: {}
+            - name: mise-cache
               hostPath:
-                path: /var/lib/pulumi-mise-data
+                path: /var/lib/pulumi-mise-cache
                 type: DirectoryOrCreate
           # Installs the vals binary for the ref+openbao:// resolver
           # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
           # the pin lives in the mise ecosystem — keep the version in step
-          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
-          # cache mirroring npm-cache, so after the first run on a node this
-          # is a copy, not a download. Kubernetes `command:` replaces the
+          # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
+          #
+          # The INSTALL dir is pod-local on purpose: concurrent installs into
+          # a shared hostPath wedge it permanently — observed live, five
+          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
+          # after racing a cold node cache. Only the DOWNLOAD cache is shared
+          # (the expensive part); the extract is cheap. Any node's old
+          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
+          # delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -165,11 +173,19 @@ spec:
               command: ["/bin/sh", "-ec"]
               args:
                 - |
-                  mise install vals@0.45.0
+                  ok=""
+                  for attempt in 1 2 3; do
+                    if mise install vals@0.45.0; then ok=1; break; fi
+                    echo "mise install failed (attempt $attempt); retrying" >&2
+                    sleep 3
+                  done
+                  [ -n "$ok" ]
                   mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
               env:
                 - name: MISE_DATA_DIR
                   value: /mise-data
+                - name: MISE_CACHE_DIR
+                  value: /mise-cache
                 - name: MISE_YES
                   value: "1"
               volumeMounts:
@@ -177,6 +193,8 @@ spec:
                   mountPath: /opt/vals
                 - name: mise-data
                   mountPath: /mise-data
+                - name: mise-cache
+                  mountPath: /mise-cache
           containers:
             - name: pulumi
               resources:

--- a/kubernetes/apps/pulumi/unifi-network/stack.yaml
+++ b/kubernetes/apps/pulumi/unifi-network/stack.yaml
@@ -147,16 +147,24 @@ spec:
             - name: vals-bin
               emptyDir: {}
             - name: mise-data
+              emptyDir: {}
+            - name: mise-cache
               hostPath:
-                path: /var/lib/pulumi-mise-data
+                path: /var/lib/pulumi-mise-cache
                 type: DirectoryOrCreate
           # Installs the vals binary for the ref+openbao:// resolver
           # (components/store/refs.ts, PLAN §D.1). mise does the fetching so
           # the pin lives in the mise ecosystem — keep the version in step
-          # with .config/mise.toml [tools] — and MISE_DATA_DIR is a hostPath
-          # cache mirroring npm-cache, so after the first run on a node this
-          # is a copy, not a download. Kubernetes `command:` replaces the
+          # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
+          #
+          # The INSTALL dir is pod-local on purpose: concurrent installs into
+          # a shared hostPath wedge it permanently — observed live, five
+          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
+          # after racing a cold node cache. Only the DOWNLOAD cache is shared
+          # (the expensive part); the extract is cheap. Any node's old
+          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
+          # delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -164,11 +172,19 @@ spec:
               command: ["/bin/sh", "-ec"]
               args:
                 - |
-                  mise install vals@0.45.0
+                  ok=""
+                  for attempt in 1 2 3; do
+                    if mise install vals@0.45.0; then ok=1; break; fi
+                    echo "mise install failed (attempt $attempt); retrying" >&2
+                    sleep 3
+                  done
+                  [ -n "$ok" ]
                   mise exec vals@0.45.0 -- /bin/sh -ec 'cp "$(command -v vals)" /opt/vals/vals'
               env:
                 - name: MISE_DATA_DIR
                   value: /mise-data
+                - name: MISE_CACHE_DIR
+                  value: /mise-cache
                 - name: MISE_YES
                   value: "1"
               volumeMounts:
@@ -176,6 +192,8 @@ spec:
                   mountPath: /opt/vals
                 - name: mise-data
                   mountPath: /mise-data
+                - name: mise-cache
+                  mountPath: /mise-cache
           containers:
             - name: pulumi
               resources:


### PR DESCRIPTION
**Unblocks five crash-looping stacks** — merge when ready; the sooner this lands, the sooner authentik/backups/equestria/sgc/unifi-network reconcile again.

## What happened

Within minutes of #724's rollout, eight workspace pods cold-started simultaneously and raced `mise install vals@0.45.0` against the **shared** `MISE_DATA_DIR` hostPath. On the node where one install won cleanly, the three residents run fine (gulf-of-mexico, home-operations, ocracoke — their inits completed and the stacks work). On the other node the concurrent extracts corrupted the install dir, and every retry now hits the same wedged state: `Init:CrashLoopBackOff`, `mise ERROR Failed to install aqua:helmfile/vals@0.45.0: Permission denied (os error 13)`.

## The fix — structural, not a retry band-aid

- `MISE_DATA_DIR` (the **install** dir) becomes an `emptyDir`: per-pod, cannot race, extract is cheap.
- The hostPath now shares only `MISE_CACHE_DIR` (the **download** cache — the expensive part), at a **new path** (`/var/lib/pulumi-mise-cache`) so the wedged `pulumi-mise-data` dirs are simply abandoned rather than needing node surgery. They're safe to delete from nodes whenever.
- A 3× retry around `mise install` for transient download flakes, with `set -e` semantics preserved (`[ -n "$ok" ]` fails the init if all attempts lose).

Validated in the actual `jdxcode/mise:2026.8.3` image: install with split dirs → `mise exec` → copy → the copied binary executes.

## After merge

The five wedged pods get recreated with the new spec and converge; then the parity gate run and the final Phase 8 verification proceed as planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)