### PR TITLE
feat(openbao): dual-write the DockgeLxc item — hosts/dockge/ froze at Phase 4

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -2,6 +2,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { FullItem } from "@1password/connect";
+import { baoKvSecret, baoProvenance, dockgeBaoPath } from "@components/bao.ts";
 import { Tailscale } from "@components/constants.ts";
 import { awaitOutput, copyFileToRemote, getTailscaleSection } from "@components/helpers.ts";
 import type { OPClient } from "@components/op.ts";
@@ -452,6 +453,50 @@ export class DockgeLxc extends ComponentResource {
       },
       cro,
     );
+
+    // Phase 8 dual-write (openbao-migration PLAN §G): the item also lands at
+    // its canonical OpenBao path (`secrets/hosts/dockge/<slug>`, the
+    // tag:dockge rule in scripts/op-to-bao/mapping.ts) with the exact field
+    // shape of the OnePasswordItem above. That prefix was seeded by the
+    // one-time Phase 4 migration and then FROZE — found live the day the
+    // 1Password write-back was fixed, when `DockgeLxc: Luna`'s new ipAddress
+    // reached 1Password while BAO_STORE_READS consumers kept reading the
+    // Phase 4 copy. 1Password stays authoritative until Phase 11 — written
+    // ALONGSIDE the item, never instead of it; rollback is a plain
+    // `git revert` of this block.
+    if (args.globals.baoDualWriteEnabled) {
+      baoKvSecret(
+        `${args.host.name}-dockge-bao`,
+        {
+          mount: "secrets",
+          path: output(args.host.title).apply(title => dockgeBaoPath(`DockgeLxc: ${title}`)),
+          data: {
+            name: name,
+            hostname: this.hostname,
+            ipAddress: this.ipAddress,
+            tailscaleIpAddress: this.tailscaleIpAddress,
+            ssh: {
+              hostname: this.tailscaleHostname,
+              username: args.globals.proxmoxCredential.username,
+              password: args.globals.proxmoxCredential.password,
+            },
+            tailscale: {
+              hostname: this.tailscaleHostname,
+              ipAddress: this.tailscaleIpAddress,
+            },
+          },
+          customMetadata: baoProvenance({
+            source_title: interpolate`DockgeLxc: ${args.host.title}`,
+            source_tags: "dockge,lxc",
+            contains_secrets: "true",
+            concealed_fields: "ssh.password",
+          }),
+        },
+        mergeOptions(cro, { provider: args.globals.baoProvider }),
+      );
+    } else {
+      log.warn(`No OpenBao credentials (BAO_TOKEN, or BAO_ROLE_ID + BAO_SECRET_ID) — skipping the OpenBao dual-write for ${args.host.name}'s dockge item. 1Password stays authoritative; the hosts/dockge/ copy stays frozen at its Phase 4 state until a credentialed run.`, this);
+    }
 
     const deleteDockerDaemon = new remote.Command(
       `${name}-delete-docker-daemon`,

--- a/components/bao.ts
+++ b/components/bao.ts
@@ -237,6 +237,16 @@ export function pbsBaoPath(title: string): string {
 }
 
 /**
+ * Canonical OpenBao path (within the `secrets` mount) for a Dockge LXC item,
+ * from its 1Password title — matches the `tag:dockge` rule in
+ * `scripts/op-to-bao/mapping.ts` (`hosts/dockge/<slug(title)>`), which is the
+ * prefix `BaoStore.getDockgeInstances` lists.
+ */
+export function dockgeBaoPath(title: string): string {
+  return `hosts/dockge/${baoSlug(title)}`;
+}
+
+/**
  * Standard custom_metadata provenance for Pulumi-generated secrets, mirroring
  * the op-to-bao convention: labels about the secret live in custom_metadata,
  * values consumers need live in data (vals cannot read metadata).


### PR DESCRIPTION
The final parity run was green on every section except one, and that one DIFF is a real find: `getDockgeInstances / DockgeLxc: Luna` differs in exactly one field — `ipAddress`.

## What happened

- `hosts/dockge/*` was seeded by the one-time Phase 4 `op-to-bao --apply` and **nothing has written it since** — `DockgeLxc`'s `OnePasswordItem` is the only tag family `BaoStore` lists whose producer had no dual-write twin (PBS LXC got one in Phase 8a; dockge was missed).
- The staleness was invisible while the 1Password write-back was broken — both sides were equally frozen. #725 fixed the write-back, the next ocracoke run delivered Luna's corrected `ipAddress` to 1Password, and the KV copy became demonstrably stale within hours. Parity's `getDockgeInstances` section caught it same-day.

## The fix

The identical pattern every other generated credential already uses: `baoKvSecret` alongside the `OnePasswordItem`, at the `tag:dockge` path `mapping.ts` derives (`hosts/dockge/<slug>` — the prefix `getDockgeInstances` lists), `concealed_fields: ssh.password` preserving the `secret()` marker, warn-when-skipped, `retainOnDelete`. First run per dockge host overwrites the frozen Phase 4 copy; the provider manages the path from then on.

## Verification

- 33/33 store tests; tsc clean on home / ocracoke / gulf-of-mexico
- After merge + one run of each dockge-owning stack: parity's `getDockgeInstances` goes green, which makes the **entire parity script green** — the last section standing

🤖 Generated with [Claude Code](https://claude.com/claude-code)