### PR TITLE
fix(refs): say which document failed to resolve, and on which line

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -698,7 +698,7 @@ export class DockgeLxc extends ComponentResource {
       // running before substitution would see a syntax that matches nothing.
       // There is only one resolver now: Phase 11 converted the last 1Password
       // references, so every reference in a rendered file names OpenBao.
-      (input: Input<string>) => this.args.globals.store.resolveSecretReferences(input),
+      (input: Input<string>, label: string) => this.args.globals.store.resolveSecretReferences(input, label),
     ];
 
     const stacks = all([output(readdir(resolve(dockerPath, "_common"))), output(readdir(resolve(dockerPath, this.args.host.name)))]).apply(([commonFiles, hostFiles]) =>
@@ -853,7 +853,7 @@ export class DockgeLxc extends ComponentResource {
     stackName: string,
     files: Map<string, string>,
     path: string,
-    replacements: ((input: Output<string>) => Output<string>)[],
+    replacements: ((input: Output<string>, label: string) => Output<string>)[],
     dependsOn: Input<Resource[]>,
   ): Output<{
     name: string;
@@ -912,7 +912,7 @@ export class DockgeLxc extends ComponentResource {
       .apply(defs =>
         defs.map(([, absoluteFilePath]) => {
           const content = output(readFile(absoluteFilePath, "utf-8"));
-          const replacedContent = replacements.reduce((p, r) => r(p), content);
+          const replacedContent = replacements.reduce((p, r) => r(p, absoluteFilePath), content);
           // intercept definition file and create the client id / client secret and inject that into the yaml.
           return replacedContent.apply(content => {
             const docs = yaml.parseAllDocuments(content);
@@ -933,7 +933,9 @@ export class DockgeLxc extends ComponentResource {
     for (const [relativeFilePath, absoluteFilePath] of others) {
       const content = output(readFile(absoluteFilePath, "utf-8"));
       const file = relativeFilePath;
-      const replacedContent = replacements.reduce((p, r) => r(p), content);
+      // Name the document: an unresolved reference reports WHICH file and which
+      // line, instead of leaving you to grep the whole tree for a scheme.
+      const replacedContent = replacements.reduce((p, r) => r(p, absoluteFilePath), content);
 
       if (file.endsWith("init.sh")) {
         hasInit = true;

--- a/components/authentik.ts
+++ b/components/authentik.ts
@@ -546,7 +546,7 @@ export class AuthentikApplicationManager extends pulumi.ComponentResource {
           // definitions live in the cluster repos and convert to the ref+
           // syntax on their own schedule, so both must resolve here until no
           // definition carries op://.
-          return pulumi.output(this.store.resolveSecretReferences(yamlString)).apply(y => yaml.parse(y) as GatusDefinition);
+          return pulumi.output(this.store.resolveSecretReferences(yamlString, `gatus definition for ${definition.metadata.name}`)).apply(y => yaml.parse(y) as GatusDefinition);
         }),
       );
     });

--- a/components/store/index.ts
+++ b/components/store/index.ts
@@ -99,8 +99,8 @@ export abstract class VaultStore {
    * none on `op://`.
    */
   private readonly refResolver = new SecretRefResolver();
-  public resolveSecretReferences(value: Input<string>): Output<string> {
-    return this.refResolver.resolve(value);
+  public resolveSecretReferences(value: Input<string>, label?: string): Output<string> {
+    return this.refResolver.resolve(value, label);
   }
 
   /**

--- a/components/store/refs.test.ts
+++ b/components/store/refs.test.ts
@@ -126,6 +126,50 @@ describe("SecretRefResolver", () => {
     );
   });
 
+  it("names the document and the LINE, which is what makes the failure findable", async () => {
+    // The motivating incident: a well-formed scheme inside a COMMENT explaining
+    // that the reference should not exist. The old error named neither the file
+    // nor the line, so a one-line fix took a hunt across eleven files.
+    const fake = fakeVals({});
+    const doc = ["# first line", "# second line", "# it can never become `ref+sops://` — putting it there is circular", "KEY=plain"].join("\n");
+    await assert.rejects(
+      () => resolver(fake).resolveText(doc, "docker/alpha-site/bao-transit/.env"),
+      (error: Error) => {
+        assert.match(error.message, /^docker\/alpha-site\/bao-transit\/\.env: /, "must lead with the document");
+        assert.match(error.message, /\(line 3\)/, "must name the line the scheme is on");
+        // Still no content: the line NUMBER is safe, the line's text is not a
+        // promise this error should make.
+        assert.doesNotMatch(error.message, /circular/);
+        return true;
+      },
+    );
+  });
+
+  it("says nothing about a document when the caller did not name one", async () => {
+    const fake = fakeVals({});
+    await assert.rejects(
+      () => resolver(fake).resolveText("a: ref+sops://x.sops.yaml#/k"),
+      (error: Error) => {
+        assert.match(error.message, /^document still contains/);
+        return true;
+      },
+    );
+  });
+
+  it("names the document when VALS itself fails, which is the common case", async () => {
+    // A reference to a path that does not exist. vals names the reference; the
+    // error must also name the file, or you are grepping for it.
+    const fake = fakeVals({});
+    await assert.rejects(
+      () => resolver(fake).resolveText("PASSWORD=ref+openbao://secrets/shared/nope#/password", "docker/celestia/forgejo/.env"),
+      (error: Error) => {
+        assert.match(error.message, /^docker\/celestia\/forgejo\/\.env: /);
+        assert.match(error.message, /does not exist/, "the provider's own reason survives");
+        return true;
+      },
+    );
+  });
+
   it("a document with ONLY an unsupported provider still fails loudly", async () => {
     // The gate matches any scheme-shaped reference, not just openbao — a
     // sops-only file must enter resolution and die in the residue guard, not

--- a/components/store/refs.ts
+++ b/components/store/refs.ts
@@ -102,12 +102,12 @@ export class SecretRefResolver {
    * every resolved value is a credential by construction, and the containing
    * file content must not reach Pulumi state in the clear.
    */
-  public resolve(value: Input<string>): Output<string> {
+  public resolve(value: Input<string>, label?: string): Output<string> {
     return output(value).apply(v => {
       // `search`, not `test`: the shared pattern is /g and `test` advances
       // its lastIndex; `search` neither reads nor writes it.
       if (v.search(REF_SCHEME) === -1) return output(v);
-      return secret(output(this.resolveText(v)));
+      return secret(output(this.resolveText(v, label)));
     });
   }
 
@@ -117,10 +117,10 @@ export class SecretRefResolver {
    * as a plain promise — a rejected Output fans out through the SDK's
    * internal sibling promises, which only the engine observes.
    */
-  public resolveText(v: string): Promise<string> {
+  public resolveText(v: string, label?: string): Promise<string> {
     let pending = this.resolved.get(v);
     if (!pending) {
-      pending = this.evaluate(v);
+      pending = this.evaluate(v, label);
       this.resolved.set(v, pending);
       // A failed eval must not poison the memo forever — a retry (the
       // operator reconciles on backoff) should re-run vals, not replay the
@@ -130,26 +130,59 @@ export class SecretRefResolver {
     return pending;
   }
 
-  private async evaluate(v: string): Promise<string> {
+  private async evaluate(v: string, label?: string): Promise<string> {
     this.client ??= this.makeClient();
     const doc = yaml.stringify({ content: v });
-    const resolvedDoc = await this.exec(doc, {
-      VAULT_ADDR: this.client.address,
-      VAULT_TOKEN: await this.client.authToken(),
-    });
+    let resolvedDoc: string;
+    try {
+      resolvedDoc = await this.exec(doc, {
+        VAULT_ADDR: this.client.address,
+        VAULT_TOKEN: await this.client.authToken(),
+      });
+    } catch (error) {
+      // vals' own failures — a path that does not exist, a backend that will
+      // not authenticate — are the COMMON case, and they arrived with no
+      // indication of which document held the reference. vals names the ref;
+      // this names the file it came from. The original message is preserved
+      // verbatim: it carries the reference and the provider's reason, never a
+      // resolved value.
+      throw new Error(`${where(label)}${error instanceof Error ? error.message : String(error)}`, { cause: error });
+    }
     const parsed = yaml.parse(resolvedDoc) as { content?: unknown } | null;
     const content = parsed?.content;
     if (typeof content !== "string") {
-      throw new Error(`vals eval returned ${content === undefined ? "no content" : typeof content} for a ${v.length}-byte document — expected the wrapped string back`);
+      throw new Error(`${where(label)}vals eval returned ${content === undefined ? "no content" : typeof content} for a ${v.length}-byte document — expected the wrapped string back`);
     }
     const residue = Array.from(new Set(Array.from(content.matchAll(REF_SCHEME), m => m[0])));
     if (residue.length > 0) {
       // Schemes only, never spans: the surrounding content is resolved
-      // secrets by now, and an error message must not carry any of it.
-      throw new Error(`document still contains ${residue.length} unresolved secret-reference scheme(s) after vals eval: ${residue.join(", ")} — an unsupported provider, or a reference vals did not recognize`);
+      // secrets by now, and an error message must not carry any of it. Line
+      // numbers come from the ORIGINAL document, which holds references and
+      // no resolved values — and the original is the file a human edits.
+      throw new Error(
+        `${where(label)}document still contains ${residue.length} unresolved secret-reference scheme(s) after vals eval: ${residue.map(scheme => `${scheme}${lineOf(v, scheme)}`).join(", ")} — an unsupported provider, a reference vals did not recognize, or a scheme written in prose (see the estate rule: never write a resolvable scheme, even in a comment)`,
+      );
     }
     return content;
   }
+}
+
+/**
+ * `path: ` when the caller named the document, empty when it did not.
+ *
+ * Every one of these errors used to be anonymous, which is why a single
+ * well-formed scheme in a comment cost a hunt across eleven files to find
+ * rather than a glance.
+ */
+function where(label?: string): string {
+  return label ? `${label}: ` : "";
+}
+
+/** ` (line N)` for the first occurrence in the ORIGINAL document, or "". */
+function lineOf(original: string, scheme: string): string {
+  const index = original.indexOf(scheme);
+  if (index === -1) return "";
+  return ` (line ${original.slice(0, index).split("\n").length})`;
 }
 
 /**


### PR DESCRIPTION
Every error out of the reference resolver was anonymous. When a well-formed scheme inside a **comment** broke every home-operations run ([#745](https://github.com/david-driscoll/home-operations/pull/745)), the message was:

```
document still contains 1 unresolved secret-reference scheme(s) after vals eval: ref+openbao://
```

Neither the file nor the line — so a one-line fix meant grepping eleven files. It now reads:

```
docker/alpha-site/bao-transit/.env: document still contains 1 unresolved secret-reference
scheme(s) after vals eval: ref+openbao:// (line 12) — …or a scheme written in prose
(see the estate rule: never write a resolvable scheme, even in a comment)
```

**Three parts:**

- **The caller names the document.** `DockgeLxc` passes the file path at both application sites; `authentik.ts` names the Gatus definition. The label is optional, so an unnamed call still works and just says less.
- **Line numbers come from the ORIGINAL document**, not the resolved one — the original holds references and no resolved values, and it's the file a human edits. Numbers only: the line's *text* is not a promise this error should make.
- **vals' own failures are labelled too**, and that's the common case — a reference to a path that doesn't exist. vals names the reference; this names the file it came from, preserving the provider's message verbatim and passing it as `cause`.

**Verified by reproducing the original incident:** reinstating that comment now fails with the file and `(line 12)`.

Companion [vault#188](https://github.com/david-driscoll/vault/pull/188) keeps the two repos' store files byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)