### PR TITLE
Hotfix: defang the reference scheme in bao-transit's .env (breaks every stacks/home run)

### DIFF
--- a/docker/alpha-site/bao-transit/.env
+++ b/docker/alpha-site/bao-transit/.env
@@ -10,14 +10,19 @@
 # bootstrap/openbao/provision-static-unseal.sh for how it gets there.
 #
 # It used to be an `<op scheme>://` reference on this line, and it is the one
-# reference in the estate that can never become `ref+openbao://` — putting this
+# reference in the estate that can never become an OpenBao reference — putting this
 # key inside the thing it unseals is the circular dependency the seal chain
 # exists to avoid. Its durable home is now
 # vault/bootstrap/openbao/alpha-site-static-unseal.sops.yaml (INVENTORY.md §2).
 #
-# The scheme above is broken apart deliberately. The resolver hands WHOLE FILES
-# to vals, and vals expands references wherever they appear — comments
-# included. A well-formed reference in a comment is live code.
+# NEVER write a resolvable scheme in this file, not even in prose and not even
+# to say a reference should NOT exist. The resolver hands WHOLE FILES to vals,
+# vals expands references wherever they appear — comments included — and what
+# vals cannot expand it leaves behind, which the post-check then rejects as an
+# unresolved reference. That is not hypothetical: the first version of this
+# comment said `ref+openbao` followed by `://` and failed every
+# home-operations run until it was reworded. Name schemes in words, or break
+# them apart like `<op scheme>://` above.
 #
 # Rotation: set current_key to the new key and move the old one to
 # previous_key/previous_key_id in config.hcl, then drop the previous pair on


### PR DESCRIPTION
**stacks/home has been failing since #744 merged. My regression.**

```
Error: document still contains 1 unresolved secret-reference scheme(s) after vals eval:
ref+openbao:// — an unsupported provider, or a reference vals did not recognize
```

The comment I added to `docker/alpha-site/bao-transit/.env` said a certain scheme "can never become `ref+openbao://`". `REF_SCHEME` (`/ref\+[a-z0-9]+:\/\//g`) matches that shape **wherever it appears** — the resolver hands whole files to vals, vals expands references anywhere including comments, and what it can't expand it leaves for the residue guard to reject. **The guard worked exactly as designed.**

The bitter part: the same sentence breaks `op://` apart as `<op scheme>://` for precisely this reason, and cites the Phase 8 lesson that produced that rule. I defanged one scheme and left the other live on the same line.

Reworded to name the scheme in words, with the standing rule stated at the point of temptation and this failure as the worked example — because "obviously nobody would" is exactly what I thought while doing it.

**Verified:** zero matches against the real regex in both files; a sweep of every file under `docker/` finds only the five legitimate references (three arcane-agent `token.env`s, pdm, uptime), all real assignments.

Merge this and the next stacks/home run recovers — the half-applied state on dockge-as (compose.yaml synced 16:03, .env still the pre-#744 copy) resolves itself on that run. No risk to the seal: `/var/local/unseal-key` is in place and verified, and compose applies the host env_file after `.env`, so bao-transit gets the right key either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)