### PR TITLE
feat(cloudnative-pg): add cloudnative-pg namespace tree (repo consolidation piece 21)

### DIFF
--- a/kubernetes/apps/cloudnative-pg/barman/helmrelease.yaml
+++ b/kubernetes/apps/cloudnative-pg/barman/helmrelease.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app plugin-barman-cloud
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: plugin-barman-cloud
+      version: 0.7.1
+      sourceRef:
+        kind: HelmRepository
+        name: cloudnative-pg
+  maxHistory: 3
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  valuesFrom:
+    - kind: ConfigMap
+      name: ${APP}-values
+      valuesKey: values.yaml

--- a/kubernetes/apps/cloudnative-pg/barman/ks.yaml
+++ b/kubernetes/apps/cloudnative-pg/barman/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app plugin-barman-cloud
+  namespace: &namespace cloudnative-pg
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: postgres-operator
+      namespace: *namespace
+  path: ./kubernetes/apps/cloudnative-pg/barman
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/cloudnative-pg/barman/kustomization.yaml
+++ b/kubernetes/apps/cloudnative-pg/barman/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+configMapGenerator:
+- name: ${APP}-values
+  files:
+  - values.yaml=./resources/values.yaml
+  options:
+    disableNameSuffixHash: true

--- a/kubernetes/apps/cloudnative-pg/barman/resources/values.yaml
+++ b/kubernetes/apps/cloudnative-pg/barman/resources/values.yaml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/cloudnative-pg/charts/refs/heads/main/charts/plugin-barman-cloud/values.schema.json
+priorityClassName: "system-cluster-critical"

--- a/kubernetes/apps/cloudnative-pg/kustomization.yaml
+++ b/kubernetes/apps/cloudnative-pg/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cloudnative-pg
+components:
+  - ../../components/alerts
+  - ../../components/common
+resources:
+  - ./operator/ks.yaml
+  - ./barman/ks.yaml

--- a/kubernetes/apps/cloudnative-pg/operator/cloudnative-pg.yaml
+++ b/kubernetes/apps/cloudnative-pg/operator/cloudnative-pg.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: postgres-operator
+spec:
+  chart:
+    spec:
+      chart: cloudnative-pg
+      version: 0.29.0
+      sourceRef:
+        kind: HelmRepository
+        name: cloudnative-pg
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    crds:
+      create: true
+    monitoring:
+      podMonitorEnabled: true
+    grafanaDashboard:
+      create: true

--- a/kubernetes/apps/cloudnative-pg/operator/ks.yaml
+++ b/kubernetes/apps/cloudnative-pg/operator/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app postgres-operator
+  namespace: &namespace cloudnative-pg
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/cloudnative-pg/operator
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/cloudnative-pg/operator/kustomization.yaml
+++ b/kubernetes/apps/cloudnative-pg/operator/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cloudnative-pg.yaml
+  - ./repository.yaml

--- a/kubernetes/apps/cloudnative-pg/operator/repository.yaml
+++ b/kubernetes/apps/cloudnative-pg/operator/repository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: cloudnative-pg
+spec:
+  interval: 1h
+  url: https://cloudnative-pg.github.io/charts


### PR DESCRIPTION
## What

Copies `kubernetes/apps/cloudnative-pg` verbatim from `equestria-cluster` (operator + barman plugin), as part of the namespace-by-namespace repo consolidation ([vault#84](https://github.com/david-driscoll/vault/issues/84) piece 21, Phase A).

Nested `Kustomization`s' `sourceRef.name` changed from `flux-system` to `home-operations`, matching the proven pattern.

## Companion PR

david-driscoll/equestria-cluster#3152 — **merge this PR first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)