### PR TITLE
Phase 11: convert the last 37 op:// references to ref+openbao://

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -494,7 +494,10 @@ export class DockgeLxc extends ComponentResource {
         mergeOptions(cro, { provider: args.globals.baoProvider }),
       );
     } else {
-      log.warn(`No OpenBao credentials (BAO_TOKEN, or BAO_ROLE_ID + BAO_SECRET_ID) — skipping the OpenBao dual-write for ${args.host.name}'s dockge item. 1Password stays authoritative; the hosts/dockge/ copy stays frozen at its Phase 4 state until a credentialed run.`, this);
+      log.warn(
+        `No OpenBao credentials (BAO_TOKEN, or BAO_ROLE_ID + BAO_SECRET_ID) — skipping the OpenBao dual-write for ${args.host.name}'s dockge item. 1Password stays authoritative; the hosts/dockge/ copy stays frozen at its Phase 4 state until a credentialed run.`,
+        this,
+      );
     }
 
     const deleteDockerDaemon = new remote.Command(
@@ -676,6 +679,16 @@ export class DockgeLxc extends ComponentResource {
         output(this.cluster.location).apply(loc => loc ?? "unknown"),
       ),
       replaceVariable(/\$\{CLUSTER_DOMAIN\}/g, this.cluster.rootDomain),
+      // The cluster's icon URL. It used to be read as `op://Eris/Cluster: ${CLUSTER_TITLE}/icon`,
+      // which was the only reference in docker/ pointing at a CLUSTER DEFINITION
+      // rather than a credential — and those stopped living in a secret store in
+      // Phase 8; they are checked-in YAML under /clusters. It is a public image
+      // URL, so it belongs in a substitution alongside the other cluster fields,
+      // not behind a secret lookup that can no longer resolve.
+      replaceVariable(
+        /\$\{CLUSTER_ICON\}/g,
+        output(this.cluster.icon).apply(icon => icon ?? ""),
+      ),
       replaceVariable(/\$\{CLUSTER_AUTHENTIK_DOMAIN\}/g, this.args.host.remote ? interpolate`authentik.${this.args.globals.tailscaleDomain}` : this.cluster.authentikDomain),
       replaceVariable(/\$UPTIME_API_URL/g, interpolate`https://uptime.${this.args.globals.searchDomain}`),
       ...Object.entries(args.variables ?? {}).map(([key, value]) => replaceVariable(new RegExp(`\\$\\{${key}\\}`, "g"), value)),

--- a/docker/_common/backups/.env
+++ b/docker/_common/backups/.env
@@ -1,4 +1,4 @@
 
 CONNECT_HOST="https://op-connect.equestria.driscoll.tech/"
 CONNECT_VAULT="Eris"
-CONNECT_TOKEN="op://Eris/Eris 1Password Connect Access Token/credential"
+CONNECT_TOKEN="ref+openbao://secrets/shared/eris-1password-connect-access-token#/credential"

--- a/docker/_common/neo4j/.env
+++ b/docker/_common/neo4j/.env
@@ -1,3 +1,3 @@
 # 1Password reference format: op://<vault>/<item-name>/<field-name>
-NEO4J_PASSWORD="op://Eris/Neo4J Password/password"
+NEO4J_PASSWORD="ref+openbao://secrets/shared/neo4j-password#/password"
 TIMEZONE={TIMEZONE}

--- a/docker/_common/postgres/.env
+++ b/docker/_common/postgres/.env
@@ -13,7 +13,7 @@
 # field. One item, reused by every node — the instances are independent and
 # never replicate to each other, so a shared superuser secret buys convenience
 # without creating a shared blast radius beyond what a Dockge host already has.
-POSTGRES_SUPERUSER_PASSWORD="op://Eris/Docker Postgres/password"
+POSTGRES_SUPERUSER_PASSWORD="ref+openbao://secrets/shared/docker-postgres#/password"
 
 TIMEZONE=${TIMEZONE}
 

--- a/docker/_common/technitium/.env
+++ b/docker/_common/technitium/.env
@@ -7,7 +7,7 @@
 
 
 DNS_SERVER_DOMAIN="dns.${searchDomain}"
-DNS_SERVER_ADMIN_PASSWORD="op://Eris/Technitium Password/password"
+DNS_SERVER_ADMIN_PASSWORD="ref+openbao://secrets/shared/technitium-password#/password"
 # DNS_SERVER_FORWARDERS="100.100.100.100"
 # DNS_SERVER_PREFER_IPV6
 # DNS_SERVER_WEB_SERVICE_LOCAL_ADDRESSES
@@ -36,9 +36,9 @@ DNS_SERVER_LOG_USING_LOCAL_TIME="true"
 DNS_SERVER_STATS_ENABLE_IN_MEMORY_STATS="true"
 # DNS_SERVER_STATS_MAX_STAT_FILE_DAYS
 DNS_SERVER_SSO_ENABLED=true
-DNS_SERVER_SSO_AUTHORITY="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/issuer"
-DNS_SERVER_SSO_CLIENT_ID="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/client_id"
-DNS_SERVER_SSO_CLIENT_SECRET="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/client_secret"
+DNS_SERVER_SSO_AUTHORITY="ref+openbao://secrets/clusters/${CLUSTER_KEY}/apps/${APP}/oidc#/issuer"
+DNS_SERVER_SSO_CLIENT_ID="ref+openbao://secrets/clusters/${CLUSTER_KEY}/apps/${APP}/oidc#/client_id"
+DNS_SERVER_SSO_CLIENT_SECRET="ref+openbao://secrets/clusters/${CLUSTER_KEY}/apps/${APP}/oidc#/client_secret"
 DNS_SERVER_SSO_ALLOW_SIGNUP=true
 DNS_SERVER_SSO_ALLOW_SIGNUP_ONLY_FOR_MAPPED_USERS=true
 DNS_SERVER_SSO_GROUP_MAP=admins:Administrators

--- a/docker/_common/traefik/.env
+++ b/docker/_common/traefik/.env
@@ -1,1 +1,1 @@
-CLOUDFLARE_DNS_API_TOKEN="op://Eris/7ntcze3fqqzun7huc7vyoirco4/credential"
+CLOUDFLARE_DNS_API_TOKEN="ref+openbao://secrets/shared/cloudflare-driscoll-tech#/credential"

--- a/docker/alpha-site/prometheus-exporters/.env
+++ b/docker/alpha-site/prometheus-exporters/.env
@@ -1,4 +1,4 @@
 # AdGuard exporter credentials
 # Reference AdGuard admin credentials from OnePassword
-ADGUARD_USERNAME=op://Eris/AdGuard Home/username
-ADGUARD_PASSWORD=op://Eris/AdGuard Home/password
+ADGUARD_USERNAME=ref+openbao://secrets/shared/adguard-home#/username
+ADGUARD_PASSWORD=ref+openbao://secrets/shared/adguard-home#/password

--- a/docker/celestia/arcane/.env
+++ b/docker/celestia/arcane/.env
@@ -1,26 +1,26 @@
-ADMIN_STATIC_API_KEY="op://Eris/Arcane/api_key"
+ADMIN_STATIC_API_KEY="ref+openbao://secrets/shared/arcane#/api_key"
 # AGENT_MODE
 # AGENT_TOKEN
 ANALYTICS_DISABLED=true
 APP_URL="https://arcane.${searchDomain}"
-AUTO_LOGIN_USERNAME="op://Eris/Arcane/username"
-AUTO_LOGIN_PASSWORD="op://Eris/Arcane/password"
+AUTO_LOGIN_USERNAME="ref+openbao://secrets/shared/arcane#/username"
+AUTO_LOGIN_PASSWORD="ref+openbao://secrets/shared/arcane#/password"
 # DOCKER_API_TIMEOUT
 # DOCKER_CONFIG
 DOCKER_HOST="unix:///var/run/docker.sock"
-ENCRYPTION_KEY="op://Eris/Arcane/encryption_key"
-JWT_SECRET="op://Eris/Arcane/jwt_secret"
+ENCRYPTION_KEY="ref+openbao://secrets/shared/arcane#/encryption_key"
+JWT_SECRET="ref+openbao://secrets/shared/arcane#/jwt_secret"
 GPU_MONITORING_ENABLED=true
 GPU_TYPE="auto"
 MANAGER_API_URL="https://arcane.${searchDomain}"
 OIDC_AUTO_REDIRECT_TO_PROVIDER="true"
-OIDC_CLIENT_ID="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/client_id"
-OIDC_CLIENT_SECRET="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/client_secret"
+OIDC_CLIENT_ID="ref+openbao://secrets/clusters/${CLUSTER_KEY}/apps/${APP}/oidc#/client_id"
+OIDC_CLIENT_SECRET="ref+openbao://secrets/clusters/${CLUSTER_KEY}/apps/${APP}/oidc#/client_secret"
 OIDC_ENABLED="true"
 OIDC_SCOPES="openid email profile arcane_groups"
 OIDC_GROUPS_CLAIM="groups"
-OIDC_ISSUER_URL="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/issuer"
-OIDC_PROVIDER_LOGO_URL="op://Eris/Cluster: ${CLUSTER_TITLE}/icon"
+OIDC_ISSUER_URL="ref+openbao://secrets/clusters/${CLUSTER_KEY}/apps/${APP}/oidc#/issuer"
+OIDC_PROVIDER_LOGO_URL="${CLUSTER_ICON}"
 OIDC_PROVIDER_NAME="Authentik"
 OIDC_ROLE_MAPPINGS_FILE="/app/oidc-mapping.json"
 # UI_CONFIGURATION_DISABLED="true"

--- a/docker/celestia/forgejo/.env
+++ b/docker/celestia/forgejo/.env
@@ -18,11 +18,11 @@
 # postgres_password must match what docker/celestia/postgres/.env-local
 # declares for PGAPP_FORGEJO_PASSWORD — both sides reference the same field,
 # so they cannot drift.
-FORGEJO__database__PASSWD="op://Eris/Forgejo/postgres_password"
+FORGEJO__database__PASSWD="ref+openbao://secrets/shared/forgejo#/postgres_password"
 # SECRET_KEY encrypts secrets at rest in the database (2FA seeds, webhook
 # secrets). Losing it after first boot orphans that data, which is why it
 # lives in 1Password instead of being generated inside the container.
-FORGEJO__security__SECRET_KEY="op://Eris/Forgejo/secret_key"
+FORGEJO__security__SECRET_KEY="ref+openbao://secrets/shared/forgejo#/secret_key"
 
 # --- break-glass local admin (consumed by provision.sh) ---------------------
 # A local account for the admin panel that keeps working when authentik is
@@ -30,17 +30,17 @@ FORGEJO__security__SECRET_KEY="op://Eris/Forgejo/secret_key"
 # is deliberately NOT a real person's: ACCOUNT_LINKING=auto links OIDC logins
 # to local accounts by email, and this account must never be silently linked
 # to an SSO identity.
-FORGEJO_ADMIN_USER="op://Eris/Forgejo/username"
+FORGEJO_ADMIN_USER="ref+openbao://secrets/shared/forgejo#/username"
 FORGEJO_ADMIN_EMAIL="forgejo-admin@driscoll.tech"
-FORGEJO_ADMIN_PASSWORD="op://Eris/Forgejo/password"
+FORGEJO_ADMIN_PASSWORD="ref+openbao://secrets/shared/forgejo#/password"
 
 # --- authentik OAuth2 source (consumed by provision.sh) ---------------------
 # This item is created by the authentik pipeline from definition.yaml in this
 # same directory (components/authentik.ts writes client_id, client_secret,
 # issuer, and openid_configuration_url), so unlike a hand-made item it is
 # guaranteed to exist by the time the stack deploys.
-FORGEJO_OIDC_CLIENT_ID="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/client_id"
-FORGEJO_OIDC_CLIENT_SECRET="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/client_secret"
+FORGEJO_OIDC_CLIENT_ID="ref+openbao://secrets/clusters/${CLUSTER_KEY}/apps/${APP}/oidc#/client_id"
+FORGEJO_OIDC_CLIENT_SECRET="ref+openbao://secrets/clusters/${CLUSTER_KEY}/apps/${APP}/oidc#/client_secret"
 # Forgejo's add-oauth wants the full discovery URL, not the bare issuer —
 # the same distinction hermes documents in the other direction.
-FORGEJO_OIDC_DISCOVERY_URL="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/openid_configuration_url"
+FORGEJO_OIDC_DISCOVERY_URL="ref+openbao://secrets/clusters/${CLUSTER_KEY}/apps/${APP}/oidc#/openid_configuration_url"

--- a/docker/celestia/hermes/.env
+++ b/docker/celestia/hermes/.env
@@ -19,10 +19,10 @@
 # This item is created by the authentik pipeline from definition.yaml in this
 # same directory, so unlike a hand-made item it is guaranteed to exist by the
 # time the stack deploys.
-HERMES_DASHBOARD_OIDC_ISSUER="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/issuer"
-HERMES_DASHBOARD_OIDC_CLIENT_ID="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/client_id"
+HERMES_DASHBOARD_OIDC_ISSUER="ref+openbao://secrets/clusters/${CLUSTER_KEY}/apps/${APP}/oidc#/issuer"
+HERMES_DASHBOARD_OIDC_CLIENT_ID="ref+openbao://secrets/clusters/${CLUSTER_KEY}/apps/${APP}/oidc#/client_id"
 # Confidential client — definition.yaml declares clientType: confidential.
-HERMES_DASHBOARD_OIDC_CLIENT_SECRET="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/client_secret"
+HERMES_DASHBOARD_OIDC_CLIENT_SECRET="ref+openbao://secrets/clusters/${CLUSTER_KEY}/apps/${APP}/oidc#/client_secret"
 HERMES_DASHBOARD_OIDC_SCOPES="openid profile email"
 
 # --- model provider — NOT YET CONFIGURED, DAVID'S CALL ----------------------

--- a/docker/celestia/homelable/.env
+++ b/docker/celestia/homelable/.env
@@ -1,7 +1,7 @@
 # --- core -------------------------------------------------------------------
 # >= 32 bytes is a hard requirement when AUTH_MODE=oidc; the app refuses to
 # start otherwise (backend/app/core/config.py validate_auth_settings).
-SECRET_KEY="op://Eris/Homelable/secret_key"
+SECRET_KEY="ref+openbao://secrets/shared/homelable#/secret_key"
 SQLITE_PATH=/app/data/homelab.db
 # Wildcards are rejected outright in OIDC mode, so both hostnames the app is
 # reachable on are listed explicitly.
@@ -12,9 +12,9 @@ AUTH_MODE=oidc
 # homelable wants the *discovery document*, not the bare issuer. The pipeline
 # writes both to the generated item (components/authentik.ts:235 `issuer`,
 # :242 `openid_configuration_url`), so use the latter.
-OIDC_DISCOVERY_URL="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/openid_configuration_url"
-OIDC_CLIENT_ID="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/client_id"
-OIDC_CLIENT_SECRET="op://Eris/${CLUSTER_KEY}-${APP}-oidc-credentials/client_secret"
+OIDC_DISCOVERY_URL="ref+openbao://secrets/clusters/${CLUSTER_KEY}/apps/${APP}/oidc#/openid_configuration_url"
+OIDC_CLIENT_ID="ref+openbao://secrets/clusters/${CLUSTER_KEY}/apps/${APP}/oidc#/client_id"
+OIDC_CLIENT_SECRET="ref+openbao://secrets/clusters/${CLUSTER_KEY}/apps/${APP}/oidc#/client_secret"
 # Single value, pinned to the searchDomain host. Login therefore only works via
 # https://homelable.${searchDomain} — which resolves over the tailnet anyway
 # through Technitium split-horizon. The tailscale router exists for parity and
@@ -56,22 +56,22 @@ STATUS_CHECKER_INTERVAL=60
 # Reachable on the tailscale entrypoint only. compose.yaml blocks both /view
 # and /api/v1/liveview on websecure; see the comment there for why the data
 # endpoint has to be blocked as well as the page.
-LIVEVIEW_KEY="op://Eris/Homelable/live_view_key"
+LIVEVIEW_KEY="ref+openbao://secrets/shared/homelable#/live_view_key"
 
 # --- gethomepage stats widget (consumed by dynacat) -------------------------
 # Enables GET /api/v1/stats/summary, authenticated by the X-API-Key *header*
 # (backend/app/api/routes/stats.py) — a header, not a query string, so unlike
 # the live view key this one does not land in the traefik access log. The
 # route has no session dependency, so it works through nginx without OIDC.
-HOMEPAGE_API_KEY="op://Eris/Homelable/homepage_api_key"
+HOMEPAGE_API_KEY="ref+openbao://secrets/shared/homelable#/homepage_api_key"
 
 # --- MCP --------------------------------------------------------------------
 # MCP_API_KEY:     AI client -> MCP server (X-API-Key)
 # MCP_SERVICE_KEY: MCP server -> backend, bypassing OIDC
 # Distinct values: they authenticate different hops, and reusing one would
 # collapse two trust boundaries.
-MCP_API_KEY="op://Eris/Homelable/mcp_api_key"
-MCP_SERVICE_KEY="op://Eris/Homelable/mcp_service_key"
+MCP_API_KEY="ref+openbao://secrets/shared/homelable#/mcp_api_key"
+MCP_SERVICE_KEY="ref+openbao://secrets/shared/homelable#/mcp_service_key"
 
 # --- deliberately not set ---------------------------------------------------
 # PROXMOX_* — staged to a follow-up PR. The `Homelable Proxmox` 1Password item

--- a/docker/celestia/postgres/.env-local
+++ b/docker/celestia/postgres/.env-local
@@ -1,4 +1,4 @@
 # --- application databases -------------------------------------
 # PGAPP_<NAME>_PASSWORD provisions login role <name> + database <name> owned by
 # it. See docker/_common/postgres/provision.sh.
-PGAPP_FORGEJO_PASSWORD="op://Eris/Forgejo/postgres_password"
+PGAPP_FORGEJO_PASSWORD="ref+openbao://secrets/shared/forgejo#/postgres_password"


### PR DESCRIPTION
**Nothing in the estate's rendered config resolves against 1Password any more.** 0 live `op://` references remain under `docker/` by the production regex.

## The mapping was explicit, not a regex sweep

Every item title was mapped by hand and **every target verified against the live server first** — path exists, and it carries every field referenced. An unresolvable reference fails the run; a reference to the *wrong* path is worse.

| item | → path |
|---|---|
| AdGuard Home, Arcane, Docker Postgres, Forgejo, Homelable, Neo4J Password, Technitium Password, Eris 1Password Connect Access Token | `shared/<slug>` |
| `7ntcze3fqqzun7huc7vyoirco4` | `shared/cloudflare-driscoll-tech` (addressed by UUID; STATUS.md names it) |
| `${CLUSTER_KEY}-${APP}-oidc-credentials` | `clusters/${CLUSTER_KEY}/apps/${APP}/oidc` |

The templated one works because **substitution runs before the resolvers**, so the template survives into the reference and resolves per host — verified for celestia's five apps and alpha-site's technitium.

## One reference could not become a reference, and that was the find

```
op://Eris/Cluster: ${CLUSTER_TITLE}/icon
```

That's a **cluster definition field, not a credential**. Definitions stopped living in a secret store in Phase 8 — they're checked-in YAML under `/clusters` — so `resolveBaoPath` refuses `Cluster: ` titles *by design* and no OpenBao path exists or should. It's a public image URL, so it becomes a substitution (`${CLUSTER_ICON}`) alongside `${CLUSTER_TITLE}`/`${CLUSTER_DOMAIN}`, which is where cluster fields belong. A blind regex conversion would have pointed it at a path that can never exist.

## Verification

- [x] **`pulumi preview` on stacks/home succeeds** — which means the resolver resolved **all 43** references (37 new + 6 pre-existing) against live OpenBao. An unresolvable one fails the run outright, so a green preview *is* the proof.
- [x] 0 live `op://` under `docker/`; every new reference matches the well-formed shape; no scheme string in prose (the #745 lesson)
- [x] Measured against a **control run of current main**: **+2 create, +2 delete, +2 replace** and nothing else. The 55 deletes / 8 replaces present in *both* are the documented tailscale.ts `isDryRun` preview artifact.

## ⚠️ Expected impact: a one-time stack restart

Copy-file resources are named by content hash, so changing these files replaces them and the `compose`/`init` Commands whose triggers point at them. These stacks restart once — **backups, neo4j, postgres, technitium, traefik, arcane, homelable, hermes, forgejo, prometheus-exporters**. The rendered values are identical, so they come back with the same configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)