### PR TITLE
feat(home): add Minio bucket versioning for the state-archive bucket

### DIFF
--- a/stacks/home/index.ts
+++ b/stacks/home/index.ts
@@ -30,6 +30,13 @@ const alphaSiteProxmoxCredentials = globals.store.getSecretByTitle<CredentialDef
 const dockgeCredential = globals.store.getSecretByTitle<PasswordDefinition>("Dockge Credential");
 const celestiaCluster = globals.store.getCluster("Cluster: Celestia");
 const alphaSiteCluster = globals.store.getCluster("Cluster: Alpha Site");
+// `protect: true` + `retainOnDelete: true` guard this bucket against the
+// failure mode that `deleteBeforeReplace: true` enabled twice elsewhere in
+// this repo — see components/StandardDns.ts and project memory
+// (standarddns-cloudflare-import-outage, standarddns-unifi-import-armed-
+// deletes) for what happens when a bad replace plan can delete-then-adopt
+// an `import:` resource without a human in the loop. Don't drop `protect`
+// here without reading those first. See docs/cluster-consolidation/05-import-audit.md.
 const _minioBucket = new minio.S3Bucket(
   `home-operations-minio-bucket`,
   {
@@ -41,6 +48,23 @@ const _minioBucket = new minio.S3Bucket(
     protect: true,
     retainOnDelete: true,
     import: "home-operations",
+  },
+);
+
+// Versioning on the state-archive bucket: cheap protection against a bad
+// `pulumi stack export`/backend write clobbering a prior good one.
+// Additive-only — does not touch the import: behavior above.
+const _minioBucketVersioning = new minio.S3BucketVersioning(
+  `home-operations-minio-bucket-versioning`,
+  {
+    bucket: _minioBucket.bucket,
+    versioningConfiguration: {
+      status: "Enabled",
+    },
+  },
+  {
+    provider: globals.truenasMinioProvider,
+    protect: true,
   },
 );
 


### PR DESCRIPTION
## What

Piece E ("Import audit") of the [cluster consolidation plan](https://github.com/david-driscoll/vault/issues/84), specifically `docs/cluster-consolidation/05-import-audit.md`, deliverables 2 and 3:

1. **Added `minio.S3BucketVersioning`** for the `home-operations` Minio bucket (`stacks/home/index.ts`) — additive-only, doesn't touch the existing `import: "home-operations"` resource option or its `protect`/`retainOnDelete` settings. Confirmed the resource shape against the live `@pulumi/minio@0.17.0` Pulumi Registry schema (`bucket` + `versioningConfiguration: { status }`, both required inputs) before writing it.
2. **Added a short comment** above the existing `S3Bucket` resource explaining why `protect: true` is load-bearing, pointing at the two `components/StandardDns.ts` DNS-import outages (Cloudflare 2026-07-25, UniFi 2026-07-28) this posture guards against — same rationale as the plan doc's recommendation.

## What this PR does NOT include

The plan doc's deliverable 1 — a two-consecutive `pulumi preview` diff on the existing `import: "home-operations"` resource, to confirm the bucket-name-as-id doesn't perpetually re-plan the same way the Cloudflare/UniFi DNS record ids did — **was not run**. This execution environment has no reachable Pulumi/1Password/Minio credentials (no `.mise.toml` `op://` wiring, no `PULUMI_BACKEND_URL`/`PULUMI_CONFIG_PASSPHRASE`, no `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`). The `pulumi-cli-preview` MCP tool confirmed this concretely: without those, it fell back to a nonexistent local file-backend path instead of the stack's real Minio-backed state, rather than actually previewing anything.

**A human (or an agent with `op run`/`pulumi-env.sh` credentials) needs to run:**

```bash
cd stacks/home
pulumi preview   # run 1
pulumi preview   # run 2, nothing else changing state in between
```

and diff the two `home-operations-minio-bucket` operation lists before this piece is considered fully closed — see §2 of the plan doc for exactly what "clean" vs. "danger sign" looks like. That verification should also be a good moment to sanity-check the new `S3BucketVersioning` resource plans as a clean `create` (not a replace of the existing bucket).

## Verification performed

- `npx tsc --noEmit -p tsconfig.json`: no new errors introduced. 8 pre-existing errors elsewhere in the tree (`components/helpers.ts`, `components/store/clusters.test.ts`, `components/store/index.ts`, `components/truenas/truenas-types.ts`) are unrelated to this change and reproduce identically on `main` before this diff.
- `npx biome check stacks/home/index.ts`: 2 pre-existing findings (import ordering, one long-line format) reproduce identically on `main` before this diff; no new findings from the added block.
- Confirmed the `minio.S3BucketVersioning` resource shape via the Pulumi Registry MCP tool against the pinned `@pulumi/minio@0.17.0` (matches `package-lock.json`).
- Did **not** run `pulumi preview`/`pulumi up` — no credentials in this environment, per above.

## Ref

- Plan doc: `docs/cluster-consolidation/05-import-audit.md`
- Tracking issue: david-driscoll/vault#84

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>