### PR TITLE
fix(cert-manager): resolve Kustomization name collision with namespace redirect

### DIFF
--- a/kubernetes/apps/cert-manager/cert-issuers/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-issuers/ks.yaml
@@ -12,7 +12,7 @@ spec:
       app.kubernetes.io/name: *app
       driscoll.dev/name: *app
   dependsOn:
-    - name: cert-manager
+    - name: cert-manager-controller
       namespace: cert-manager
   path: ./kubernetes/apps/cert-manager/cert-issuers
   prune: true

--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app cert-manager
+  name: &app cert-manager-controller
   namespace: &namespace cert-manager
 spec:
   commonMetadata:

--- a/kubernetes/apps/cert-manager/trust-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/trust-manager/ks.yaml
@@ -12,7 +12,7 @@ spec:
       app.kubernetes.io/name: *app
       driscoll.dev/name: *app
   dependsOn:
-    - name: cert-manager
+    - name: cert-manager-controller
       namespace: cert-manager
   path: ./kubernetes/apps/cert-manager/trust-manager
   prune: true


### PR DESCRIPTION
## What broke

`kubernetes/apps/cert-manager/cert-manager/ks.yaml` (the actual cert-manager Helm chart install) named its Kustomization `cert-manager` — identical to the namespace-umbrella redirect Kustomization that `equestria-cluster`/`stargate-command-cluster` create when redirecting the `cert-manager` namespace to `home-operations` as part of the [repo consolidation](docs/cluster-consolidation/21-repo-consolidation-flux-repoint.md).

Since both objects share the same `name`/`namespace`, the redirect Kustomization's own build output (path `./kubernetes/apps/cert-manager`, which includes the inner `ks.yaml` as a resource) overwrites its **own** spec on server-side apply. The next reconcile of the now-mutated object no longer includes `cert-issuers`/`trust-manager`/`trust-bundles` in its resource set, so `prune: true` deletes its own Kustomization object plus those three, along with their Middleware/Provider/Alert/ExternalSecret resources.

Confirmed live via `kustomize-controller` logs on `admin@equestria` (2026-08-13T16:16:54–55Z) — this self-prune is why `cert-manager` currently has **zero controller pods and zero Kustomization objects on both equestria and stargate-command-cluster**, which cascades into `network/certificates` and `network/traefik-whoami` reporting `Ready:False` (`dependency 'cert-manager/cert-issuers' not found`).

## Fix

Rename the inner Kustomization to `cert-manager-controller`. The actual `HelmRelease`/`OCIRepository` objects stay named `cert-manager` (hardcoded separately), so this doesn't touch the running workload. Updated the two `dependsOn` references (`cert-issuers`, `trust-manager`) to match.

Every other already-migrated namespace avoids this collision because its inner app name differs from the namespace name (`longhorn-system` → `longhorn`, `openebs-system` → `openebs`, `nfs-system` → `csi-driver-nfs`); `cert-manager` was the one case where they were identical.

## Validation

- `kustomize build kubernetes/apps/cert-manager` — clean, four distinct Kustomization names
- `flate test ks` — all 4 cert-manager Kustomizations pass

## Expected effect once merged

Both clusters' Flux `cluster-apps` will re-create the (now non-colliding) `cert-manager` Kustomization tree, restoring the cert-manager controller, ClusterIssuers, trust-manager, and trust-bundles — which should clear `network/certificates` and `network/traefik-whoami` back to `Ready:True` on both `equestria` and `stargate-command-cluster`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)