### PR TITLE
Phase 11 groundwork: declare which written fields are secret — three writers did not

### DIFF
--- a/components/BackupPlanOrchestrator.ts
+++ b/components/BackupPlanOrchestrator.ts
@@ -88,11 +88,10 @@ export class BackupPlanOrchestrator extends ComponentResource {
           mount: "secrets",
           path: `clusters/_inventory/${baoSlug(title)}`,
           data: { plan },
+          concealedFields: ["plan"],
           customMetadata: baoProvenance({
             source_title: title,
             source_tags: "backup-plan",
-            contains_secrets: "true",
-            concealed_fields: "plan",
           }),
         },
         { parent: this, provider: this.globals.baoProvider },

--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -485,11 +485,10 @@ export class DockgeLxc extends ComponentResource {
               ipAddress: this.tailscaleIpAddress,
             },
           },
+          concealedFields: ["ssh.password"],
           customMetadata: baoProvenance({
             source_title: interpolate`DockgeLxc: ${args.host.title}`,
             source_tags: "dockge,lxc",
-            contains_secrets: "true",
-            concealed_fields: "ssh.password",
           }),
         },
         mergeOptions(cro, { provider: args.globals.baoProvider }),

--- a/components/ProxmoxBackupServerLxc.ts
+++ b/components/ProxmoxBackupServerLxc.ts
@@ -591,6 +591,12 @@ systemctl reload proxmox-backup-proxy.service
               privateKeyId: backrestPrivateKey.id,
             },
           },
+          // A root password, an SSH password and a backrest private key, none
+          // of which were declared before Phase 11. Nothing reads this path
+          // today — the 1Password item stays authoritative for this family
+          // because it is a human login credential — but an undeclared
+          // credential in KV is a trap for the first reader, not a non-issue.
+          concealedFields: ["password", "ssh.password", "backrest.privateKey"],
           customMetadata: baoProvenance({
             source_title: interpolate`Proxmox Backup Server LXC: ${args.host.title}`,
             source_tags: output(args.tags).apply(tags => [...tags, "pbs", "lxc", "backup"].join(",")),

--- a/components/authentik.ts
+++ b/components/authentik.ts
@@ -271,6 +271,12 @@ export class AuthentikApplicationManager extends pulumi.ComponentResource {
               jwks_url: providerConfig.jwksUrl,
               openid_configuration_url: pulumi.interpolate`${providerConfig.issuerUrl}.well-known/openid-configuration`,
             },
+            // The OAuth client secret. This path is READ live through
+            // BaoStore (`<cluster>-<app>-oidc-credentials` resolves here), and
+            // it carried no concealment declaration at all until Phase 11 —
+            // the value only stayed out of state in the clear because the
+            // Vault provider happens to declare its own field sensitive.
+            concealedFields: ["client_secret"],
             customMetadata: baoProvenance({
               source_title: `${this.args.clusterKey}-${definition.metadata.name}-oidc-credentials`,
             }),

--- a/components/bao.ts
+++ b/components/bao.ts
@@ -278,6 +278,25 @@ export interface BaoKvSecretArgs {
   data: pulumi.Input<Record<string, unknown>>;
   /** Provenance labels only, never values. See `baoProvenance()`. */
   customMetadata?: pulumi.Input<Record<string, pulumi.Input<string>>>;
+  /**
+   * Which keys in `data` are credentials, dotted for nested ones
+   * (`ssh.password`). REQUIRED — pass `[]` to state that nothing here is
+   * secret, and mean it.
+   *
+   * `BaoStore.shapeItem` marks a field `secret()` if and only if it appears in
+   * `custom_metadata.concealed_fields`; OpenBao has no field types, so this
+   * list IS the secrecy. A writer that omitted it produced a path whose
+   * credentials read back as PLAINTEXT, and nothing downstream complained:
+   * shapeItem's guard fires on "claims contains_secrets but lists none", which
+   * is the opposite mistake. Phase 11 found exactly that on the OIDC paths
+   * (client_secret, read live) and the PBS paths (root password, SSH password,
+   * backrest private key).
+   *
+   * Required rather than defaulted so adding a call site forces the decision
+   * at the moment the data is written, which is the only moment anyone knows
+   * the answer.
+   */
+  concealedFields: pulumi.Input<string>[];
 }
 
 /**
@@ -293,6 +312,16 @@ export interface BaoKvSecretArgs {
  * ciphertext of every prior one behind.
  */
 export function baoKvSecret(name: string, args: BaoKvSecretArgs, opts: pulumi.CustomResourceOptions): vault.kv.SecretV2 {
+  // Fold the concealment declaration into custom_metadata, so a caller cannot
+  // set one and forget the other. `contains_secrets` is what makes shapeItem's
+  // "marked secret but lists nothing" guard meaningful.
+  const customMetadata = pulumi
+    .all([args.customMetadata ?? {}, pulumi.all(args.concealedFields)])
+    .apply(([provenance, concealed]) => ({
+      ...provenance,
+      ...(concealed.length > 0 ? { contains_secrets: "true", concealed_fields: concealed.join(",") } : {}),
+    }));
+
   return new vault.kv.SecretV2(
     name,
     {
@@ -300,7 +329,7 @@ export function baoKvSecret(name: string, args: BaoKvSecretArgs, opts: pulumi.Cu
       // SecretV2.name IS the path within the mount, not a display name.
       name: args.path,
       dataJson: pulumi.secret(pulumi.jsonStringify(args.data)),
-      customMetadata: { data: args.customMetadata },
+      customMetadata: { data: customMetadata },
       deleteAllVersions: true,
     },
     {

--- a/components/tailscale.ts
+++ b/components/tailscale.ts
@@ -173,6 +173,9 @@ export class TailscaleMonitor {
                 ),
             ),
           })),
+          // Addressing, not credentials: node names, IPs, MACs, node types.
+          // Declared empty deliberately rather than omitted.
+          concealedFields: [],
           customMetadata: baoProvenance({ source_title: title, source_tags: "tailscale-export" }),
         },
         pulumi.mergeOptions(cro, { provider: this.globals.baoProvider }) as pulumi.CustomResourceOptions,

--- a/stacks/authentik/index.ts
+++ b/stacks/authentik/index.ts
@@ -101,7 +101,10 @@ if (globals.baoDualWriteEnabled) {
       // These are Authentik object IDs, not credentials — but they go in the
       // `secrets` mount because that is the only KV mount consumers can read.
       data: pulumi.output({ groups, roles, flows, scopeMappings }),
-      customMetadata: baoProvenance({ source_title: "Authentik Outputs" }),
+      // Authentik object IDs (flows, groups, mappings) — identifiers, not
+    // credentials. Declared empty deliberately rather than omitted.
+    concealedFields: [],
+    customMetadata: baoProvenance({ source_title: "Authentik Outputs" }),
     },
     { provider: globals.baoProvider, parent: globals },
   );

--- a/stacks/home/index.ts
+++ b/stacks/home/index.ts
@@ -1,4 +1,5 @@
 import type { AuthentikOutputs } from "@components/authentik.ts";
+import { baoKvSecret, baoProvenance } from "@components/bao.ts";
 import { BackupPlanDirector } from "@components/BackupPlanDirector.ts";
 import { Tailscale } from "@components/constants.ts";
 import { awaitOutput } from "@components/helpers.ts";
@@ -135,6 +136,40 @@ const _thanosMinioSecret = new OnePasswordItem("thanos-minio-secret", {
     },
   },
 });
+
+// The OpenBao twin of the item above.
+//
+// This one was missing, and it is the Phase 8 "frozen twin" bug live: TWO
+// ExternalSecrets read `shared/thanos-s3-storage` (equestria observability/thanos
+// and SGC observability/prometheus-proxy), but the only producer wrote
+// 1Password. What they were reading is the one-time op-to-bao copy from
+// 2026-08-08, version 1, never refreshed — so the day this Minio credential
+// rotates, Pulumi updates 1Password, OpenBao keeps the stale value, and Thanos
+// starts failing against object storage with a credential nothing shows as
+// wrong. A one-time seed is a freeze, not a source.
+//
+// Key names must match the 1Password item exactly: both consumers `extract`
+// the whole path and rewrite every key to `minio_<key>`.
+if (globals.baoDualWriteEnabled) {
+  baoKvSecret(
+    "thanos-minio-secret-bao",
+    {
+      mount: "secrets",
+      path: "shared/thanos-s3-storage",
+      data: {
+        username: globals.truenasMinioProvider.minioUser,
+        password: globals.truenasMinioProvider.minioPassword,
+        bucket: thanosStorage.bucket,
+        endpoint: globals.truenasMinioProvider.minioServer,
+      },
+      concealedFields: ["password"],
+      customMetadata: baoProvenance({ source_title: "Thanos S3 Storage" }),
+    },
+    { provider: globals.baoProvider },
+  );
+} else {
+  pulumi.log.warn("No OpenBao credentials (BAO_TOKEN, or BAO_ROLE_ID + BAO_SECRET_ID) — skipping the OpenBao dual-write for Thanos S3 Storage. The shared/thanos-s3-storage path its ExternalSecrets read stays frozen until a credentialed run.");
+}
 
 const celestiaHost = new ProxmoxHost("celestia", {
   globals: globals,


### PR DESCRIPTION
## What

`BaoStore.shapeItem` marks a field `secret()` **if and only if** it appears in `custom_metadata.concealed_fields`. OpenBao has no field types, so **that list is the secrecy**. Three Pulumi writers never wrote one:

| path | undeclared credentials | read today? |
|---|---|---|
| `clusters/<key>/apps/<app>/oidc` | `client_secret` | **yes, live** — `<cluster>-<app>-oidc-credentials` resolves here through `BaoStore` |
| `hosts/pbs/*` | root password, SSH password, backrest private key | no |
| `shared/thanos-s3-storage` | (see frozen twin below) | via ESO |

**Severity, checked rather than assumed:** the OIDC client secret is **encrypted in live state today** — but only because `@pulumi/vault` declares its own `oidcClientSecret` sensitive. That is provider luck, not our design; any consumer putting it somewhere not declared sensitive would have written it in the clear.

## Why this is structural, not three edits

`shapeItem`'s guard catches the *opposite* mistake — "claims `contains_secrets` but lists nothing". Nothing caught "holds credentials and claims nothing". **The parity script can't either**: it compares `isSecret(whole item)`, which stays true as long as any one field is marked, so per-field marker loss is invisible to it.

So `baoKvSecret` now **requires** a `concealedFields` declaration. Pass `[]` to say nothing here is secret — and mean it. Adding a call site forces the decision at the moment the data is written, which is the only moment anyone knows the answer. All six call sites declare; the two that already hand-wrote the metadata keys move onto the typed field.

## The frozen twin, live

Two ExternalSecrets read `shared/thanos-s3-storage` (equestria `observability/thanos`, SGC `observability/prometheus-proxy`) while **the only producer wrote 1Password**. They were reading the one-time op-to-bao copy from 2026-08-08 — version 1, never refreshed. The day that Minio credential rotates, Pulumi updates 1Password, OpenBao keeps the stale value, and Thanos fails against object storage with a credential nothing shows as wrong. Phase 8 bug 3, new instance: **a one-time seed is a freeze, not a source.**

## Preview

`+1 create` (the thanos twin), **12 `~customMetadata` updates**, no replacements, no data diffs.

⚠️ The preview also shows **55 deletes / 8 replaces** — a **control run of the unmodified tree produces exactly the same ones**. That is the documented artifact of `tailscale.ts` building resources inside `apply()` behind an `isDryRun` early-return, not this change.

Verified: no new typecheck errors; 67 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)