### PR TITLE
feat(longhorn): tolerate the future critical-tier taint ahead of time

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/values.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/values.yaml
@@ -50,7 +50,13 @@ defaultSettings:
   storageOverProvisioningPercentage: 600
   upgradeChecker: true
   priorityClass: system-node-critical
-  # taintToleration: key1=value1:NoSchedule; key2:NoExecute
+  # Lands months ahead of the taint it tolerates (docs/cluster-consolidation/20-low-power-tier.md
+  # applies node-role.driscoll.tech/critical=true:NoSchedule to the future control planes).
+  # Longhorn only applies a taintToleration change to a running instance-manager once its
+  # engine/replica instances are idle or volumes are detached -- otherwise it waits for the next
+  # ~1h sync. Setting it now, while nothing is tainted yet, means it's already synced by the time
+  # 20 actually applies the taint. See docs/cluster-consolidation/10-drain-safety.md work item 1.
+  taintToleration: node-role.driscoll.tech/critical=true:NoSchedule
   # systemManagedComponentsNodeSelector: "label-key1:label-value1"
   # disableSchedulingOnCordonedNode: false
   # replicaZoneSoftAntiAffinity: false


### PR DESCRIPTION
## What

Sets `defaultSettings.taintToleration` to `node-role.driscoll.tech/critical=true:NoSchedule` in Longhorn's values, months before that taint is actually applied to any node.

## Why now, before the taint exists

Per [Longhorn's docs](https://longhorn.io/docs/1.9.0/advanced-resources/deploy/taint-toleration/), a `taintToleration` change only reaches a running instance-manager immediately if workloads are stopped and volumes detached; with volumes attached it waits until no engine/replica instance is running on that node, or up to ~1 hour for the next sync otherwise. Landing this now — while nothing is tainted and there's no urgency — means the setting is already correct and synced by the time [20-low-power-tier.md](../blob/main/docs/cluster-consolidation/20-low-power-tier.md) actually applies `node-role.driscoll.tech/critical=true:NoSchedule` to the future control planes.

## Verified safe

Confirmed live 2026-08-13 on both clusters: no node carries this taint today (`kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.spec.taints}{"\n"}{end}'` prints empty for all 7 nodes). Tolerating a taint that doesn't exist changes no current scheduling behavior — this is additive and inert.

Part of [docs/cluster-consolidation/10-drain-safety.md](../blob/main/docs/cluster-consolidation/10-drain-safety.md), work item 1, for vault#84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)