### PR TITLE
Phase 11: the seal key leaves 1Password for a host env-file

### DIFF
--- a/docker/alpha-site/bao-transit/.env
+++ b/docker/alpha-site/bao-transit/.env
@@ -1,26 +1,24 @@
 # 32-byte AES-256-GCM-96 key that auto-unseals bao-transit. Generate with:
 #   openssl rand -base64 32
-# (config.hcl reads it via env://; the docs' file:// example uses raw bytes
-# from `openssl rand -out <file> 32`, base64 is accepted for the inline form.)
 #
-# MIGRATION NOTE: this is an op:// reference today because it is created during
-# Phase 2, before OpenBao can hold anything. It must NOT stay in 1Password —
-# this key unseals the node that unseals everything else, so 1Password would
-# remain a root of trust for the whole estate.
+# BAO_UNSEAL_KEY IS DELIBERATELY NOT SET HERE.
 #
-# Its permanent home is vault/bootstrap/openbao/alpha-site-static-unseal.sops.yaml
-# (see that repo's INVENTORY.md). vals landed in Phase 8, but the SOPS form
-# cannot resolve where this file is rendered: the operator's workspace pods
-# have neither a vault-repo checkout for the relative path nor the age key.
-# Moving this line off op:// is its own piece of design work — the Phase 2
-# leftover STATUS.md already tracks.
+# It is supplied by /var/local/unseal-key on the host — a root-owned env-file
+# outside every stack directory, so nothing that renders or syncs this stack
+# can read or overwrite it. compose.yaml lists it as a second `env_file` with
+# `required: true`; see the comment there for why, and the vault repo's
+# bootstrap/openbao/provision-static-unseal.sh for how it gets there.
 #
-# The scheme in the example below is deliberately broken apart. The resolver
-# hands WHOLE FILES to vals and vals expands references wherever they appear —
-# comments included; a well-formed ref+ URL in a comment is live code. (The
-# envsubst-in-comments lesson, one layer up: this exact line, well-formed,
-# failed every home-operations run the day the resolver landed.)
+# It used to be an `<op scheme>://` reference on this line, and it is the one
+# reference in the estate that can never become `ref+openbao://` — putting this
+# key inside the thing it unseals is the circular dependency the seal chain
+# exists to avoid. Its durable home is now
+# vault/bootstrap/openbao/alpha-site-static-unseal.sops.yaml (INVENTORY.md §2).
 #
-#   BAO_UNSEAL_KEY=<ref+sops scheme>://../../vault/bootstrap/openbao/alpha-site-static-unseal.sops.yaml#/current_key
+# The scheme above is broken apart deliberately. The resolver hands WHOLE FILES
+# to vals, and vals expands references wherever they appear — comments
+# included. A well-formed reference in a comment is live code.
 #
-BAO_UNSEAL_KEY=op://Eris/OpenBao Alpha Site Static Unseal/current_key
+# Rotation: set current_key to the new key and move the old one to
+# previous_key/previous_key_id in config.hcl, then drop the previous pair on
+# the following pass. current_key_id is a plain identifier, not a secret.

--- a/docker/alpha-site/bao-transit/compose.yaml
+++ b/docker/alpha-site/bao-transit/compose.yaml
@@ -12,6 +12,31 @@ services:
     command: server -config=/openbao/config/config.hcl
     env_file:
       - path: .env
+      # BAO_UNSEAL_KEY comes from a root-owned env-file on the HOST, not from
+      # the rendered .env above. This key unseals the node that unseals
+      # equestria's OpenBao, which holds everything else — so while it was an
+      # op:// reference in .env, 1Password stayed a root of trust for the whole
+      # estate, which INVENTORY.md §2 forbids. It cannot move INTO OpenBao
+      # either (that is the circular dependency the seal chain exists to
+      # avoid), and the Pulumi operator cannot render it from SOPS: its
+      # workspace pods have neither a vault-repo checkout nor the age key.
+      #
+      # So it lives where the recovery shares and the Pulumi passphrase already
+      # live — bootstrap-tier material, provisioned onto its host out of band
+      # and never rendered by anything automated. See the vault repo:
+      # bootstrap/openbao/provision-static-unseal.sh.
+      #
+      # `required: true` on purpose: a recreate with the file missing must fail
+      # to start, loudly. The alternative is a container that comes up with an
+      # empty BAO_UNSEAL_KEY and fails at unseal instead, which reads like a
+      # config bug rather than a missing key.
+      #
+      # Still `env://` rather than a `file://` seal path: the key is base64 and
+      # the seal's file:// form takes raw bytes, so switching would silently
+      # change how a 44-character value is interpreted. This changes only where
+      # the variable comes from, never how the key is parsed.
+      - path: /var/local/unseal-key
+        required: true
     # mlock keeps the unsealed root key out of swap. The alternative is
     # disable_mlock = true in config.hcl, which is strictly worse on a host that
     # has swap enabled.


### PR DESCRIPTION
`BAO_UNSEAL_KEY` is no longer rendered into the bao-transit stack's `.env`. It comes from **`/var/local/unseal-key` on the host** — a root-owned env-file outside every stack directory, so nothing that renders or syncs the stack can read or overwrite it.

## Why this one is different from every other reference

This key unseals the node that unseals equestria's OpenBao, which holds everything else. While it was an `op://` reference, **1Password stayed a root of trust for the entire estate** — the one thing INVENTORY.md §2 says must not be true. It can't move *into* OpenBao (that's the circular dependency the seal chain exists to avoid), and the Pulumi operator can't render it from SOPS: its workspace pods have neither a vault-repo checkout for the relative path nor the age key.

So it goes where the recovery shares and the Pulumi passphrase already live: **bootstrap-tier material, provisioned onto its host out of band, never rendered by anything automated.**

## Two choices worth not re-litigating

- **Still `env://BAO_UNSEAL_KEY` in config.hcl, not a `file://` seal path.** The stored key is base64; the seal's `file://` form takes raw bytes. Switching would silently change how a 44-character value is interpreted, and the place you'd find out is unseal time. This changes only *where the variable comes from*, never how the key is parsed.
- **`required: true` on the host env_file.** A recreate with the file missing must fail to start, loudly — better than a container that comes up with an empty `BAO_UNSEAL_KEY` and fails at unseal, which reads like a config bug rather than a missing key.

## ⚠️ Merge gate

**`/var/local/unseal-key` must exist on dockge-as before this merges.** [vault#183](https://github.com/david-driscoll/vault/pull/183) adds `provision-static-unseal.sh`; its `verify` confirms the file, its permissions, that it matches the SOPS copy, and that bao-transit reports `sealed=false`.

## Scope note

This does **not** retire the `op://` resolver. **38 live `op://` references remain across 12 files under `docker/`** — Phase 8 converted only the subset it named. That's the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)