### PR TITLE
feat(volsync-system): add volsync-system namespace tree (repo consolidation piece 21)

### DIFF
--- a/kubernetes/apps/volsync-system/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: volsync-system
+components:
+  - ../../components/alerts
+  - ../../components/common
+  - ../../components/repos/app-template
+resources:
+  - ./volsync/ks.yaml
+  - ./restore-cleanup/ks.yaml

--- a/kubernetes/apps/volsync-system/restore-cleanup/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/restore-cleanup/helmrelease.yaml
@@ -1,0 +1,103 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app restore-cleanup
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+  values:
+    serviceAccount:
+      *app : {}
+
+    rbac:
+      roles:
+        *app :
+          type: ClusterRole
+          rules:
+            - apiGroups: ["volsync.backube"]
+              resources: ["replicationdestinations"]
+              verbs: ["get", "list", "delete"]
+      bindings:
+        *app :
+          type: ClusterRoleBinding
+          roleRef:
+            identifier: *app
+          subjects:
+            - identifier: *app
+
+    controllers:
+      *app :
+        type: cronjob
+        pod:
+          automountServiceAccountToken: true
+        serviceAccount:
+          identifier: *app
+        cronjob:
+          schedule: "30 3 * * *"
+          concurrencyPolicy: Forbid
+          backoffLimit: 2
+          activeDeadlineSeconds: 300
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+        containers:
+          main:
+            image:
+              repository: bitnami/kubectl
+              tag: latest
+              digest: sha256:558420daf32bbc382e3e9af4537f4073085b336ddd47399a3b70e70087115978
+              pullPolicy: IfNotPresent
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -eu
+                # Delete ReplicationDestination objects whose one-time bootstrap
+                # restore has completed (spec.trigger.manual == status.lastManualSync
+                # == "restore-once", the value set by components/volsync-restore).
+                # This cascades via ownerReferences to delete the dst-dest/dst-cache
+                # PVCs it provisioned. The app's real PVC is unaffected - it only
+                # referenced the ReplicationDestination at create time.
+                # (out=$(...) form, not a trailing pipe, so a kubectl failure here
+                # actually fails the job under `set -e` instead of being masked by
+                # the exit status of the downstream `while read` loop.)
+                out=$(kubectl get replicationdestinations.volsync.backube -A \
+                  -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,TRIGGER:.spec.trigger.manual,SYNCED:.status.lastManualSync' \
+                  --no-headers)
+                echo "$out" | while read -r ns name trigger synced; do
+                    if [ "$trigger" = "restore-once" ] && [ "$trigger" = "$synced" ]; then
+                      echo "Deleting completed restore-once ReplicationDestination $ns/$name"
+                      kubectl delete replicationdestinations.volsync.backube "$name" -n "$ns"
+                    fi
+                  done
+                echo "Done."
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi

--- a/kubernetes/apps/volsync-system/restore-cleanup/ks.yaml
+++ b/kubernetes/apps/volsync-system/restore-cleanup/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app volsync-restore-cleanup
+  namespace: &namespace volsync-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+  path: ./kubernetes/apps/volsync-system/restore-cleanup
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/volsync-system/restore-cleanup/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/restore-cleanup/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/volsync-system/volsync/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/volsync/helmrelease.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: volsync
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.16.0
+  url: oci://ghcr.io/home-operations/charts-mirror/volsync
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "https://token.actions.githubusercontent.com"
+        subject: "https://github.com/home-operations/charts-mirror/.github/workflows/app-builder.yaml@refs/heads/main"
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: volsync
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: volsync
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    manageCRDs: true
+    replicaCount: 1
+    metrics:
+      disableAuth: true

--- a/kubernetes/apps/volsync-system/volsync/ks.yaml
+++ b/kubernetes/apps/volsync-system/volsync/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app volsync
+  namespace: &namespace volsync-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: csi-driver-nfs
+      namespace: nfs-system
+  path: ./kubernetes/apps/volsync-system/volsync
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/volsync-system/volsync/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/volsync/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./mutatingadmissionpolicy.yaml
+  - ./volume.yaml

--- a/kubernetes/apps/volsync-system/volsync/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/mutatingadmissionpolicy.yaml
@@ -1,0 +1,106 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/admissionregistration.k8s.io/mutatingadmissionpolicybinding_v1.json
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: volsync-mover-jitter
+spec:
+  policyName: volsync-mover-jitter
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/admissionregistration.k8s.io/mutatingadmissionpolicy_v1.json
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: volsync-mover-jitter
+  namespace: volsync-system
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["jobs"]
+  matchConditions:
+    - name: has-volsync-job-name-prefix
+      expression: >
+        object.metadata.name.startsWith("volsync-src-")
+    - name: has-volsync-created-by-labels
+      expression: >
+        object.metadata.labels["app.kubernetes.io/created-by"] == "volsync"
+  failurePolicy: Fail
+  reinvocationPolicy: IfNeeded
+  mutations:
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: >
+          [
+            JSONPatch{
+              op: "add", path: "/spec/template/spec/initContainers",
+              value: []
+            },
+            JSONPatch{
+              op: "add", path: "/spec/template/spec/initContainers/-",
+              value: Object.spec.template.spec.initContainers{
+                name: "jitter",
+                image: "docker.io/library/busybox:1.38.0@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616",
+                imagePullPolicy: "IfNotPresent",
+                command: ["sh", "-c", "sleep $(shuf -i 0-60 -n 1)"]
+              }
+            }
+          ]
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/admissionregistration.k8s.io/mutatingadmissionpolicybinding_v1.json
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: volsync-mover-nfs
+spec:
+  policyName: volsync-mover-nfs
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/admissionregistration.k8s.io/mutatingadmissionpolicy_v1.json
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: volsync-mover-nfs
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["jobs"]
+  matchConditions:
+    - name: has-volsync-job-name-prefix
+      expression: >
+        object.metadata.name.startsWith("volsync-")
+    - name: has-volsync-created-by-labels
+      expression: >
+        object.metadata.labels["app.kubernetes.io/created-by"] == "volsync"
+    - name: repository-volume-does-not-exist
+      expression: >
+        !object.spec.template.spec.volumes.exists(item, item.name == "repository")
+  failurePolicy: Fail
+  reinvocationPolicy: IfNeeded
+  mutations:
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: >
+          [
+            JSONPatch{
+              op: "add", path: "/spec/template/spec/containers/0/volumeMounts/-",
+              value: Object.spec.template.spec.containers.volumeMounts{
+                name: "repository",
+                mountPath: "/repository"
+              }
+            },
+            JSONPatch{
+              op: "add", path: "/spec/template/spec/volumes/-",
+              value: Object.spec.template.spec.volumes{
+                name: "repository",
+                nfs: Object.spec.template.spec.volumes.nfs{
+                  server: "10.10.10.10",
+                  path: "/mnt/stash/backup/${CLUSTER_CNAME}/volsync"
+                }
+              }
+            }
+          ]

--- a/kubernetes/apps/volsync-system/volsync/volume.yaml
+++ b/kubernetes/apps/volsync-system/volsync/volume.yaml
@@ -1,0 +1,44 @@
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master-standalone-strict/persistentvolume-v1.json
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: volsync
+  labels:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  mountOptions:
+    - nfsvers=4.2
+    - hard
+    - intr
+    - nconnect=8
+    - noatime
+  capacity:
+    storage: 100Gi
+  storageClassName: nfs-csi
+  csi:
+    driver: nfs.csi.k8s.io
+    volumeHandle: volsync-volume-id
+    volumeAttributes:
+      server: "${SPIKE_IP}"
+      share: /mnt/stash/backup/volsync
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: volsync
+  labels:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  storageClassName: nfs-csi
+  volumeName: volsync
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Gi


### PR DESCRIPTION
## What

Copies `kubernetes/apps/volsync-system` verbatim from `equestria-cluster` (volsync + restore-cleanup), as part of the namespace-by-namespace repo consolidation ([vault#84](https://github.com/david-driscoll/vault/issues/84) piece 21, Phase A).

Nested `Kustomization`s' `sourceRef.name` changed from `flux-system` to `home-operations`, matching the proven pattern.

Object names/namespace are unchanged, so `dependsOn: volsync-system/volsync` references from other apps' Kustomizations are unaffected by where this content is fetched from.

## Companion PR

david-driscoll/equestria-cluster#3151 — **merge this PR first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)