### PR TITLE
Phase 10: the authentik outpost credential comes from the cluster that issued it

### DIFF
--- a/components/store/index.ts
+++ b/components/store/index.ts
@@ -72,9 +72,18 @@ export class VaultStore {
       .apply(shapeTailscaleExports);
   }
 
-  public getKubeConfig(title: string) {
-    return output(op().getItemByTitle(title)).apply(generateKubeConfig);
-  }
+  /**
+   * `getKubeConfig` used to live here: it read a 1Password item by title and
+   * assembled a kubeconfig from its sa/cluster/cluster_api/token/certificate
+   * fields. Its only caller was the authentik outpost ServiceConnection, which
+   * now reads that credential from the cluster that issued it (Phase 10 --
+   * home-operations stacks/applications/kubernetes.ts).
+   *
+   * Deleted rather than kept: `BaoStore` never overrode it, so under
+   * BAO_STORE_READS it read 1Password SILENTLY, with no warning -- the one
+   * fallback class the flag exists to eliminate. Dead code that quietly reads
+   * the wrong store is a trap for whoever adds the next caller.
+   */
 
   public getKubernetesClusters(): Output<(KubernetesClusterDefinition & { kubeConfig: string })[]> {
     return this.getAllClusters()
@@ -292,46 +301,6 @@ function generateTailscaleKubeConfig(clusterKey: string, tailscaleDomain: Input<
   });
 }
 
-function generateKubeConfig(item: OnePasswordItem) {
-  const credential = getSecretItem<{
-    sa: string;
-    cluster: string;
-    cluster_api: string;
-    token: string;
-    certificate: string;
-  }>(item);
-  return interpolate`{
-  "kind": "Config",
-  "apiVersion": "v1",
-  "clusters": [
-    {
-      "cluster": {
-        "certificate-authority-data": "${credential.certificate.apply(c => Buffer.from(c, "utf8").toString("base64"))}",
-        "server": "https://${credential.cluster_api}:6443"
-      },
-      "name": "${credential.cluster}"
-    }
-  ],
-  "contexts": [
-    {
-      "context": {
-        "cluster": "${credential.cluster}",
-        "user": "${credential.sa}"
-      },
-      "name": "${credential.cluster}"
-    }
-  ],
-  "current-context": "${credential.cluster}",
-  "users": [
-    {
-      "name": "${credential.sa}",
-      "user": {
-        "token": "${credential.token}"
-      }
-    }
-  ]
-}`;
-}
 
 function createProxmoxBackupServerDefinition(client: OPClient, item: OnePasswordItem): Output<ProxmoxBackupServerLxcDefinition> {
   const backupServerDefinition = getSecretItem<Exclude<ProxmoxBackupServerLxcDefinition, "dockge" | "cluster">>(item);

--- a/stacks/applications/kubernetes.ts
+++ b/stacks/applications/kubernetes.ts
@@ -10,7 +10,6 @@ import * as pulumi from "@pulumi/pulumi";
 import { kebabCase } from "moderndash";
 import { concatMap, from, lastValueFrom, map, toArray } from "rxjs";
 import * as yaml from "yaml";
-import type { OPClient } from "../../components/op.ts";
 import { kubernetesBackups } from "./kubernetes-backups.ts";
 
 export async function kubernetesApplications(globals: GlobalResources, outputs: AuthentikOutputs, clusterDefinition: pulumi.Unwrap<ReturnType<GlobalResources["store"]["getKubernetesCluster"]>>) {
@@ -126,7 +125,7 @@ export async function kubernetesApplications(globals: GlobalResources, outputs: 
       ).apply(() => apps);
     });
 
-  const outpostCredential = globals.store.getKubeConfig(`${clusterDefinition.key}-authentik-outpost`);
+  const outpostCredential = await outpostKubeConfig(coreApi, clusterDefinition);
 
   const serviceConnection = new authentik.ServiceConnectionKubernetes(clusterDefinition.key, {
     name: clusterDefinition.key,
@@ -189,38 +188,71 @@ export async function kubernetesApplications(globals: GlobalResources, outputs: 
   return {};
 }
 
-function _generateKubeConfig(credential: pulumi.Output<ReturnType<OPClient["mapItem"]>>) {
-  return pulumi.interpolate`{
-  "kind": "Config",
-  "apiVersion": "v1",
-  "clusters": [
-    {
-      "cluster": {
-        "certificate-authority-data": "${credential.fields.certificate.apply(z => Buffer.from(z.value!, "utf8").toString("base64"))}",
-        "server": "https://${credential.fields.cluster_api.value}:6443"
+/**
+ * The kubeconfig Authentik's Kubernetes ServiceConnection authenticates with,
+ * built from the credential in the target cluster itself.
+ *
+ * This used to be a 1Password item: two PushSecrets in each cluster pushed the
+ * ServiceAccount token and CA there, and Pulumi read them back by title
+ * (`<key>-authentik-outpost`) through `VaultStore.getKubeConfig`. Phase 10 of
+ * the 1Password->OpenBao migration (vault repo docs/openbao-migration/PLAN.md
+ * SS-G row 10) deletes that hop rather than moving it to OpenBao:
+ *
+ *   - Of the five fields the item carried, only `token` and `ca.crt` were ever
+ *     secrets. `sa`, `cluster` and `cluster_api` are config this function
+ *     already has -- they were being laundered through a secret store to get
+ *     from the cluster to Pulumi.
+ *   - This function is ALREADY talking to that cluster: `coreApi` above lists
+ *     namespaces and ApplicationDefinitions over the tailnet kubeproxy, and the
+ *     `tailnet-cluster-ops` ClusterRole it is impersonated as already grants
+ *     `secrets: get`. So reading the Secret costs no new provider, no new
+ *     network path and no new RBAC.
+ *   - Pushing to OpenBao instead would have meant widening the read-only
+ *     `eso-<cluster>` policy to allow writes, making every consuming cluster a
+ *     writer of the shared store, and would have kept a second copy of the
+ *     credential forever. This keeps zero copies in either store.
+ */
+async function outpostKubeConfig(coreApi: kubernetes.CoreV1Api, clusterDefinition: pulumi.Unwrap<ReturnType<GlobalResources["store"]["getKubernetesCluster"]>>) {
+  // Created by the authentik-remote-cluster HelmRelease in the target cluster,
+  // in the namespace named for the cluster (kubernetes/apps/<key>/idp/).
+  const secretName = "authentik-remote-cluster";
+  const secret = await coreApi.readNamespacedSecret({ name: secretName, namespace: clusterDefinition.key });
+
+  const field = (key: string) => {
+    const value = secret.data?.[key];
+    if (!value) throw new Error(`${clusterDefinition.key}/${secretName} has no '${key}' -- the ServiceAccount token Secret is missing or not yet populated`);
+    return Buffer.from(value, "base64").toString("utf8");
+  };
+
+  // `sa` is the ServiceAccount this token belongs to; it was a literal in the
+  // pushed Secret too. `cluster_api` was `apiserver.${CLUSTER_DOMAIN}`, which is
+  // this cluster's rootDomain -- verified against both live values before the
+  // switch (apiserver.equestria.driscoll.tech / apiserver.sgc.driscoll.tech).
+  const kubeConfig = pulumi.jsonStringify({
+    kind: "Config",
+    apiVersion: "v1",
+    clusters: [
+      {
+        cluster: {
+          // The pushed item stored the CA verbatim and re-encoded it here, so
+          // the b64 of the raw PEM is the byte-identical result.
+          "certificate-authority-data": Buffer.from(field("ca.crt"), "utf8").toString("base64"),
+          server: `https://apiserver.${clusterDefinition.rootDomain}:6443`,
+        },
+        name: clusterDefinition.key,
       },
-      "name": "${credential.fields.cluster.value}"
-    }
-  ],
-  "contexts": [
-    {
-      "context": {
-        "cluster": "${credential.fields.cluster.value}",
-        "user": "${credential.fields.sa.value}"
-      },
-      "name": "${credential.fields.cluster.value}"
-    }
-  ],
-  "current-context": "${credential.fields.cluster.value}",
-  "users": [
-    {
-      "name": "${credential.fields.sa.value}",
-      "user": {
-        "token": "${credential.fields.token.value}"
-      }
-    }
-  ]
-}`;
+    ],
+    contexts: [{ context: { cluster: clusterDefinition.key, user: secretName }, name: clusterDefinition.key }],
+    "current-context": clusterDefinition.key,
+    // The token came from a Concealed 1Password field, so `getSecretItem`
+    // marked it secret() and the whole kubeconfig inherited that. Reading the
+    // API directly loses the marker, and an unmarked kubeconfig writes a
+    // cluster-scoped token into Pulumi state in the clear -- with no symptom
+    // until someone runs `pulumi stack export`. Mark it here.
+    users: [{ name: secretName, user: { token: pulumi.secret(field("token")) } }],
+  });
+
+  return kubeConfig;
 }
 
 function mapAuthentikResource<T extends keyof AuthentikDefinition, K extends keyof NonNullable<AuthentikDefinition[T]>>(type: T, resource: { [V in K]: string }): NonNullable<AuthentikDefinition[T]> {


### PR DESCRIPTION
## What

The outpost `ServiceConnectionKubernetes` authenticated with a kubeconfig assembled from a 1Password item that two PushSecrets in each cluster kept populated. Pulumi now reads that credential from the cluster itself, and `getKubeConfig`/`generateKubeConfig` are deleted with their last caller.

**Of the five fields the item carried, only two were ever secrets.** `sa` is a literal, `cluster` is the cluster key, `cluster_api` is `apiserver.<rootDomain>` — config this function already has, laundered through a secret store to get from the cluster to Pulumi.

**And it was already talking to that cluster:** `coreApi` lists namespaces and ApplicationDefinitions over the tailnet kubeproxy ~100 lines above the call site, and `tailnet-cluster-ops` (the ClusterRole it is impersonated as) already grants `secrets: get`. No new provider, no new network path, **no RBAC change**.

## Why not repoint the push at OpenBao

`eso-<cluster>` is **read-only** (`read` on `secrets/data/{shared,clusters/<cluster>}/*`). Pushing would require widening it to `create`/`update`, making every consuming cluster a *writer* of the shared store — today a compromised ESO ServiceAccount can only read its own cluster's secrets. It would also keep a second copy of the credential forever. This keeps **zero** copies in either store.

## Deleting getKubeConfig is the point, not a side effect

`BaoStore` never overrode it, so under `BAO_STORE_READS=1` it read 1Password **silently, with no warning** — the one fallback class the flag exists to eliminate. It now has zero callers estate-wide, and dead code that quietly reads the wrong store is a trap for whoever adds the next caller. (The vault repo carried an unused copy; deleted there in its own PR.)

## The riskiest line

The token is explicitly `pulumi.secret()`-wrapped. It came from a Concealed 1Password field, so `getSecretItem` marked it and the kubeconfig inherited that; reading the API directly loses the marker, and an unmarked kubeconfig writes a cluster-scoped token into Pulumi state in the clear — **no symptom until `pulumi stack export`**.

## Verification

- [x] Against **both live clusters**: the kubeconfig built from the cluster is identical to the one built from the 1Password item, field for field (server, names, CA, token), **secret marker preserved on both**
- [x] `pulumi preview` on `stacks/applications` (equestria): **16 to update / 360 unchanged** — byte-identical to a **control run of the pre-change tree**. `ServiceConnectionKubernetes` appears in neither; the 16 are pre-existing authentik provider churn
- [x] No new typecheck errors (11 pre-existing on main, none in the changed files)

## Order

Merge and let the applications stack **run** before the cluster-repo PRs that delete the PushSecrets. `deletionPolicy: None` means the 1Password item freezes rather than being deleted, so the order is safe either way — this is just the honest one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)