### PR TITLE
feat(system-upgrade): add system-upgrade namespace tree (repo consolidation piece 21)

### DIFF
--- a/kubernetes/apps/system-upgrade/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: system-upgrade
+components:
+  - ../../components/alerts
+  - ../../components/common
+  - ../../components/repos/app-template
+resources:
+  - ./tuppr/ks.yaml
+  - ./upgrades/ks.yaml

--- a/kubernetes/apps/system-upgrade/tuppr/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/helmrelease.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: tuppr
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.4.7
+    digest: sha256:c3f7523fa3b1c58d9c01b1701c557676bdaf2409b2f06c27aa881f27bc2d43bf
+  url: oci://ghcr.io/home-operations/charts/tuppr
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tuppr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: tuppr
+  interval: 1h
+  values:
+    replicaCount: 1
+    monitoring:
+      serviceMonitor:
+        enabled: true
+      prometheusRule:
+        enabled: true
+    webhook:
+      enabled: true

--- a/kubernetes/apps/system-upgrade/tuppr/ks.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tuppr
+  namespace: &namespace system-upgrade
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/system-upgrade/tuppr
+  prune: true
+  wait: false
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system

--- a/kubernetes/apps/system-upgrade/tuppr/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/system-upgrade/upgrades/alerts.yaml
+++ b/kubernetes/apps/system-upgrade/upgrades/alerts.yaml
@@ -1,0 +1,46 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: system-upgrade
+    role: alert-rules
+  name: tuppr-alerts
+  namespace:
+spec:
+  groups:
+    - name: tuppr
+      rules:
+        - alert: TupprUpgradeFailed
+          expr: tuppr_talos_upgrade_phase{phase="Failed"} == 3 or tuppr_kubernetes_upgrade_phase{phase="Failed"} == 3
+          for: 0m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Tuppr upgrade failed"
+            description: "Upgrade {{ $labels.name }} has failed"
+
+        - alert: TupprUpgradeStuck
+          expr: |
+            (
+              tuppr_talos_upgrade_phase{phase="InProgress"} == 1 and
+              increase(tuppr_talos_upgrade_nodes_completed[30m]) == 0
+            ) or (
+              tuppr_kubernetes_upgrade_phase{phase="InProgress"} == 1
+            )
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Tuppr upgrade appears stuck"
+            description: "Upgrade {{ $labels.name }} has been in progress for 30+ minutes without completing nodes"
+
+        - alert: TupprHealthCheckFailures
+          expr: rate(tuppr_health_check_failures_total[5m]) > 0.1
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High health check failure rate"
+            description: "Health checks for {{ $labels.upgrade_name }} are failing frequently"

--- a/kubernetes/apps/system-upgrade/upgrades/ks.yaml
+++ b/kubernetes/apps/system-upgrade/upgrades/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tuppr-upgrades
+  namespace: &namespace system-upgrade
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: tuppr
+      namespace: system-upgrade
+  path: ./kubernetes/apps/system-upgrade/upgrades
+  prune: true
+  wait: false
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system

--- a/kubernetes/apps/system-upgrade/upgrades/kubernetes.yaml
+++ b/kubernetes/apps/system-upgrade/upgrades/kubernetes.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: KubernetesUpgrade
+metadata:
+  name: kubernetes
+spec:
+  kubernetes:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
+    version: v1.36.3
+  healthChecks:
+    - apiVersion: volsync.backube/v1alpha1
+      kind: ReplicationSource
+      expr: |-
+        status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+    - apiVersion: v1
+      kind: Node
+      expr: status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+
+  # maintenance:
+  #   windows:
+  #     - start: "0 11 * * *"    # Daily at 11
+  #       duration: "2h"         # How long window stays open
+  #       timezone: "${TIMEZONE}"

--- a/kubernetes/apps/system-upgrade/upgrades/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/upgrades/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./kubernetes.yaml
+  - ./talos.yaml

--- a/kubernetes/apps/system-upgrade/upgrades/talos.yaml
+++ b/kubernetes/apps/system-upgrade/upgrades/talos.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: TalosUpgrade
+metadata:
+  name: talos
+spec:
+  talos:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+    version: v1.13.8
+  policy:
+    rebootMode: default
+  healthChecks:
+    # A wedged VolSync mover (e.g. a failed snapshot clone) can hold Synchronizing:
+    # True indefinitely with no built-in timeout of its own. Bound this check so
+    # one stuck backup job can't silently freeze node upgrades for days (2026-07
+    # incident: fluttershy/othalla stayed cordoned a week because of this).
+    - apiVersion: volsync.backube/v1alpha1
+      kind: ReplicationSource
+      expr: status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+      timeout: 15m
+    - apiVersion: v1
+      kind: Node
+      expr: status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+      timeout: 15m
+    - apiVersion: longhorn.io/v1beta2
+      kind: Volume
+      namespace: longhorn-system
+      description: Wait for degraded Longhorn volumes to finish rebuilding before draining the next node, so its replica isn't the last healthy copy
+      expr: status.robustness != "degraded"
+      timeout: 15m
+
+  # maintenance:
+  #   windows:
+  #     - start: "0 11 * * *"    # Daily at 11
+  #       duration: "2h"         # How long window stays open
+  #       timezone: "${TIMEZONE}"


### PR DESCRIPTION
## What

Copies `kubernetes/apps/system-upgrade` verbatim from `equestria-cluster` (tuppr + tuppr-upgrades), as part of the namespace-by-namespace repo consolidation ([vault#84](https://github.com/david-driscoll/vault/issues/84) piece 21, Phase A).

Nested `Kustomization`s' `sourceRef.name` changed from `flux-system` to `home-operations`, matching the pattern already proven on `longhorn-system`, `nfs-system`, `openebs-system`, `cert-manager`, `pulumi`, `coder`.

## Why this is safe

Inert until the matching `equestria-cluster` PR merges.

## Companion PR

david-driscoll/equestria-cluster#3150 — **merge this PR first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)