### PR TITLE
fix(bao-transit): defang the ref+sops example — vals expands comments

### DIFF
--- a/components/store/refs.ts
+++ b/components/store/refs.ts
@@ -30,6 +30,15 @@
  * a bare dotenv line exits 0 with EMPTY output, which a pipeline would write
  * out as an empty file.
  *
+ * A consequence to respect when WRITING files this pipeline renders:
+ * references are live wherever they appear — vals does not know what a
+ * comment is. A well-formed `ref+…://` URL in a comment resolves (baking a
+ * secret into the rendered file) or fails the run (an unreadable one killed
+ * every home-operations run the day this landed, from a Phase 2 MIGRATION
+ * NOTE in bao-transit's .env). This is the envsubst-expands-in-comments
+ * lesson from Phase 6, one layer up. Break the scheme apart in prose:
+ * `<ref+sops scheme>://…`, never the real thing.
+ *
  * One `vals eval` per document that contains references, memoized by content
  * for the life of the process. `vals` comes from mise locally
  * (`.config/mise.toml [tools]`) and from the `vals` initContainer on the

--- a/docker/alpha-site/bao-transit/.env
+++ b/docker/alpha-site/bao-transit/.env
@@ -9,10 +9,18 @@
 # remain a root of trust for the whole estate.
 #
 # Its permanent home is vault/bootstrap/openbao/alpha-site-static-unseal.sops.yaml
-# (see that repo's INVENTORY.md). Once vals lands in Phase 8, replace the line
-# below with the SOPS reference — vals resolves both schemes, so this is a
-# one-line change:
+# (see that repo's INVENTORY.md). vals landed in Phase 8, but the SOPS form
+# cannot resolve where this file is rendered: the operator's workspace pods
+# have neither a vault-repo checkout for the relative path nor the age key.
+# Moving this line off op:// is its own piece of design work — the Phase 2
+# leftover STATUS.md already tracks.
 #
-#   BAO_UNSEAL_KEY=ref+sops://../../vault/bootstrap/openbao/alpha-site-static-unseal.sops.yaml#/current_key
+# The scheme in the example below is deliberately broken apart. The resolver
+# hands WHOLE FILES to vals and vals expands references wherever they appear —
+# comments included; a well-formed ref+ URL in a comment is live code. (The
+# envsubst-in-comments lesson, one layer up: this exact line, well-formed,
+# failed every home-operations run the day the resolver landed.)
+#
+#   BAO_UNSEAL_KEY=<ref+sops scheme>://../../vault/bootstrap/openbao/alpha-site-static-unseal.sops.yaml#/current_key
 #
 BAO_UNSEAL_KEY=op://Eris/OpenBao Alpha Site Static Unseal/current_key


### PR DESCRIPTION
**The last unblock** — `home-operations` is the one stack still failing, and this is why. One-line-of-substance fix.

## What happened

`docker/alpha-site/bao-transit/.env` carries a Phase 2 MIGRATION NOTE documenting the seal key's future home, with a well-formed example:

```
#   BAO_UNSEAL_KEY=ref+sops://../../vault/bootstrap/openbao/alpha-site-static-unseal.sops.yaml#/current_key
```

The Phase 8 resolver hands whole files to vals, and **vals expands references wherever they appear — it does not know what a comment is**. The example became live code: vals' sops provider tried to read a vault-repo relative path that doesn't exist in the workspace pod (no checkout, no age key) and failed the run. This is STATUS.md's Phase 6 lesson #5 — envsubst expands inside comments — recurring one layer up, and fail-loud was the right outcome: had the file been *readable*, the **seal-chain key** would have been baked into a comment of the rendered `.env`.

## The fix

- The example scheme is broken apart (`<ref+sops scheme>://…`) so neither the resolver gate nor vals can parse it; verified the gate no longer matches the file.
- The note now explains why the SOPS form can't ship yet: resolving it in the operator needs a vault-repo checkout + age key in the workspace, which is its own design problem — the Phase 2 leftover STATUS.md already tracks. The live `op://` line keeps working through the 1Password resolver until then.
- The rule is recorded in the resolver header: references are live wherever they appear; write broken-apart schemes in prose, never the real thing.

Sweep: no other ref-shaped comments exist under `docker/` in either form.

## After merge

home-operations converges (its next run has nothing scheme-shaped in that file, so vals isn't even invoked for it) → parity gate → Phase 8 close-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)