### PR TITLE
fix(mise): repoint CONNECT_HOST at equestria, not SGC

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -77,7 +77,7 @@ AWS_REGION = "home"
 # you decrypt state and run Pulumi to fix it. Point this at the sops file
 # if you ever need that.
 PULUMI_CONFIG_PASSPHRASE = "ref+openbao://secrets/shared/pulumi-passphrase#/password"
-CONNECT_HOST = "https://op-connect.sgc.driscoll.tech/"
+CONNECT_HOST = "https://op-connect.equestria.driscoll.tech/"
 CONNECT_VAULT = "Eris"
 # Still needed: Pulumi WRITES the PBS items a human logs into the generated
 # LXCs with (Phase 11 estate decision). Nothing READS 1Password any more.


### PR DESCRIPTION
## What

Repoints `CONNECT_HOST` in `.config/mise.toml` from
`https://op-connect.sgc.driscoll.tech/` to
`https://op-connect.equestria.driscoll.tech/`.

## Why

Part of §1 of
[`docs/cluster-consolidation/03-secrets-bootstrap-independence.md`](https://github.com/david-driscoll/home-operations/blob/main/docs/cluster-consolidation/03-secrets-bootstrap-independence.md),
which is one piece of the [cluster consolidation plan](https://github.com/david-driscoll/vault/issues/84)
(vault#84).

SGC is being dissolved by that plan. This repo's `mise.toml` was the last
place still pointing 1Password Connect reads at the SGC cluster — every
other repo already made this move:

| Location | Value |
|---|---|
| `home-operations/docker/_common/backups/.env` | ✅ already `op-connect.equestria.driscoll.tech` |
| `equestria-cluster/.config/mise.toml` | ✅ already `op-connect.equestria.driscoll.tech` |
| `stargate-command-cluster/.config/mise.toml` | ✅ already `op-connect.equestria.driscoll.tech` |
| `home-operations/.config/mise.toml` | ❌ → fixed by this PR |
| `vault/.config/mise.toml` | ❌ → fixed by a companion PR in the vault repo |

Both clusters run their own Connect HTTPRoute
(`kubernetes/apps/kube-system/1password/httproute.yaml`), so both
hostnames are live today — this is "why is our own repo the odd one out,"
not "the SGC one is broken."

Verified by grep across all four repos: no CI workflow, docker-compose
file, or script references `op-connect.sgc` anywhere else. The only other
hits are two crew-generated `docs/codebase/STACK.md` mirrors (in this repo
and vault), which regenerate off this source file and need no separate
edit.

## Scope note

`OPClient`/`OnePasswordItem` is still actively used for writes (dual-write
to OpenBao for most call sites, PBS-only by design for one) — this PR does
not touch that, only the read-path host. Nothing in this repo currently
*reads* from 1Password Connect for anything a stack consumes (confirmed:
`BaoStore`/OpenBao is the sole read path per Phase 11 of the OpenBao
migration), so this repoint is low-risk — `CONNECT_HOST` is only
load-bearing for `OnePasswordItem` create/update/delete calls and for a
human logging into a generated LXC.

## Verification

- Confirmed the stale line still read `op-connect.sgc.driscoll.tech` in a
  fresh worktree off latest `main` before editing (not stale doc info).
- `pulumi preview` was **not** run for this change — it's a single-line
  hostname repoint with no Pulumi program dependency, and the doc's
  "clusters-down `pulumi preview`" exit-gate test is explicitly out of
  scope for this PR (requires powering down infrastructure; tracked
  separately as §3 of the same plan doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)