### PR TITLE
Phase 9 flip: vault Stack CR reads from OpenBao + parity comparator fix

### DIFF
--- a/kubernetes/apps/pulumi/vault/stack.yaml
+++ b/kubernetes/apps/pulumi/vault/stack.yaml
@@ -89,6 +89,16 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
+    # Phase 9 cutover: secret reads come from OpenBao (BaoStore) instead of
+    # 1Password — the vault repo's own copy of the Phase 8 seam. Explicit,
+    # never inferred from credential presence — see baoStoreReadsEnabled in
+    # vault components/store/bao.ts. The gate for setting this was that
+    # repo's scripts/bao-store-parity.ts fully green plus stable dual
+    # preview pairs (vault docs/openbao-migration/STATUS.md, Phase 9).
+    BAO_STORE_READS:
+      type: Literal
+      literal:
+        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/scripts/bao-store-parity.ts
+++ b/scripts/bao-store-parity.ts
@@ -58,8 +58,29 @@ function fields(item: Record<string, unknown>): Record<string, unknown> {
   return rest;
 }
 
+/**
+ * Deep key-sorted serialization. NOT `JSON.stringify(x, sortedKeys)` — a
+ * replacer ARRAY filters properties at EVERY nesting depth, so any key that
+ * exists only inside a section object (`ssh.username`, `backrest.privateKey`)
+ * would be dropped from BOTH serializations and section-level drift would
+ * compare equal. That bug shipped in the Phase 8 version of this file and
+ * silently hollowed out the getDockgeInstances check until the Phase 9 port
+ * review caught it (vault repo, docs/openbao-migration/STATUS.md).
+ */
+function stable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stable);
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => [k, stable(v)]),
+    );
+  }
+  return value;
+}
+
 function canonical(item: Record<string, unknown>): string {
-  return JSON.stringify(fields(item), Object.keys(fields(item)).sort());
+  return JSON.stringify(stable(fields(item)));
 }
 
 let failures = 0;


### PR DESCRIPTION
## What

1. **`BAO_STORE_READS=1` on the vault Stack CR** — the Phase 9 operator flip. The BAO_ADDR/AppRole envRefs have been wired since Phase 8a; this is the one flag Phase 8 deliberately left unset ("Phase 9 owns that repo's cutover"). **Merge [vault#179](https://github.com/david-driscoll/vault/pull/179) first** — it carries the seam and the gate evidence.
2. **`scripts/bao-store-parity.ts` comparator fix.** `canonical()` compared with `JSON.stringify(value, sortedKeyArray)` — a replacer **array** filters keys at every nesting depth, so fields that exist only inside sections (`ssh.username`, `backrest.privateKey`) were dropped from both serializations and section drift compared equal. The `getDockgeInstances` leg of the Phase 8 gate was hollow. Found by vault#179's adversarial port review, reproduced by execution.

## Verification

- [x] Re-ran this repo's parity live with the fixed comparator against both stores: **fully green, all 22 sections** (12 titles, dockge 4, 6 clusters, Authentik Outputs, 3-stack/13-host tailscale exports, 52 backup plans) — the blindness was latent, not masking drift
- [x] vault repo gates green: parity first-run green, both preview pairs stable, `~cluster` diff pulled apart with `--diff` (only `meta.category`/`meta.urls`/`notesPlain`, by design)

Expect the first vault-stack resync after this merge to apply the one-time `~cluster` component-input updates and nothing else beyond that stack's standing access-token churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)