### PR TITLE
feat(coder): add coder namespace tree (repo consolidation piece 21)

### DIFF
--- a/kubernetes/apps/coder/coder/definition.yaml
+++ b/kubernetes/apps/coder/coder/definition.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: Coder
+  category: Applications
+  description: Self-hosted Cloud Development Environments
+  url: &url https://code.${ROOT_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/coder.svg
+  # Coder OSS has no IdP role sync, so Authentik decides who may sign in at all
+  # and every login lands as a Coder member. Admins are promoted in-app.
+  access_policy:
+    groups:
+      - admins
+      - family
+  authentik:
+    oauth2:
+      clientType: confidential
+      allowedRedirectUris:
+        - url: "https://code.${ROOT_DOMAIN}/api/v2/users/oidc/callback"
+        - url: "https://code.${TAILSCALE_DOMAIN}/api/v2/users/oidc/callback"
+      propertyMappings:
+        - email
+        - openid
+        - profile
+      includeClaimsInIdToken: true
+      subMode: user_email
+
+  gatus:
+    - group: "Applications"
+      url: https://code.${ROOT_DOMAIN}/healthz
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/coder/coder/externalsecret.yaml
+++ b/kubernetes/apps/coder/coder/externalsecret.yaml
@@ -1,0 +1,92 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-pguser-secret
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-pguser-secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        uri: "{{ .postgres_uri }}"
+  dataFrom:
+    - extract:
+        key: '${APP}-postgres'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: database
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "postgres_$1"
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-oidc-secret
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  # ClusterSecretStore/cluster reads Secrets out of the `equestria` namespace
+  # (remoteNamespace: equestria). Coder lives in its own `coder` namespace, so
+  # its coder-oidc-credentials Secret was never visible to that store and this
+  # ExternalSecret has been SecretSyncedError since 2026-08-08T18:25Z —
+  # "could not get secret data from provider" — leaving OIDC login broken.
+  #
+  # OpenBao is the fix rather than a workaround: Phase 8a writes this exact
+  # credential to secrets/clusters/equestria/apps/coder/oidc, with field names
+  # identical to the in-cluster Secret, and it is namespace-independent by
+  # construction.
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-oidc-secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        issuer: "{{ .oidc_issuer }}"
+        client_id: "{{ .oidc_client_id }}"
+        client_secret: "{{ .oidc_client_secret }}"
+  dataFrom:
+    # Path within the `secrets` mount; the store pins `path: secrets`.
+    # was: '${APP}-oidc-credentials' out of ClusterSecretStore/cluster
+    - extract:
+        key: clusters/equestria/apps/${APP}/oidc
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: openbao
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "oidc_$1"

--- a/kubernetes/apps/coder/coder/helmrelease.yaml
+++ b/kubernetes/apps/coder/coder/helmrelease.yaml
@@ -1,0 +1,101 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: coder-v2
+spec:
+  interval: 1h
+  url: https://helm.coder.com/v2
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app coder
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: coder
+      version: 2.36.0
+      sourceRef:
+        kind: HelmRepository
+        name: coder-v2
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    coder:
+      annotations:
+        reloader.stakater.com/auto: "true"
+      # TLS is terminated by Traefik on the internal Gateway, so the pod serves
+      # plain HTTP. Do not set coder.tls.* or any CODER_TLS_* / CODER_HTTP_ADDRESS
+      # here — the chart owns those.
+      service:
+        type: ClusterIP
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          memory: 2Gi
+      # Equivalent of the failover/fast-node-eviction component, which only
+      # applies to app-template charts.
+      tolerations:
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      env:
+        - name: CODER_ACCESS_URL
+          value: https://code.${ROOT_DOMAIN}
+        - name: CODER_WILDCARD_ACCESS_URL
+          value: "*.code.${ROOT_DOMAIN}"
+        - name: CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE
+          value: "false"
+        - name: CODER_PG_CONNECTION_URL
+          valueFrom:
+            secretKeyRef:
+              name: coder-pguser-secret
+              key: uri
+        - name: CODER_OIDC_ISSUER_URL
+          valueFrom:
+            secretKeyRef:
+              name: coder-oidc-secret
+              key: issuer
+        - name: CODER_OIDC_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: coder-oidc-secret
+              key: client_id
+        - name: CODER_OIDC_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: coder-oidc-secret
+              key: client_secret
+        - name: CODER_OIDC_SCOPES
+          value: openid,profile,email,offline_access
+        - name: CODER_OIDC_SIGN_IN_TEXT
+          value: Sign in with Authentik
+        - name: CODER_OIDC_ICON_URL
+          value: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/authentik.svg
+        # Authentik is the only identity source; there are no local passwords.
+        - name: CODER_DISABLE_PASSWORD_AUTH
+          value: "true"
+        - name: CODER_PROXY_TRUSTED_HEADERS
+          value: X-Forwarded-For
+        - name: CODER_PROMETHEUS_ENABLE
+          value: "true"
+        - name: CODER_PROMETHEUS_COLLECT_AGENT_STATS
+          value: "true"

--- a/kubernetes/apps/coder/coder/httproute.yaml
+++ b/kubernetes/apps/coder/coder/httproute.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ${APP}
+  annotations:
+    reloader.stakater.com/auto: "true"
+    external-dns.alpha.kubernetes.io/target: "${INTERNAL_DOMAIN}"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+      kind: Gateway
+  hostnames:
+    - "code.${ROOT_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: ${APP}
+          port: 80
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: local-user
+---
+# Per-workspace app subdomains (dashboard port forwarding, coder_apps). These
+# proxy websockets and stream non-200 responses, so they skip the error-pages
+# middleware that local-user adds; local-api keeps the internal-network guard.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ${APP}-apps
+  annotations:
+    reloader.stakater.com/auto: "true"
+    external-dns.alpha.kubernetes.io/target: "${INTERNAL_DOMAIN}"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+      kind: Gateway
+  hostnames:
+    - "*.code.${ROOT_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: ${APP}
+          port: 80
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: local-api

--- a/kubernetes/apps/coder/coder/ks.yaml
+++ b/kubernetes/apps/coder/coder/ks.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app coder
+  namespace: &namespace coder
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/coder/coder
+  prune: true
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  dependsOn:
+    - name: postgres
+      namespace: database
+    - name: external-secrets
+      namespace: kube-system
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    # No failover/fast-node-eviction: it patches `defaultPodOptions`, which only
+    # the app-template chart reads. The equivalent tolerations are set natively
+    # under coder.tolerations in helmrelease.yaml.
+    - ../../../components/postgres
+    - ../../../components/tailscale
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      TAILSCALE_HOST: code

--- a/kubernetes/apps/coder/coder/kustomization.yaml
+++ b/kubernetes/apps/coder/coder/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./definition.yaml
+  - ./podmonitor.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/coder/coder/podmonitor.yaml
+++ b/kubernetes/apps/coder/coder/podmonitor.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/podmonitor_v1.json
+# A PodMonitor rather than a Service + ServiceMonitor: the postgres/tailscale
+# components apply commonLabels that kustomize also injects into Service
+# selectors, which would not match the Helm-created coder pods.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ${APP}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: coder
+      app.kubernetes.io/instance: coder
+  podMetricsEndpoints:
+    # CODER_PROMETHEUS_ADDRESS defaults to 0.0.0.0:2112; the chart does not
+    # declare it as a named container port.
+    - targetPort: 2112
+      interval: 1m
+      path: /metrics

--- a/kubernetes/apps/coder/coder/prometheusrule.yaml
+++ b/kubernetes/apps/coder/coder/prometheusrule.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ${APP}-rules
+spec:
+  groups:
+    - name: coder.rules
+      rules:
+        - alert: CoderAbsent
+          annotations:
+            description: Coder has disappeared from Prometheus target discovery.
+            summary: Coder is down.
+          expr: |
+            absent(up{job=~".*coder.*"} == 1)
+          for: 15m
+          labels:
+            severity: critical
+        - alert: CoderWorkspaceBuildFailures
+          annotations:
+            description: >-
+              {{ humanize $value }} workspace builds failed in the last hour.
+            summary: Coder workspace builds are failing.
+          expr: |
+            increase(coderd_workspace_builds_total{status="failed"}[1h]) > 2
+          for: 0m
+          labels:
+            severity: warning
+        - alert: CoderAgentsUnhealthy
+          annotations:
+            description: >-
+              {{ humanize $value }} workspace agents are stuck in a failed
+              startup state.
+            summary: Coder workspace agents cannot start.
+          expr: |
+            sum(coderd_agents_connections{lifecycle_state=~"start_timeout|start_error"}) > 0
+          for: 15m
+          labels:
+            severity: warning

--- a/kubernetes/apps/coder/kustomization.yaml
+++ b/kubernetes/apps/coder/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: coder
+components:
+  - ../../components/alerts
+  - ../../components/common
+resources:
+  - ./coder/ks.yaml


### PR DESCRIPTION
## What

Copies `kubernetes/apps/coder` verbatim from `equestria-cluster` into this repo, as part of the namespace-by-namespace repo consolidation ([vault#84](https://github.com/david-driscoll/vault/issues/84) piece 21, Phase A — [docs/cluster-consolidation/21-repo-consolidation-flux-repoint.md](https://github.com/david-driscoll/home-operations/blob/main/docs/cluster-consolidation/21-repo-consolidation-flux-repoint.md)).

Matches the pattern already proven 5x (`longhorn-system`, `nfs-system`, `openebs-system`, `cert-manager`, `pulumi`):
- nested `Kustomization`'s `sourceRef.name` changed from `flux-system` to `home-operations` (required — the content only exists in this repo now, so self-referencing `flux-system` would try to resolve against equestria-cluster and 404)
- everything else copied verbatim

## Why this is safe

This content is **inert** until the matching `equestria-cluster` PR (redirects the namespace's Flux `Kustomization` to source from here) merges. Until then nothing in the live cluster reads this path.

## Companion PR

david-driscoll/equestria-cluster#3149 — adds the `home-operations.coder.yaml` redirect stub and removes the native `coder/coder/` tree there. **Merge this PR first**, then the equestria-cluster one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)