### PR TITLE
fix(pulumi): the vals initContainer runs as root — uid 1000 cannot write a hostPath

### DIFF
--- a/kubernetes/apps/pulumi/applications/equestria.yaml
+++ b/kubernetes/apps/pulumi/applications/equestria.yaml
@@ -158,13 +158,10 @@ spec:
           # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
           #
-          # The INSTALL dir is pod-local on purpose: concurrent installs into
-          # a shared hostPath wedge it permanently — observed live, five
-          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
-          # after racing a cold node cache. Only the DOWNLOAD cache is shared
-          # (the expensive part); the extract is cheap. Any node's old
-          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
-          # delete, never reuse.
+          # The INSTALL dir is pod-local (emptyDir); only the DOWNLOAD cache
+          # is shared — the expensive part, the extract is cheap. Any node's
+          # old /var/lib/pulumi-mise-data is an abandoned predecessor — safe
+          # to delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -187,6 +184,16 @@ spec:
                   value: /mise-cache
                 - name: MISE_YES
                   value: "1"
+              # The workspace pod template pins runAsUser 1000/runAsNonRoot,
+              # under which a root-owned hostPath is unwritable — every EACCES
+              # in the first rollout was this, not an install race (the pods
+              # that "worked" predated the vals init entirely). This one init
+              # runs as root to use the shared cache; the binary it drops is
+              # 0755 root-owned, which uid 1000 executes fine.
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+                runAsNonRoot: false
               volumeMounts:
                 - name: vals-bin
                   mountPath: /opt/vals

--- a/kubernetes/apps/pulumi/applications/sgc.yaml
+++ b/kubernetes/apps/pulumi/applications/sgc.yaml
@@ -158,13 +158,10 @@ spec:
           # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
           #
-          # The INSTALL dir is pod-local on purpose: concurrent installs into
-          # a shared hostPath wedge it permanently — observed live, five
-          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
-          # after racing a cold node cache. Only the DOWNLOAD cache is shared
-          # (the expensive part); the extract is cheap. Any node's old
-          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
-          # delete, never reuse.
+          # The INSTALL dir is pod-local (emptyDir); only the DOWNLOAD cache
+          # is shared — the expensive part, the extract is cheap. Any node's
+          # old /var/lib/pulumi-mise-data is an abandoned predecessor — safe
+          # to delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -187,6 +184,16 @@ spec:
                   value: /mise-cache
                 - name: MISE_YES
                   value: "1"
+              # The workspace pod template pins runAsUser 1000/runAsNonRoot,
+              # under which a root-owned hostPath is unwritable — every EACCES
+              # in the first rollout was this, not an install race (the pods
+              # that "worked" predated the vals init entirely). This one init
+              # runs as root to use the shared cache; the binary it drops is
+              # 0755 root-owned, which uid 1000 executes fine.
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+                runAsNonRoot: false
               volumeMounts:
                 - name: vals-bin
                   mountPath: /opt/vals

--- a/kubernetes/apps/pulumi/authentik/stack.yaml
+++ b/kubernetes/apps/pulumi/authentik/stack.yaml
@@ -159,13 +159,10 @@ spec:
           # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
           #
-          # The INSTALL dir is pod-local on purpose: concurrent installs into
-          # a shared hostPath wedge it permanently — observed live, five
-          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
-          # after racing a cold node cache. Only the DOWNLOAD cache is shared
-          # (the expensive part); the extract is cheap. Any node's old
-          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
-          # delete, never reuse.
+          # The INSTALL dir is pod-local (emptyDir); only the DOWNLOAD cache
+          # is shared — the expensive part, the extract is cheap. Any node's
+          # old /var/lib/pulumi-mise-data is an abandoned predecessor — safe
+          # to delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -188,6 +185,16 @@ spec:
                   value: /mise-cache
                 - name: MISE_YES
                   value: "1"
+              # The workspace pod template pins runAsUser 1000/runAsNonRoot,
+              # under which a root-owned hostPath is unwritable — every EACCES
+              # in the first rollout was this, not an install race (the pods
+              # that "worked" predated the vals init entirely). This one init
+              # runs as root to use the shared cache; the binary it drops is
+              # 0755 root-owned, which uid 1000 executes fine.
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+                runAsNonRoot: false
               volumeMounts:
                 - name: vals-bin
                   mountPath: /opt/vals

--- a/kubernetes/apps/pulumi/backups/stack.yaml
+++ b/kubernetes/apps/pulumi/backups/stack.yaml
@@ -159,13 +159,10 @@ spec:
           # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
           #
-          # The INSTALL dir is pod-local on purpose: concurrent installs into
-          # a shared hostPath wedge it permanently — observed live, five
-          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
-          # after racing a cold node cache. Only the DOWNLOAD cache is shared
-          # (the expensive part); the extract is cheap. Any node's old
-          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
-          # delete, never reuse.
+          # The INSTALL dir is pod-local (emptyDir); only the DOWNLOAD cache
+          # is shared — the expensive part, the extract is cheap. Any node's
+          # old /var/lib/pulumi-mise-data is an abandoned predecessor — safe
+          # to delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -188,6 +185,16 @@ spec:
                   value: /mise-cache
                 - name: MISE_YES
                   value: "1"
+              # The workspace pod template pins runAsUser 1000/runAsNonRoot,
+              # under which a root-owned hostPath is unwritable — every EACCES
+              # in the first rollout was this, not an install race (the pods
+              # that "worked" predated the vals init entirely). This one init
+              # runs as root to use the shared cache; the binary it drops is
+              # 0755 root-owned, which uid 1000 executes fine.
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+                runAsNonRoot: false
               volumeMounts:
                 - name: vals-bin
                   mountPath: /opt/vals

--- a/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
+++ b/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
@@ -159,13 +159,10 @@ spec:
           # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
           #
-          # The INSTALL dir is pod-local on purpose: concurrent installs into
-          # a shared hostPath wedge it permanently — observed live, five
-          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
-          # after racing a cold node cache. Only the DOWNLOAD cache is shared
-          # (the expensive part); the extract is cheap. Any node's old
-          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
-          # delete, never reuse.
+          # The INSTALL dir is pod-local (emptyDir); only the DOWNLOAD cache
+          # is shared — the expensive part, the extract is cheap. Any node's
+          # old /var/lib/pulumi-mise-data is an abandoned predecessor — safe
+          # to delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -188,6 +185,16 @@ spec:
                   value: /mise-cache
                 - name: MISE_YES
                   value: "1"
+              # The workspace pod template pins runAsUser 1000/runAsNonRoot,
+              # under which a root-owned hostPath is unwritable — every EACCES
+              # in the first rollout was this, not an install race (the pods
+              # that "worked" predated the vals init entirely). This one init
+              # runs as root to use the shared cache; the binary it drops is
+              # 0755 root-owned, which uid 1000 executes fine.
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+                runAsNonRoot: false
               volumeMounts:
                 - name: vals-bin
                   mountPath: /opt/vals

--- a/kubernetes/apps/pulumi/home-operations/stack.yaml
+++ b/kubernetes/apps/pulumi/home-operations/stack.yaml
@@ -160,13 +160,10 @@ spec:
           # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
           #
-          # The INSTALL dir is pod-local on purpose: concurrent installs into
-          # a shared hostPath wedge it permanently — observed live, five
-          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
-          # after racing a cold node cache. Only the DOWNLOAD cache is shared
-          # (the expensive part); the extract is cheap. Any node's old
-          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
-          # delete, never reuse.
+          # The INSTALL dir is pod-local (emptyDir); only the DOWNLOAD cache
+          # is shared — the expensive part, the extract is cheap. Any node's
+          # old /var/lib/pulumi-mise-data is an abandoned predecessor — safe
+          # to delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -189,6 +186,16 @@ spec:
                   value: /mise-cache
                 - name: MISE_YES
                   value: "1"
+              # The workspace pod template pins runAsUser 1000/runAsNonRoot,
+              # under which a root-owned hostPath is unwritable — every EACCES
+              # in the first rollout was this, not an install race (the pods
+              # that "worked" predated the vals init entirely). This one init
+              # runs as root to use the shared cache; the binary it drops is
+              # 0755 root-owned, which uid 1000 executes fine.
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+                runAsNonRoot: false
               volumeMounts:
                 - name: vals-bin
                   mountPath: /opt/vals

--- a/kubernetes/apps/pulumi/ocracoke/stack.yaml
+++ b/kubernetes/apps/pulumi/ocracoke/stack.yaml
@@ -159,13 +159,10 @@ spec:
           # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
           #
-          # The INSTALL dir is pod-local on purpose: concurrent installs into
-          # a shared hostPath wedge it permanently — observed live, five
-          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
-          # after racing a cold node cache. Only the DOWNLOAD cache is shared
-          # (the expensive part); the extract is cheap. Any node's old
-          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
-          # delete, never reuse.
+          # The INSTALL dir is pod-local (emptyDir); only the DOWNLOAD cache
+          # is shared — the expensive part, the extract is cheap. Any node's
+          # old /var/lib/pulumi-mise-data is an abandoned predecessor — safe
+          # to delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -188,6 +185,16 @@ spec:
                   value: /mise-cache
                 - name: MISE_YES
                   value: "1"
+              # The workspace pod template pins runAsUser 1000/runAsNonRoot,
+              # under which a root-owned hostPath is unwritable — every EACCES
+              # in the first rollout was this, not an install race (the pods
+              # that "worked" predated the vals init entirely). This one init
+              # runs as root to use the shared cache; the binary it drops is
+              # 0755 root-owned, which uid 1000 executes fine.
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+                runAsNonRoot: false
               volumeMounts:
                 - name: vals-bin
                   mountPath: /opt/vals

--- a/kubernetes/apps/pulumi/unifi-network/stack.yaml
+++ b/kubernetes/apps/pulumi/unifi-network/stack.yaml
@@ -158,13 +158,10 @@ spec:
           # with .config/mise.toml [tools]. Kubernetes `command:` replaces the
           # image's `mise` entrypoint, deliberately.
           #
-          # The INSTALL dir is pod-local on purpose: concurrent installs into
-          # a shared hostPath wedge it permanently — observed live, five
-          # workspace pods in Init:CrashLoopBackOff on 'Permission denied'
-          # after racing a cold node cache. Only the DOWNLOAD cache is shared
-          # (the expensive part); the extract is cheap. Any node's old
-          # /var/lib/pulumi-mise-data is that wedged predecessor — safe to
-          # delete, never reuse.
+          # The INSTALL dir is pod-local (emptyDir); only the DOWNLOAD cache
+          # is shared — the expensive part, the extract is cheap. Any node's
+          # old /var/lib/pulumi-mise-data is an abandoned predecessor — safe
+          # to delete, never reuse.
           initContainers:
             - name: vals
               # renovate: datasource=docker depName=jdxcode/mise
@@ -187,6 +184,16 @@ spec:
                   value: /mise-cache
                 - name: MISE_YES
                   value: "1"
+              # The workspace pod template pins runAsUser 1000/runAsNonRoot,
+              # under which a root-owned hostPath is unwritable — every EACCES
+              # in the first rollout was this, not an install race (the pods
+              # that "worked" predated the vals init entirely). This one init
+              # runs as root to use the shared cache; the binary it drops is
+              # 0755 root-owned, which uid 1000 executes fine.
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+                runAsNonRoot: false
               volumeMounts:
                 - name: vals-bin
                   mountPath: /opt/vals


### PR DESCRIPTION
**The actual root cause** — #726 improved the structure but misdiagnosed the failure. Merge this and the five stacks converge.

## Diagnosis, corrected

- The operator's workspace pod template pins `runAsUser: 1000, runAsNonRoot: true` at pod level — so the vals init ran as uid 1000.
- A kubelet-created hostPath (`DirectoryOrCreate`) is root-owned `0755` — **unwritable at uid 1000, deterministically, on every node**. Not a race.
- The three pods that "worked" never ran the init at all: they were created from the pre-#722 Workspace spec (`initContainers: bootstrap fetch` — verified) before the Kustomization applied the CR change. That coincidence is what made it look node-dependent.
- #726's split made the error unambiguous: `create_dir_all: /mise-cache/lockfiles: Permission denied` — failing on `mkdir` before any install could possibly race.

## Fix

Container-level `securityContext {runAsUser: 0, runAsNonRoot: false}` on the vals init **only** — the one container that must write the shared cache. The `pulumi` container stays uid 1000 and merely executes the `0755` root-owned binary from the emptyDir. The `pulumi` namespace carries no PodSecurity enforcement labels, and these workspace pods already run with cluster credentials — the init installing a pinned binary is not the privilege boundary here. #726's data/cache split stays; it's correct regardless.

## After merge

Five wedged stacks converge → settle-watcher fires → parity gate → final Phase 8 report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)