### PR TITLE
Phase 11 cleanup: remove BAO_STORE_READS, which no longer switches anything

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -56,12 +56,6 @@ CONNECT_VAULT = "Eris"
 CONNECT_TOKEN = "op://Eris/Eris 1Password Connect Access Token/credential"
 AUTHENTIK_TOKEN = "op://Eris/Authentik Token/credential"
 AUTHENTIK_URL = "op://Eris/Authentik Token/url"
-# Phase 8 cutover: local runs read secrets from OpenBao (BaoStore), matching
-# the operator's Stack CRs. Local runs now REQUIRE the OpenBao credentials —
-# eval "$(bootstrap/openbao/pulumi-env.sh)" from the vault repo first; without
-# them GlobalResources fails loudly at construction rather than silently
-# reading a different store than the operator does.
-BAO_STORE_READS = "1"
 # UNIFI_HOST = "unifi.driscoll.tech"
 # UNIFI_USERNAME = "op://Eris/unifipoller/username"
 # UNIFI_PASSWORD = "op://Eris/unifipoller/password"

--- a/kubernetes/apps/pulumi/applications/equestria.yaml
+++ b/kubernetes/apps/pulumi/applications/equestria.yaml
@@ -87,14 +87,6 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
-    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
-    # 1Password. Explicit, never inferred from credential presence — see
-    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
-    # this was scripts/bao-store-parity.ts fully green, inventory included.
-    BAO_STORE_READS:
-      type: Literal
-      literal:
-        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/applications/sgc.yaml
+++ b/kubernetes/apps/pulumi/applications/sgc.yaml
@@ -87,14 +87,6 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
-    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
-    # 1Password. Explicit, never inferred from credential presence — see
-    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
-    # this was scripts/bao-store-parity.ts fully green, inventory included.
-    BAO_STORE_READS:
-      type: Literal
-      literal:
-        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/authentik/stack.yaml
+++ b/kubernetes/apps/pulumi/authentik/stack.yaml
@@ -88,14 +88,6 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
-    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
-    # 1Password. Explicit, never inferred from credential presence — see
-    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
-    # this was scripts/bao-store-parity.ts fully green, inventory included.
-    BAO_STORE_READS:
-      type: Literal
-      literal:
-        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/backups/stack.yaml
+++ b/kubernetes/apps/pulumi/backups/stack.yaml
@@ -88,14 +88,6 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
-    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
-    # 1Password. Explicit, never inferred from credential presence — see
-    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
-    # this was scripts/bao-store-parity.ts fully green, inventory included.
-    BAO_STORE_READS:
-      type: Literal
-      literal:
-        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
+++ b/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
@@ -88,14 +88,6 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
-    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
-    # 1Password. Explicit, never inferred from credential presence — see
-    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
-    # this was scripts/bao-store-parity.ts fully green, inventory included.
-    BAO_STORE_READS:
-      type: Literal
-      literal:
-        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/home-operations/stack.yaml
+++ b/kubernetes/apps/pulumi/home-operations/stack.yaml
@@ -89,14 +89,6 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
-    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
-    # 1Password. Explicit, never inferred from credential presence — see
-    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
-    # this was scripts/bao-store-parity.ts fully green, inventory included.
-    BAO_STORE_READS:
-      type: Literal
-      literal:
-        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/ocracoke/stack.yaml
+++ b/kubernetes/apps/pulumi/ocracoke/stack.yaml
@@ -88,14 +88,6 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
-    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
-    # 1Password. Explicit, never inferred from credential presence — see
-    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
-    # this was scripts/bao-store-parity.ts fully green, inventory included.
-    BAO_STORE_READS:
-      type: Literal
-      literal:
-        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/system/stack.yaml
+++ b/kubernetes/apps/pulumi/system/stack.yaml
@@ -83,14 +83,6 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
-    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
-    # 1Password. Explicit, never inferred from credential presence — see
-    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
-    # this was scripts/bao-store-parity.ts fully green, inventory included.
-    BAO_STORE_READS:
-      type: Literal
-      literal:
-        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/unifi-network/stack.yaml
+++ b/kubernetes/apps/pulumi/unifi-network/stack.yaml
@@ -87,14 +87,6 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
-    # Phase 8 cutover: secret reads come from OpenBao (BaoStore) instead of
-    # 1Password. Explicit, never inferred from credential presence — see
-    # baoStoreReadsEnabled in components/store/bao.ts. The gate for setting
-    # this was scripts/bao-store-parity.ts fully green, inventory included.
-    BAO_STORE_READS:
-      type: Literal
-      literal:
-        value: "1"
   secretsRef:
     github:token:
       type: Secret

--- a/kubernetes/apps/pulumi/vault/stack.yaml
+++ b/kubernetes/apps/pulumi/vault/stack.yaml
@@ -89,16 +89,6 @@ spec:
       secret:
         name: pulumi-operator-bao-approle
         key: secret-id
-    # Phase 9 cutover: secret reads come from OpenBao (BaoStore) instead of
-    # 1Password — the vault repo's own copy of the Phase 8 seam. Explicit,
-    # never inferred from credential presence — see baoStoreReadsEnabled in
-    # vault components/store/bao.ts. The gate for setting this was that
-    # repo's scripts/bao-store-parity.ts fully green plus stable dual
-    # preview pairs (vault docs/openbao-migration/STATUS.md, Phase 9).
-    BAO_STORE_READS:
-      type: Literal
-      literal:
-        value: "1"
   secretsRef:
     github:token:
       type: Secret


### PR DESCRIPTION
Phase 11 deleted the 1Password read path, so there is one store and nothing to select. The variable has been inert since then.

An env var that **looks** like a switch but isn't is worse than no env var — the next person debugging a read will reach for it first, and it will tell them nothing.

Removed from all ten Stack CRs and `.config/mise.toml`. **`BAO_ADDR` and `BAO_ROLE_ID`/`BAO_SECRET_ID` stay** — those are load-bearing; without them `GlobalResources` fails at construction rather than quietly reading something else. Verified they survive in every file, and `kustomize build` still renders.

Companion: [vault#185](https://github.com/david-driscoll/vault/pull/185) does the same there and carries the Phase 11 STATUS.md record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)