### PR TITLE
fix(system): restore the auth-delegator binding the workspace needs

### DIFF
--- a/kubernetes/apps/pulumi/system/serviceaccount.yaml
+++ b/kubernetes/apps/pulumi/system/serviceaccount.yaml
@@ -5,8 +5,26 @@ kind: ServiceAccount
 metadata:
   name: ${APP}
   namespace: ${NAMESPACE}
-# No ClusterRoleBinding, deliberately. The other stacks bind
-# `system:auth-delegator` because they reach the Kubernetes API — this one
-# reads /clusters/*.yaml out of its own checkout and writes OpenBao, and needs
-# no cluster access at all. Copying the binding across would have granted
-# TokenReview to a workload that never calls it.
+---
+# NOT optional, and not about what this stack reaches.
+#
+# It was dropped from this stack on the reasoning that the system stack only
+# reads /clusters/*.yaml and writes OpenBao, so it needs no Kubernetes access.
+# That misreads what the binding is for: the operator authenticates the
+# workspace pod's gRPC connection by calling TokenReview with the workspace's
+# own token, and `system:auth-delegator` is what permits that call. Without it
+# the workspace starts, runs, and is never talked to — the Stack sits
+# Reconciling forever with `Unauthenticated: TokenReview API is unavailable`
+# and never produces a state at all.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ${APP}-system-auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    namespace: ${NAMESPACE}
+    name: ${APP}


### PR DESCRIPTION
**The system stack has been stuck since it was created**, never producing a state:

```
Ready=False  Unauthenticated: TokenReview API is unavailable
```

My mistake in [#748](https://github.com/david-driscoll/home-operations/pull/748). I dropped the `system:auth-delegator` ClusterRoleBinding while scaffolding, reasoning that this stack only reads `/clusters/*.yaml` and writes OpenBao, so it needs no Kubernetes access.

That misreads what the binding is for. It isn't about what the *stack* reaches — **it's how the operator authenticates the workspace pod's gRPC connection**, by calling TokenReview with the workspace's own token. Without it the pod starts, runs, and is never talked to. Every other stack has it for the same reason.

Least privilege still applies; understanding what a permission actually does comes first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)