### PR TITLE
feat(database): add database namespace tree (repo consolidation piece 21)

### DIFF
--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: database
+components:
+  - ../../components/alerts
+  - ../../components/common
+  - ../../components/repos/app-template
+resources:
+  - ./postgres
+  - ./valkey/ks.yaml
+  # - ./neo4j/ks.yaml

--- a/kubernetes/apps/database/neo4j/definition.yaml
+++ b/kubernetes/apps/database/neo4j/definition.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: Neo4J
+  category: ${CLUSTER_TITLE}
+  description: Neo4J - graph database
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/neo4j.svg
+  url: &url "https://${APP}.${CLUSTER_DOMAIN}"
+  access_policy:
+    groups:
+      - admins
+  authentik:
+    proxy:
+      mode: "forward_single"
+      externalHost: *url
+  gatus:
+    - url: *url
+      conditions:
+        - "[STATUS] == 200"
+    - url: "tcp://${APP}.${CLUSTER_DOMAIN}:7687"
+      interval: 30s
+      conditions:
+        - "[CONNECTED] == true"

--- a/kubernetes/apps/database/neo4j/externalsecret.yaml
+++ b/kubernetes/apps/database/neo4j/externalsecret.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-config
+  namespace: equestria
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-config
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        NEO4J_AUTH: "neo4j/{{ .neo4j_password }}"
+  dataFrom:
+    - extract:
+        key: 'Neo4J Password'
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "neo4j_$1"

--- a/kubernetes/apps/database/neo4j/helmrelease.yaml
+++ b/kubernetes/apps/database/neo4j/helmrelease.yaml
@@ -1,0 +1,135 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app neo4j
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 1h
+  driftDetection:
+    mode: enabled
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  dependsOn: []
+  values:
+    controllers:
+      *app :
+        enabled: true
+        pod:
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 30
+        containers:
+          *app :
+            image:
+              repository: neo4j
+              tag: "2026.07.1-trixie@sha256:dca31d0d938dd8bb199c8846abedd897c3a07ddb629eca46a8009ac9e87aece2"
+              pullPolicy: IfNotPresent
+            env:
+              TZ: "${TIMEZONE}"
+              NEO4J_PLUGINS: '["apoc", "apoc-extended", "genai"]'
+              NEO4J_server__http__x_forward__private_ips_enabled: "true"
+              NEO4J_AUTH:
+                secretKeyRef:
+                  name: "${APP}-config"
+                  key: NEO4J_AUTH
+            ports:
+              - containerPort: &http-port 7474
+              - containerPort: &bolt-port 7687
+            securityContext:
+              runAsNonRoot: true
+              runAsGroup: 568
+              runAsUser: 568
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+                memory: 1Gi
+              limits:
+                memory: 4Gi
+
+    service:
+      *app :
+        controller: *app
+        type: ClusterIP
+        ports:
+          http:
+            port: *http-port
+          bolt:
+            port: *bolt-port
+
+    persistence:
+      data:
+        existingClaim: *app
+        globalMounts:
+          - path: /logs
+            subPath: logs
+          - path: /config
+            subPath: config
+          - path: /data
+            subPath: data
+          - path: /plugins
+            subPath: plugins
+
+    route:
+      internal:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "${APP}.${CLUSTER_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - backendRefs:
+              - identifier: *app
+                port: *http-port
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: local-api
+      bolt:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "${APP}.${CLUSTER_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - backendRefs:
+              - identifier: *app
+                port: *bolt-port
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: local-api
+    # serviceMonitor:
+    #   *app :
+    #     endpoints:
+    #       - port: 2004

--- a/kubernetes/apps/database/neo4j/ks.yaml
+++ b/kubernetes/apps/database/neo4j/ks.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app neo4j
+  namespace: &namespace database
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn: []
+  path: ./kubernetes/apps/database/neo4j
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../components/failover/fast-node-eviction
+    - ../../../components/tailscale
+    - ../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_ACCESSMODES: ReadWriteOnce

--- a/kubernetes/apps/database/neo4j/kustomization.yaml
+++ b/kubernetes/apps/database/neo4j/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./definition.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/database/postgres/app/definition.yaml
+++ b/kubernetes/apps/database/postgres/app/definition.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: Postgres
+  category: ${CLUSTER_TITLE}
+  description: Postgres monitoring
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/postgres.svg
+  gatus:
+    - url: "tcp://postgres.${CLUSTER_DOMAIN}:5432"
+      interval: 30s
+      conditions:
+        - "[CONNECTED] == true"

--- a/kubernetes/apps/database/postgres/app/externalsecret.yaml
+++ b/kubernetes/apps/database/postgres/app/externalsecret.yaml
@@ -1,0 +1,96 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-values
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-values
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      templateFrom:
+      - target: Data
+        configMap:
+          name: ${APP}-values
+          items:
+          - key: values.yaml
+            templateAs: Values
+  dataFrom:
+    # Split source on purpose: the Minio credential has migrated to OpenBao but
+    # the ${BACKBLAZE_DATABASE} extract above has NOT (B2 is excluded from the
+    # migration, estate decision 2026-08-07). So secretStoreRef stays on
+    # onepassword-connect and only this reference is redirected — flipping the
+    # store would silently take the Backblaze extract with it.
+    - extract:
+        # was: 'Spike Minio Access Token'
+        key: shared/spike-minio-access-token
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "minio_$1"
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-backup-config
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-backup-values
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        rclone.conf: |
+          [local]
+          type = s3
+          provider = Rclone
+          endpoint = {{ .minio_endpoint }}
+          access_key_id = {{ .minio_username }}
+          secret_access_key = {{ .minio_password }}
+          use_multipart_uploads = false
+  dataFrom:
+    # Split source on purpose: the Minio credential has migrated to OpenBao but
+    # the ${BACKBLAZE_DATABASE} extract above has NOT (B2 is excluded from the
+    # migration, estate decision 2026-08-07). So secretStoreRef stays on
+    # onepassword-connect and only this reference is redirected — flipping the
+    # store would silently take the Backblaze extract with it.
+    - extract:
+        # was: 'Spike Minio Access Token'
+        key: shared/spike-minio-access-token
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "minio_$1"

--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app postgres
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: cluster
+      # 0.8.x is the first cluster chart that can emit a barmancloud.cnpg.io
+      # ObjectStore and wire the plugin into .spec.plugins. 0.7.0 only knows
+      # the deprecated in-core .spec.backup.barmanObjectStore.
+      version: 0.8.1
+      sourceRef:
+        kind: HelmRepository
+        name: cloudnative-pg
+        namespace: cloudnative-pg
+  maxHistory: 3
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  valuesFrom:
+    - kind: Secret
+      name: ${APP}-values
+      valuesKey: values.yaml

--- a/kubernetes/apps/database/postgres/app/ingress.yaml
+++ b/kubernetes/apps/database/postgres/app/ingress.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: ${APP}-internal
+  annotations:
+    reloader.stakater.com/auto: "true"
+    external-dns.alpha.kubernetes.io/target: "${INTERNAL_DOMAIN}"
+    external-dns.alpha.kubernetes.io/hostname: postgres.${CLUSTER_DOMAIN}
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: postgres
+  rules:
+    - backendRefs:
+        - name: postgres-rw
+          port: 5432

--- a/kubernetes/apps/database/postgres/app/ks.yaml
+++ b/kubernetes/apps/database/postgres/app/ks.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app postgres
+  namespace: &namespace database
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/database/postgres/app
+  dependsOn:
+    - name: postgres-operator
+      namespace: cloudnative-pg
+    - name: external-secrets
+      namespace: kube-system
+  prune: true
+  wait: true
+  force: false
+  suspend: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      POSTGRES_STORAGE: "40Gi"

--- a/kubernetes/apps/database/postgres/app/kustomization.yaml
+++ b/kubernetes/apps/database/postgres/app/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./user-template.yaml
+  - ./ingress.yaml
+  - ./definition.yaml
+  - ./passwords.sops.yaml
+  - ./users.yaml
+  - ./role-broad-access.yaml
+configMapGenerator:
+- name: ${APP}-values
+  files:
+  - values.yaml=./resources/values.yaml
+  options:
+    disableNameSuffixHash: true

--- a/kubernetes/apps/database/postgres/app/passwords.sops.yaml
+++ b/kubernetes/apps/database/postgres/app/passwords.sops.yaml
@@ -1,0 +1,701 @@
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: crowdsec-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:/zWUxnbSR9Y=,iv:+aAja2/JACNjpZFjzDy1s9ZF0nQIG1l4jBIjEbXG+q0=,tag:B8QL3YzMTF2jWwaWrHMaDQ==,type:str]
+  database: ENC[AES256_GCM,data:LOUW9aOj0zc=,iv:SLED4WiAS0v30mEej5xOuEoy64P0mX1I8PPwbX1IRW8=,tag:Tin2U/p7V/6Xv+N7hfDsaw==,type:str]
+  port: ENC[AES256_GCM,data:Pf9bxA==,iv:NrsGvLG9rJk3Z/pD3AF5V3neXf8gC1qfNEAI8eq4D+g=,tag:1BQe+6LecJaAoY+yf0PvvQ==,type:str]
+  hostname: ENC[AES256_GCM,data:IuL6Zcv548t0F9ImaHaz9QjgcoXepEiDE127ERCs2kJ/nAfHItE=,iv:CqcjiQ0/krlhaxOsA3GMO5rVLVLSIPguiSHfqDvce8w=,tag:CRATe1abKbaLCSPBso8zVQ==,type:str]
+  password: ENC[AES256_GCM,data:6v0pWAcEv2XcU8ot9j9Fc+46rMq68ZsvZ1FbqaA0djM=,iv:OZFdcve7kK5wEIMG1SnWPw7rRc15aK4wSOwy5jb05gI=,tag:1T4BsQvajCp+rhCbf1B4RA==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:9djgMZr6cg==,iv:g0/JHFV7C8L02TGM2juXy+OmG6Sszpp53yCqLJQruJE=,tag:aUxh2Ccm4og0I50XEDaOAg==,type:str]
+  database: ENC[AES256_GCM,data:BoK/IMjPwg==,iv:a/BYsdTxj+/ic1YfoDN2RJxqHOkCEegeXn3EHrEjJ3E=,tag:VokwCBDFqQZ2/PENcmI0zw==,type:str]
+  port: ENC[AES256_GCM,data:386n3w==,iv:wsvDahPgJXRtvfv6o0HegvN34Bh5r3DjEGx0fXCK5U4=,tag:ya2y+MMcDwwzxLFqk/FHpQ==,type:str]
+  hostname: ENC[AES256_GCM,data:HAUHMle10kPMlPVASQHmQRDFN5AjVherVNcF5V0Gnz/vmBIPbOc=,iv:nnZffSmBVGYcXcsJX+QHGPQqmGGpi+OvaAtMVT+A5Q4=,tag:uNzcxAbgDqCuH3eQPQK4OQ==,type:str]
+  password: ENC[AES256_GCM,data:yczL8DYzmHir+C4NHuUHr13nKkCmchLbVm2xuLZdRMU=,iv:HEdg1nZTcXL+8TSwDQE83arocs0TXat4A4Q/TT3i1sE=,tag:/gs1UVCt65trGvEVURPJ7w==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openbao-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:7+k/lGCj/Q==,iv:5oLFAwc118o704drcEhgOZ+AN2ENdsdtDaRSGN2Idv4=,tag:UXUzKNOaI46l6gn+lG/kKA==,type:str]
+  database: ENC[AES256_GCM,data:R85uRlp91w==,iv:mh/9Lkmo47kq8V4lvTg40/nDfTkP3IOaoKvWjzrQJhI=,tag:L3BRWMN6WjuNwFTi7drojA==,type:str]
+  port: ENC[AES256_GCM,data:r8QV2Q==,iv:CLIHmAaatdACA0UjciDz+i5HjymDElNPPw2eid+8vQI=,tag:Pv0Z3e2BAkmXJEWRHu9Lpw==,type:str]
+  hostname: ENC[AES256_GCM,data:Hpps+/luAbJxsEyNmZmWXEj/uXWB2z5Xk1plIW+bt8t3oYbJkBw=,iv:J26MIYmLVy8vSU85UW2TifEIvp1A7sD3O2vknTYaYBk=,tag:i1YazQwagadL42V6czGApQ==,type:str]
+  password: ENC[AES256_GCM,data:ckiHma2gav1HJScpB6jWwXSm2Iwq6LF4UhddICgrkao=,iv:dos7Emd96cu/U2Lc1U3qGk2+zmN30PsCvnkIWSIG0AE=,tag:dYWcqfF0BuniA8OLdLNcow==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: coder-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:ju9ZsUI=,iv:Az2EZCIQqJ/nqVXpTjU8p6FFr7prbh+NJhxrlKLkRtg=,tag:1nzgi4nmoOqWHZP1gcIyMw==,type:str]
+  database: ENC[AES256_GCM,data:wbjxqn8=,iv:Xccp+t0auxPe+Mlums2Cnv2V0W5VY0XNzbfcRPCCP94=,tag:Y4J6wtdKSO24ZctTYyNJFw==,type:str]
+  port: ENC[AES256_GCM,data:zbkuCw==,iv:Ga9WYSQh99naaNRZcqFNVY/rdAaiSyqdsDzCRNcF3G0=,tag:/xFjZ5CYdXFMnOJdycAJow==,type:str]
+  hostname: ENC[AES256_GCM,data:jsp6DUFvdxBhXtGMScvaHywYZYHZJJ97XFnOH6WPpnMRwpXhKT0=,iv:WBTzh8UWinV4QN8t0qCRUAidQgReah28unj4F1hIzx0=,tag:80qr5CPlWFATcb/nU+ueHg==,type:str]
+  password: ENC[AES256_GCM,data:4jILkBRgQdtWZ3HO+5j3w59LLw14HeKnFB1NxvLYS2Q=,iv:eOvsAd+q576NakDr6eclGVefvBoLXh7CtduuMGUXDUU=,tag:71FXagQ2nBwMEUDYZrurPA==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tandoor-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:3TJBPLUf8g==,iv:COfYUhF8ZTc7WhgaiwvusF9nYxsYuiKlKXR5zr/1JOQ=,tag:RpxlZ4mngtEq8q0Bn6TI6g==,type:str]
+  database: ENC[AES256_GCM,data:1E6KMHwHNA==,iv:19rgVFP5wlowmOxCDFvXI9suiZmCwZkj9rZyzcBx+2w=,tag:CXL/9CKDwOqajbtZePe1dA==,type:str]
+  port: ENC[AES256_GCM,data:5uSbAg==,iv:+65KSG9kJYQXrSc85qryZr+8N5YEWCRLVact83N4ufE=,tag:YR31hBd4heMk3fED1/KXIg==,type:str]
+  hostname: ENC[AES256_GCM,data:96CBMDIEo9YaBMNR8E+xWkt6mwFIHroU7tXuzYcr2ZZqVPpbsxw=,iv:j5kP3oEF0hhAXNk4IEBjakAL/MPp+pL9DK1FTHodmQM=,tag:T9czeN7XYuVLS9K7Qr9O5A==,type:str]
+  password: ENC[AES256_GCM,data:Anhqr26rDM/g4//riJqL33Dyc6f3hg9ZPgwx5WHlmBg=,iv:QA+7+r+GslARoC4EZ5lpBsnJaohhZMQbaSN+iMGqBtI=,tag:5JcEhRGwT59GDJmFQ3/HWQ==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: immich-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:DoEUGD1e,iv:iygKIROtQanFa0x0WE1a6lKJEtzZgJL+sWvwVM2liEg=,tag:4DkbjBRaAK6GAsGIhNKT9w==,type:str]
+  database: ENC[AES256_GCM,data:FpMdH/6d,iv:EBvjvgDCYisI4VajERnHlT2nJiIL9qavBebV7IOv9GM=,tag:QNiNw2mUXX9av8uMKSiE2g==,type:str]
+  port: ENC[AES256_GCM,data:eTUP9Q==,iv:Sb4q5nkIlWWoa1sFJi71Mu+WLBwdcGcC/6pWb9tYHtg=,tag:9GPmat3raKuoBDyvgP/hLQ==,type:str]
+  hostname: ENC[AES256_GCM,data:zBncKJYPvHZLe++z9UaI3yumX2exKQwI2UWolpjghyWWkb2r864=,iv:v+4xjanQ3qDqU4EquVT0HE/2zfE3KmAdp2SBUlTBhWY=,tag:CFkmifiOQZDoS9XQfKd/lQ==,type:str]
+  password: ENC[AES256_GCM,data:puCGzG0gR21BPB8EezwoKTJKTkqdoRT+Wjk5SybJ2ps=,iv:AWy8Gwr7cHY5A226KlmtXZM5vSWE5kJ1fTvUGNFaHGg=,tag:zliWx471Be43e2gzIXG7mg==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: windmill-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:weMLlYcO+aI=,iv:ck/Xv2IzIoMotyRX+GztfwO4450qrvUSCN/h5y4ak5g=,tag:cjJnTmIJ6k4K+swBreXuyw==,type:str]
+  database: ENC[AES256_GCM,data:6A85Hc0V5kk=,iv:LhMlZE9EC4U3B4LRO82kKTZc9pt1tbyOAh08BCAONPo=,tag:cB4HIDhR+zOzvWntVQMElQ==,type:str]
+  port: ENC[AES256_GCM,data:4NxMpw==,iv:5IVrCvFyfjOZk/wyA0qu4HpzrmN4wt/kjajtla/Saf8=,tag:aQpx8pt6NPiXkhmIj17GGw==,type:str]
+  hostname: ENC[AES256_GCM,data:auZDWNinGV5BCDHG+17B6E8Tv+Fswq1BLnm2ODyEoi8cWln42Vo=,iv:R7N6GJXOzw6QBRhZmFOgSp0Eyw0mJJCMAgBmnWh7Q4M=,tag:2sHHTyS1GR6oUvh2nDGNow==,type:str]
+  password: ENC[AES256_GCM,data:gNLXhB/X1TU3Ue5/3Q/f8oJpfzT0KcVj2XSrLWJaYgE=,iv:Ynk/0/jLJEwhne8+I+//yvg1VE/G5j/PhNkzXtAu/Rs=,tag:3JSRGTGgOyU+CCw4d8H4rw==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: freshrss-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:UhLo8Cwyi94=,iv:AMwVEPCa0c3W3L/Lqnvs/yXiQKktjwZBN65yytuS320=,tag:rVPpqucJS18sonp6jA1tSg==,type:str]
+  database: ENC[AES256_GCM,data:MTexO9aCEMI=,iv:eoLbodwsVQmIov4DTdzdGeJcnCJRjWCJo3jOadeg+kE=,tag:BJqR8810ejCTqdVdERVN1Q==,type:str]
+  port: ENC[AES256_GCM,data:vK4x3Q==,iv:8pSeQEde+BvJ/MoyRTRVw4ikxeupwpYUmr/qdWVDo3w=,tag:2LKmbUnlBIgtqfVMfZ8/gQ==,type:str]
+  hostname: ENC[AES256_GCM,data:/PeG02ys9fqoI6b+AvbMLvNnojxCLHlnEXsOolqythTt8JRDJu0=,iv:/te/60WNco6ZXyVnxFFHBjhaKKz0BxtsvueOmUIXI9U=,tag:ubKaL2z04smgx0qKkpEUSg==,type:str]
+  password: ENC[AES256_GCM,data:xyqCasZOdaVA2CijKC81kdnHOQI4sVKXJp1pFlOM02k=,iv:ILgydb0TxTE4ljqh7qcGpsQbTL0DU3Lrn7yoABSt56E=,tag:9mVVLHiBaXXtM6o3LAvQUw==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: n8n-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:kr+w,iv:D4craNKKQpOuEwQqYqZZXY52cF5ishjs/MpOB2F5mMM=,tag:O/E7b2dCSAiS3P1wf84Z6Q==,type:str]
+  database: ENC[AES256_GCM,data:MIaT,iv:bCE1/ojpmO8aZ6icTIT0wMj4JkoC0pVPFLwP3dS0k90=,tag:FZJoEwRRgxRZ7E8vJhy3rQ==,type:str]
+  port: ENC[AES256_GCM,data:1RPFvA==,iv:cSZkDBsxr3UEe1efuB9nTA+7O+oZxqXciHEemINncO8=,tag:5lwKhuszAe9m/gt+usV9og==,type:str]
+  hostname: ENC[AES256_GCM,data:FKfqkSiSvcdonrb/HWo8qKiECpLaFiVsEhWQa5Ml6UL6nKwiZvE=,iv:hG4zPwsT/bkrIIKPqMMWKJrqvYzT4ZZWfEgZxWonfDQ=,tag:0hwks8VFhE+ShRHB62mzYw==,type:str]
+  password: ENC[AES256_GCM,data:r/RnNdUYNRMo21NtlH3XCRN8dJsy7EzsFTXnIjvP8Lc=,iv:lacvsb1mKmfkQ6+vtF1khDx5TGl7soco6H1JDVj7/Vo=,tag:ofxDQumVEPSPkhh0dFzPcw==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: outline-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:ExrvnV15SA==,iv:Ep7uItfFL0anD7EMmBjAMUBhtfe0b0DU1B+M0PogHio=,tag:FCF1x1x/XY20l0uDqU4zXg==,type:str]
+  database: ENC[AES256_GCM,data:PnRRYchITg==,iv:IT6u1FNFn3jW+NXZqnNy7v0PXzkrxGB8REc4YhhTyVc=,tag:t8Uy8ieIivG6KFozBQ+KiA==,type:str]
+  port: ENC[AES256_GCM,data:zcZUQg==,iv:PCVc/xUPoNP38eP5Ush3wapgRbmFgyVSqMM9QRcVcLA=,tag:C+jNrXhaABiRioXcojXikw==,type:str]
+  hostname: ENC[AES256_GCM,data:xKmSjs1Q7awfC/95+JCoBsNYcyaCot8tjvGus3YHrj7J5xCI9Wg=,iv:9aanxf8W/0RPgYEXNbhE9zVDOXYcY/o1auSj3ihX34Y=,tag:KRsDXoukgNNgwYF9Ylg/NQ==,type:str]
+  password: ENC[AES256_GCM,data:7P+s/SxuaPQZSF9mnqB+UVsTxxNKMP/EqQXQPrmDKoU=,iv:wef3u2tZaAT1mgYsgzdVzgKaSXptiSseggE8mw6fSNo=,tag:4BNz9+DTt9w2grH5zJJHNQ==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: strmgen-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:Rm1l/lKt8g==,iv:9pF8KXEcI+sJCj3uYL1SZOJCRx+uBOYqwRVVO0lXTa4=,tag:Ts4T0LZgcR87i3kcB3TeNg==,type:str]
+  database: ENC[AES256_GCM,data:Mff/ID815A==,iv:coZhhRbbnKj8E6SMaPll6rxARLFbAEADYv52pzSatSE=,tag:Xf5R9/kCmnXq0fjBNW3N4Q==,type:str]
+  port: ENC[AES256_GCM,data:76lZtQ==,iv:IiaD+A7w9Y8BdQbda9B76UD1ZXFnqMYwifc37EZ2KTI=,tag:GogUP8X8fgTkpApIdghQng==,type:str]
+  hostname: ENC[AES256_GCM,data:ldf4OjgHG0Pxl5jzgURLUPZdMoNPhIuZoV90dsiDXo+cZ7W8aoA=,iv:YPrNjeFTtok9sp5VsxxcyHc/QkgIv2TAlIhXvi9m4wY=,tag:Q+esLUdNWloDIb4oLuCz6w==,type:str]
+  password: ENC[AES256_GCM,data:YDxCahNpN4xo/nZV5A3SCz4Z9QZWxkzWNOF+YRc5zR4=,iv:IKqdnmsCdVHtTRojZSMimfUpeMbFqYoyiOo2KXf20yA=,tag:3e9N7rtsRrq25NcqMFYOyA==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: retrom-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:PWMJIOiO,iv:VjwfrtmErKWZyIanK5E8gZ1AMzDcaaVO1V5e7Z6yqds=,tag:yDGQE/ROL5hD5ZDgZnAS+g==,type:str]
+  database: ENC[AES256_GCM,data:iJONRP15,iv:ae0hw4C0OqmfYMbboCtwBCMVw8Ur6vsicaHXrzPVKlk=,tag:N5ul99OBfOoHz0TTj8/wUw==,type:str]
+  port: ENC[AES256_GCM,data:mglW9g==,iv:D908bnweC7C+3Eup7Ri6M3sAU/GOIJvEhTx+vb9iBxM=,tag:5GrNBy42IAQ88vbPJw7SSQ==,type:str]
+  hostname: ENC[AES256_GCM,data:KqAYfPj19ctbg25V2ay0GFhPNyr8bc+w5xG84yYUC4IWIG37MIo=,iv:eHw0pjP4HTpuNgE/aIm8xeFLM+e+J2/A0yxGJeGqZ9Q=,tag:1pSPgR3SUg9n6jc42flwrw==,type:str]
+  password: ENC[AES256_GCM,data:/zOtpwXQomPEyO5aogiyO+UqawEzcYLU040s5MShKD8=,iv:7rIGOnoEYOd4xO0KgsxXcFUHu/A6ONlXlIS0os6G9cA=,tag:n86JMlpG8+uFiI2C+RsWYA==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: questarr-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:IhBxlzMsnKo=,iv:vGqrijt7skPae1RS/hIcW+KQAgwo7mlFO715i+OkRDI=,tag:KipSkkQ+pajnFTCtsSVDkA==,type:str]
+  database: ENC[AES256_GCM,data:o0F/9Oh8icI=,iv:iEXJeQAcZZkHY9b8pW9OJtYahdfxb4iOrDKaNS18X0g=,tag:Zu2kLFWiu9bEqPKAnjIeig==,type:str]
+  port: ENC[AES256_GCM,data:LwEbfw==,iv:b9YNoFos8lkK5eqjc5yWZCWRarCrmB0TdJ+1i271dBk=,tag:4ztXUByAzFCh/AtXhjsoKg==,type:str]
+  hostname: ENC[AES256_GCM,data:DT2a6H3CRgZE6t+gYghAye/gNTR6x4GZRDoOjkb9hwER/rl9Ag8=,iv:0O7kjnsi1RzqilMMSjS0Ci5TLae/jKeF1dAmNLgf6vs=,tag:LfN6KDfiPdZamav4lgcx8Q==,type:str]
+  password: ENC[AES256_GCM,data:hQYZWPgwx5r24zdezFNXaEuYYrYwoWpILGj+akvDUTg=,iv:yHhztlDKBpPxLKmZRvVDRi9QFXn/it+REZaHcXII1rk=,tag:Lflv4lYjbA2SmnbQmXprEQ==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: romm-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:fXD9Ow==,iv:0jvxKt7J/QPCO5QHZP8DJz0E+OfcMAD3UvzeF8ulGbQ=,tag:0gdLS9g/vm0MR8fKE6eGKA==,type:str]
+  database: ENC[AES256_GCM,data:XDaQzg==,iv:eXVpZyaGUgJY9c50xb0n+pxFI4x8N2GftMuMCUV2hdY=,tag:OFGfp7LFORa3/G6R39vM6g==,type:str]
+  port: ENC[AES256_GCM,data:jFUUgw==,iv:wYDDO9qin/cYpX6bnEGHOkEfwkBKA6GMDi4P7F4pjDk=,tag:XEfPx0YzlqtckzlCMNVfqg==,type:str]
+  hostname: ENC[AES256_GCM,data:vh9gPV+xrc9iFg4atGivpg1VeW+gS3AkPeFToo+rQfvgQXxZ1mE=,iv:uSm14UU0V6UFl4FxFPsv6aLxp+57MXzH28qvrsku77o=,tag:VxXbXXYqbxIciEsCubNqJg==,type:str]
+  password: ENC[AES256_GCM,data:wFlaO8ZBtKBOe2Tl5cK5QDsYd2Zb24/EYtpZ4xr1AFA=,iv:5Zq5++pV+oo2O8Nv7V5myiIIUEn0AuOzAypCjsSGyuI=,tag:Devu6CZffUUN8XpIGLSrbQ==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pinepods-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:LUM3045OlLM=,iv:kMOjeXVt0s8kBpYgV5y6sIuMhINMguMKrhymqO8nd9U=,tag:XyfQHKkeWb3kFD7ZUDjhFA==,type:str]
+  database: ENC[AES256_GCM,data:HZM6TLF0/vU=,iv:B7/xy/d8XshjMJR6nH/7vNR6o8+9893iVDW73SW61/Y=,tag:7sZ+pl4KJIp11YlhQEhnBQ==,type:str]
+  port: ENC[AES256_GCM,data:d1fSgg==,iv:cNBtlrqXumv61+T3YekBD2PhBubEXw/0Rtt0GidjkVU=,tag:mxyXCanl6dA+qIW64v0mMw==,type:str]
+  hostname: ENC[AES256_GCM,data:+kNKjpGw9lLS1lCHB171lwIdc75UXncPBjPOTIulkq7OAE0NbjY=,iv:9yX76Kr0af6LIP9cuOwoYMTSa8vTaCvhQQ5F5mE0bO0=,tag:kKWqrz+hAL84B2XwyXKH+A==,type:str]
+  password: ENC[AES256_GCM,data:AiZFJrow+GKEU/icSPMeZKjHuJkfDIcdvmCF2U87BzY=,iv:91jfz4OZLcu4jZ7U762jYn52R9pEd26IzXrv2CnXVm4=,tag:rp1ndIilxLcMBSrpO3yCtA==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pulsarr-postgres-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:bF5NlG+3Mw==,iv:MMY9t8WSG/GAD4dsX5+w8BQouIa5SQ/m0A0CZYcDVBs=,tag:PffgbYFx3Dz1Vp0ADNYVHA==,type:str]
+  database: ENC[AES256_GCM,data:0D6QT0RSqA==,iv:9qM3xmZlW+UtRS0XauLxO2KDn70cN+Lq4tKmhZcurAI=,tag:mLmwfrEGJqvVWXfJuoYDOQ==,type:str]
+  port: ENC[AES256_GCM,data:soNSHQ==,iv:vFQUZBIf2zubW6I4MFrGdetQXvZ8RXpt51swJbOwtrA=,tag:jqsN2OurtBpdCw0xP6W9LQ==,type:str]
+  hostname: ENC[AES256_GCM,data:TdLXDMnL3hnxdhlxQB0a8P+SB+LR2xRw5cJmJ8hsLn+w0dWDkbk=,iv:TA/0CRJnSQSAwuR4Jvzyi8N3U1nFLaglQ2hRuWJDrYg=,tag:bvAQmnsQ5WOAzEyzJA1GWg==,type:str]
+  password: ENC[AES256_GCM,data:CGyxvJ5eGjS7cSj1AGD0Xx4V9Q2AQhBkwEYkObcVumI=,iv:JCQ6QETgZX2kkysdaf02bno2y2B5PBoHgw9OP1jrZs4=,tag:o/Jja2AEeR2sE/dVu8vB/Q==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-user-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:Acc4dpHJIgq2xhU+K1T/dw==,iv:57H514BCKEWwLCm3Ysb5FQ8zSlyqVPoqgFqbhNbcVXs=,tag:hF8xFOW3G/9Be2sSogn6kQ==,type:str]
+  database: ENC[AES256_GCM,data:B4kJprO3Kps=,iv:HoixxW8bbqMg3SfYv59wTot01zx8/4P44DhUaYT21cI=,tag:oe5V9sXs/NFxgbePZaMIoA==,type:str]
+  port: ENC[AES256_GCM,data:QOu4UQ==,iv:6zPeyrcE4WYr081QcOiMIsaEm8TkvFrvuK+H89IfCuY=,tag:TQpaket+o3TQ68NsV0dhvw==,type:str]
+  hostname: ENC[AES256_GCM,data:Qvbs8FnDY6ViPGZmq8fFLKAfdMIXYqbnSs4OtmLgAMXjYPr652Q=,iv:Ro2dVVkg7Goxwl8OIRiComFYA35s5x/ELPKGPP7Eze8=,tag:eaP88Npk4A3gjHbzPyTg5Q==,type:str]
+  password: ENC[AES256_GCM,data:31Zoqscdr74rcWnYeiUcxiQjxd2uMgEGxSCz1UT2cjI=,iv:+z7zMdrp6tAYkP2W/17RoWtQD2NUO8awXypSeKLALhA=,tag:8qcVfn8oVBOzNcSNCDfCKw==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-superuser-password
+  labels:
+    cnpg.io/reload: "true"
+stringData:
+  username: ENC[AES256_GCM,data:g53SfKqed/83LXmTNQD+EPtR,iv:fRWivZ2C7XHTh6NRulFW9sMfVsSW+c6NwnYmdzKtjSs=,tag:Rj+Us+aLZ2g5zJCMQhzpeA==,type:str]
+  database: ENC[AES256_GCM,data:5ym6ZPbMxF8=,iv:oLJJTLGG5eUgm6x6MVnSylXju1zPUHvXOmOE3af5Htg=,tag:+mvJtpzg/8PBVvHTXUCEiw==,type:str]
+  port: ENC[AES256_GCM,data:/BYdng==,iv:kPcHRV0PQM1bO/wJtgRw4uRR4olrZAuLkh3JD39ibFg=,tag:pEdUDOi84125HYqNkYBx6w==,type:str]
+  hostname: ENC[AES256_GCM,data:G8gTI29Zw9aWro2waB/ek2Uk2raAercP2CQNSICbjLLrw+sJEd8=,iv:QqdO5P4cJ7bMzEJAIxwXaEtELTnZZgKn9+pYkzdMGBo=,tag:ckLuvCkihsIUaS20VM/XeA==,type:str]
+  password: ENC[AES256_GCM,data:UtDGty5O+ozIiN5bB7NnDSCUwlT/qiwTKQu6qeSJrkZmniAGWUwLsbhskjUE5TF+eTc1oBkF28fFeb0ockxcRA==,iv:Jyt0GzxpjXs7lf9FTHOLuhaE6NvrQ+yDKRrGKQmfPX0=,tag:fP6WCHyiXbYe5KEt4+cu5Q==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2Sllmc3dtbjZHK2lxak4z
+        dHQ3U0RSY0p2Qk5Vb2diTCs1eVZLREk0dDFvCmJRKzg2M2Jua1hra2crNzQzaDd2
+        d2srWGRCbEhDV0FKUisyVzBrUU13WTQKLS0tIG1hRkJpcEptQlFWcnNzaVl1QzhL
+        Z0JKNHQ2TEtQcmkxMjBGTXdOQW1WNjAKdXoTBDnlqMu3Na1XtX/3jBCkLwNlBCOw
+        QVkUzqlw5lXbNGDZImJJWplZXPCVDCjLUBc+n90QydcbJW+IaEOzqw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUDF3Q25VcFBBR2g1QjZJ
+        bG8rY2g2aEw4bUs4UGFKSnZZM2Vyb2xaQzBnCkFramZKd0Y1VE1ycTF3Rlkra3U1
+        V1hSd2puS2ZCdkUyZGNBUTVPS1dkRWcKLS0tIGZjUzczVnRCVjNIZmVBbzB0NDJj
+        WDBYbitaSW9TM210VUtmbHpoNE9zYWcK9FIC3JMZao/CiwpZIiKYg06+41UzqNV5
+        ONKVeKwL3YAZHDgrHTtrCOaEraBurqX9EReOoKjbf218LavfAqF6fg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T18:18:41Z"
+  mac: ENC[AES256_GCM,data:ppKgkiBRlB5/jQyxnQGfNyY4AjNFhpmMESW5N+rAav4zC1m6/Na/nVoPm8ImgNesbeap0nScTXS5Bb2cwnGUDV9WGAYAdxYkg6V5uvS74ChERLZvz/PrK3M5nhiA+U0aw6r7RWebpdxpQ6KoysJCUUhuXsNJjJWVkRWbAsRDC9Y=,iv:FnaknkST2nelTFhEfpY9+VtvX8JCqGdPIB5HUTMWdG0=,tag:sBKGZ2R0nlPVhbcXviabnw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/database/postgres/app/postgres-user-template.yaml
+++ b/kubernetes/apps/database/postgres/app/postgres-user-template.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name postgres-user
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "postgres-user-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _

--- a/kubernetes/apps/database/postgres/app/resources/values.yaml
+++ b/kubernetes/apps/database/postgres/app/resources/values.yaml
@@ -1,0 +1,216 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/cloudnative-pg/charts/refs/heads/main/charts/cluster/values.schema.json
+nameOverride: &name "postgres"
+fullnameOverride: *name
+type: postgresql
+version:
+  postgresql: "17.5"
+mode: standalone
+recovery:
+  method: object_store
+  clusterName: "restore"
+  endpointURL: "{{ .minio_endpoint }}"
+  provider: s3
+  s3:
+    region: "{{ .minio_region }}"
+    # The bucket name below comes from cluster-secrets, where it is
+    # "equestria-db" — so this renders exactly what the 1Password extract
+    # produced. The endpoint above has been TrueNAS Minio for a while; only the
+    # bucket NAME still came from the Backblaze item, which is the mismatch
+    # vault#119 warned about.
+    #
+    # The variable is named in words rather than written out, because Flux
+    # postBuild envsubst expands substitutions inside COMMENTS too: spelling it
+    # normally here would bake the live value into the ConfigMap.
+    bucket: "${BACKBLAZE_DB_BUCKET}-restore"
+    path: "/"
+    accessKey: "{{ .minio_username }}"
+    secretKey: "{{ .minio_password }}"
+backups:
+  enabled: true
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  endpointURL: "{{ .minio_endpoint }}"
+  provider: s3
+  s3:
+    region: "{{ .minio_region }}"
+    bucket: "cnpg-${CLUSTER_CNAME}"
+    path: "/barman/${CLUSTER_CNAME}"
+    accessKey: "{{ .minio_username }}"
+    secretKey: "{{ .minio_password }}"
+  wal:
+    compression: gzip
+    encryption: ''
+    maxParallel: 4
+  data:
+    compression: gzip
+    encryption: ''
+    jobs: 2
+  scheduledBackups:
+  - name: daily-backup
+    schedule: "${POSTGRES_BACKUP_SCHEDULE:=0 0 16 * * *}"
+    backupOwnerReference: self
+    method: plugin
+    pluginConfiguration:
+      name: barman-cloud.cloudnative-pg.io
+  retentionPolicy: "30d"
+cluster:
+  instances: 3
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
+  priorityClassName: system-node-critical
+  storage:
+    size: ${POSTGRES_STORAGE:=10Gi}
+    storageClass: longhorn-local
+  resources:
+    requests:
+      cpu: ${POSTGRES_REQUESTS_CPU}
+      memory: ${POSTGRES_REQUESTS_MEMORY}
+    limits:
+      cpu: ${POSTGRES_LIMITS_CPU}
+      memory: ${POSTGRES_LIMITS_MEMORY}
+  logLevel: "info"
+  affinity:
+    topologyKey: kubernetes.io/hostname
+    podAntiAffinityType: required
+  enableSuperuserAccess: true
+  superuserSecret: "postgres-superuser-password"
+  roles:
+  - name: ${CLUSTER_CNAME}
+    ensure: present
+    login: true
+    superuser: true
+    passwordSecret:
+      name: postgres-user-password
+  - name: crowdsec
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: crowdsec-postgres-password
+  - name: grafana
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: grafana-postgres-password
+  - name: openbao
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: openbao-postgres-password
+  - name: coder
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: coder-postgres-password
+  - name: tandoor
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: tandoor-postgres-password
+  - name: immich
+    ensure: present
+    login: true
+    superuser: true
+    passwordSecret:
+      name: immich-postgres-password
+  - name: windmill
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: windmill-postgres-password
+  - name: freshrss
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: freshrss-postgres-password
+  - name: n8n
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: n8n-postgres-password
+  - name: outline
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: outline-postgres-password
+  - name: strmgen
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: strmgen-postgres-password
+  - name: retrom
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: retrom-postgres-password
+  - name: questarr
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: questarr-postgres-password
+  - name: romm
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: romm-postgres-password
+  - name: pinepods
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: pinepods-postgres-password
+  - name: pulsarr
+    ensure: present
+    login: true
+    superuser: false
+    passwordSecret:
+      name: pulsarr-postgres-password
+  monitoring:
+    enabled: true
+    podMonitor:
+      enabled: true
+    prometheusRule:
+      enabled: true
+      excludeRules:
+      - CNPGClusterLogicalReplicationErrorsCritical
+      - CNPGClusterLogicalReplicationErrors
+      - CNPGClusterLogicalReplicationStoppedCritical
+      - CNPGClusterLogicalReplicationStopped
+    disableDefaultQueries: false
+  postgresql:
+    parameters:
+      max_connections: "300"
+      shared_buffers: "${POSTGRES_SHARED_BUFFERS}"
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
+      wal_keep_size: "1GB"
+      max_slot_wal_keep_size: "10GB"
+      wal_sender_timeout: "120s"
+      wal_receiver_timeout: "120s"
+      tcp_keepalives_idle: "10"
+      tcp_keepalives_interval: "10"
+      tcp_keepalives_count: "3"
+    pg_hba: []
+    pg_ident: []
+    shared_preload_libraries: []
+    ldap: {}
+  serviceAccountTemplate: {}
+  additionalLabels: {}
+  annotations: {}
+imageCatalog:
+  create: true
+  images: []
+poolers: []

--- a/kubernetes/apps/database/postgres/app/role-broad-access.yaml
+++ b/kubernetes/apps/database/postgres/app/role-broad-access.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: postgres-broad-secrets
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: postgres-broad-secrets-binding
+subjects:
+- kind: ServiceAccount
+  name: postgres
+  namespace: database
+roleRef:
+  kind: Role
+  name: postgres-broad-secrets
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/apps/database/postgres/app/user-template.yaml
+++ b/kubernetes/apps/database/postgres/app/user-template.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/configmap-v1.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pgsql-user-template
+data:
+  username: "{{ .username }}"
+  password: "{{ .password }}"
+  port: "{{ .port }}"
+  database: "{{ .database }}"
+  pgpass: "{{ .hostname }}:{{ .port }}:{{ .database }}:{{ .username }}:{{ .password }}"
+  hostname: "{{ .hostname }}"
+  public-hostname: "${APP}.${CLUSTER_DOMAIN}"
+  jdbc-uri: "jdbc:postgres://{{ .hostname }}:{{ .port }}/{{ .database }}?password={{ .password }}&user={{ .username }}&sslmode=disable"
+  public-jdbc-uri: "jdbc:postgres://${APP}.${CLUSTER_DOMAIN}:{{ .port }}/{{ .database }}?password={{ .password }}&user={{ .username }}&sslmode=disable"
+  uri: "postgres://{{ .username }}:{{ .password }}@{{ .hostname }}:{{ .port }}/{{ .database }}?sslmode=disable"
+  uriql: "postgresql://{{ .username }}:{{ .password }}@{{ .hostname }}:{{ .port }}/{{ .database }}?sslmode=disable"
+  public-uri: "postgres://{{ .username }}:{{ .password }}@${APP}.${CLUSTER_DOMAIN}:{{ .port }}/{{ .database }}?sslmode=disable"
+  public-uriql: "postgresql://{{ .username }}:{{ .password }}@${APP}.${CLUSTER_DOMAIN}:{{ .port }}/{{ .database }}?sslmode=disable"
+  connection-string: "Host={{ .hostname }};Port={{ .port }};Database={{ .database }};Username={{ .username }};Password={{ .password }};Trust Server Certificate=true;SSL Mode=Disable;"
+  public-connection-string: "Host=${APP}.${CLUSTER_DOMAIN};Port={{ .port }};Database={{ .database }};Username={{ .username }};Password={{ .password }};Trust Server Certificate=true;SSL Mode=Disable;"

--- a/kubernetes/apps/database/postgres/app/users.yaml
+++ b/kubernetes/apps/database/postgres/app/users.yaml
@@ -1,0 +1,1610 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name crowdsec-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "crowdsec-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app crowdsec
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: crowdsec
+  owner: crowdsec
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: crowdsec
+    - ensure: present
+      name: crowdsec
+      owner: crowdsec
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name grafana-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "grafana-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app grafana
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: grafana
+  owner: grafana
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: grafana
+    - ensure: present
+      name: grafana
+      owner: grafana
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name openbao-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "openbao-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app openbao
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: openbao
+  owner: openbao
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: openbao
+    - ensure: present
+      name: openbao
+      owner: openbao
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name coder-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "coder-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app coder
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: coder
+  owner: coder
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: coder
+    - ensure: present
+      name: coder
+      owner: coder
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name tandoor-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "tandoor-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app tandoor
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: tandoor
+  owner: tandoor
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: tandoor
+    - ensure: present
+      name: tandoor
+      owner: tandoor
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name immich-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "immich-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app immich
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: immich
+  owner: immich
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: immich
+    - ensure: present
+      name: immich
+      owner: immich
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name windmill-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "windmill-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app windmill
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: windmill
+  owner: windmill
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: windmill
+    - ensure: present
+      name: windmill
+      owner: windmill
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name freshrss-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "freshrss-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app freshrss
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: freshrss
+  owner: freshrss
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: freshrss
+    - ensure: present
+      name: freshrss
+      owner: freshrss
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name n8n-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "n8n-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app n8n
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: n8n
+  owner: n8n
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: n8n
+    - ensure: present
+      name: n8n
+      owner: n8n
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name outline-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "outline-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app outline
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: outline
+  owner: outline
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: outline
+    - ensure: present
+      name: outline
+      owner: outline
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name strmgen-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "strmgen-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app strmgen
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: strmgen
+  owner: strmgen
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: strmgen
+    - ensure: present
+      name: strmgen
+      owner: strmgen
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name retrom-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "retrom-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app retrom
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: retrom
+  owner: retrom
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: retrom
+    - ensure: present
+      name: retrom
+      owner: retrom
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name questarr-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "questarr-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app questarr
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: questarr
+  owner: questarr
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: questarr
+    - ensure: present
+      name: questarr
+      owner: questarr
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name romm-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "romm-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app romm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: romm
+  owner: romm
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: romm
+    - ensure: present
+      name: romm
+      owner: romm
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name pinepods-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "pinepods-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app pinepods
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: pinepods
+  owner: pinepods
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: pinepods
+    - ensure: present
+      name: pinepods
+      owner: pinepods
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name pulsarr-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "pulsarr-postgres-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: &app pulsarr
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  cluster:
+    name: postgres
+  name: pulsarr
+  owner: pulsarr
+  ensure: present
+  allowConnections: true
+  databaseReclaimPolicy: retain
+  schemas:
+    - ensure: present
+      name: public
+      owner: pulsarr
+    - ensure: present
+      name: pulsarr
+      owner: pulsarr
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name postgres-user
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "postgres-user-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name postgres-superuser
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  target:
+    name: *name
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      templateFrom:
+        - target: Data
+          configMap:
+            name: pgsql-user-template
+            items:
+            - key: username
+              templateAs: Values
+            - key: password
+              templateAs: Values
+            - key: hostname
+              templateAs: Values
+            - key: public-hostname
+              templateAs: Values
+            - key: port
+              templateAs: Values
+            - key: database
+              templateAs: Values
+            - key: pgpass
+              templateAs: Values
+            - key: jdbc-uri
+              templateAs: Values
+            - key: uri
+              templateAs: Values
+            - key: uriql
+              templateAs: Values
+            - key: public-jdbc-uri
+              templateAs: Values
+            - key: public-uri
+              templateAs: Values
+            - key: public-uriql
+              templateAs: Values
+            - key: connection-string
+              templateAs: Values
+            - key: public-connection-string
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: "postgres-superuser-password"
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+
+

--- a/kubernetes/apps/database/postgres/backups/cronjob.yaml
+++ b/kubernetes/apps/database/postgres/backups/cronjob.yaml
@@ -1,0 +1,144 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app postgres-backup
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  dependsOn:
+    - name: postgres
+      namespace: database
+    - name: external-secrets
+      namespace: kube-system
+  values:
+    # Reads the per-database credential Secrets in this namespace directly.
+    # `get` only, and only in this namespace: the CronJob never lists Secrets,
+    # so a Role beats a ClusterRole and a name-scoped read beats a wildcard.
+    serviceAccount:
+      *app : {}
+
+    rbac:
+      roles:
+        *app :
+          type: Role
+          rules:
+            - apiGroups: [""]
+              resources: ["secrets"]
+              verbs: ["get"]
+      bindings:
+        *app :
+          type: RoleBinding
+          roleRef:
+            identifier: *app
+          subjects:
+            - identifier: *app
+
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        cronjob:
+          backoffLimit: 6
+          concurrencyPolicy: Forbid
+          failedJobsHistory: 3
+          schedule: "0 2 * * *"  # Daily at 2 AM
+          startingDeadlineSeconds: 30
+          successfulJobsHistory: 3
+          suspend: false
+        type: cronjob
+        pod:
+          automountServiceAccountToken: true
+        serviceAccount:
+          identifier: *app
+        containers:
+          main:
+            image:
+              repository: mcr.microsoft.com/dotnet/sdk
+              tag: '10.0-noble@sha256:e1fc6e423f543119c406d24e2e687d67c569f18f04a37a8b0005d80ad0dcee80'
+              pullPolicy: IfNotPresent
+            env:
+              # Explicit in the manifest rather than inferred from the
+              # service-account token dir, so the namespace the credentials are
+              # read from is visible where the RBAC that permits it is.
+              POD_NAMESPACE:
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              # Databases still in postgres whose application has been removed.
+              # They have no credential Secret, so they are named here rather
+              # than being skipped by a "no Secret? never mind" rule -- a
+              # missing Secret on a LIVE database must stay a hard failure.
+              # Their existing dumps are left untouched; nothing is deleted.
+              #   keeper   -- app removed 2026-03-26 (6a2139535)
+              #   vikunja  -- app removed 2026-07-27 (0b289652f)
+              DECOMMISSIONED_DATABASES: "keeper,vikunja"
+            command:
+              - /bin/sh
+              - -c
+              - >-
+                set -eux;
+                export DEBIAN_FRONTEND=noninteractive;
+                apt-get update
+                && apt install -y postgresql-common
+                && /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+                && apt-get install -y --no-install-recommends postgresql-client-17
+                && dotnet run /scripts/App.cs
+            resources:
+              requests:
+                memory: 256Mi
+                cpu: 20m
+              limits:
+                memory: 512Mi
+                cpu: 500m
+
+    # defaultPodOptions:
+    #   securityContext:
+    #     runAsUser: 999
+    #     runAsGroup: 999
+    #     fsGroup: 999
+    #     runAsNonRoot: true
+    #     fsGroupChangePolicy: "OnRootMismatch"
+    #     seccompProfile:
+    #       type: RuntimeDefault
+
+    persistence:
+      script:
+        type: configMap
+        name: postgres-backup-script
+        defaultMode: 493
+        globalMounts:
+          - path: /scripts/App.cs
+            subPath: App.cs
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+            subPath: tmp
+          - path: /.dotnet
+            subPath: dotnet
+      backups:
+        type: nfs
+        server: ${SPIKE_IP}
+        path: /mnt/stash/data/pgdump

--- a/kubernetes/apps/database/postgres/backups/ks.yaml
+++ b/kubernetes/apps/database/postgres/backups/ks.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app pg-backups
+  namespace: &namespace database
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/database/postgres/backups
+  dependsOn:
+    - name: postgres
+      namespace: database
+    - name: external-secrets
+      namespace: kube-system
+  prune: true
+  wait: true
+  force: false
+  suspend: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/database/postgres/backups/kustomization.yaml
+++ b/kubernetes/apps/database/postgres/backups/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cronjob.yaml
+configMapGenerator:
+  - files:
+      - App.cs=./resources/App.cs
+    name: postgres-backup-script
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/database/postgres/backups/resources/App.cs
+++ b/kubernetes/apps/database/postgres/backups/resources/App.cs
@@ -1,0 +1,221 @@
+#!/usr/bin/dotnet run
+// #:package YamlDotNet@16.3.0
+#:package gstocco.YamlDotNet.YamlPath@1.0.26
+#:package KubernetesClient@*
+#:package Microsoft.Extensions.Logging@10.*
+#:package Lunet.Extensions.Logging.SpectreConsole@1.2.0
+#:package ProcessX@1.5.6
+#:package Npgsql@*
+#:property JsonSerializerIsReflectionEnabledByDefault=true
+
+// Postgres backup. Credentials come from the Kubernetes Secrets in THIS
+// namespace -- the same objects the ExternalSecrets in
+// kubernetes/apps/database/postgres/app/users.yaml render from the sops-held
+// per-app passwords.
+//
+// This used to read them back out of 1Password, where a PushSecret had pushed
+// these very Secrets 24h earlier (Phase 10 of the 1Password->OpenBao
+// migration; vault repo docs/openbao-migration/PLAN.md SS-G row 10). That was a
+// round trip out of the cluster and back into the same namespace, and it cost
+// more than an indirection: the copy was up to a refreshInterval stale, and a
+// database whose PushSecret had been removed kept being backed up from a
+// FROZEN item -- invisibly, because a stale credential still authenticates.
+// Reading the Secret directly makes a missing credential an error at the
+// moment it goes missing.
+
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Text;
+using k8s;
+using Npgsql;
+using File = System.IO.File;
+
+var config = KubernetesClientConfiguration.InClusterConfig();
+using var kubernetes = new Kubernetes(config);
+
+// The Secrets live alongside this CronJob. Downward-API first so the value is
+// explicit in the manifest; the service-account namespace file is the fallback.
+var secretNamespace = Environment.GetEnvironmentVariable("POD_NAMESPACE")
+  ?? config.Namespace
+  ?? throw new InvalidOperationException("POD_NAMESPACE is not set and no in-cluster namespace could be determined");
+
+async Task<IDictionary<string, byte[]>> GetSecret(string name)
+{
+  try
+  {
+    var secret = await kubernetes.CoreV1.ReadNamespacedSecretAsync(name, secretNamespace);
+    return secret.Data ?? throw new InvalidOperationException($"secret {secretNamespace}/{name} has no data");
+  }
+  catch (k8s.Autorest.HttpOperationException ex) when (ex.Response?.StatusCode == System.Net.HttpStatusCode.NotFound)
+  {
+    // Named explicitly: this is what a database with no matching credential
+    // Secret looks like, and it is the case the 1Password round trip used to
+    // hide behind a stale copy.
+    throw new InvalidOperationException($"secret {secretNamespace}/{name} does not exist -- the database has no credential Secret in this cluster", ex);
+  }
+}
+
+static string GetField(IDictionary<string, byte[]> secret, string name, string key) =>
+  secret.TryGetValue(key, out var value)
+    ? Encoding.UTF8.GetString(value)
+    : throw new InvalidOperationException($"{key} key not found in secret {name}");
+
+// Databases whose application has been decommissioned but whose data is still
+// in postgres. They have no credential Secret, so without this they would fail
+// the run. The list is per-cluster config, set in cronjob.yaml, where each name
+// carries the date its application was removed.
+//
+// Deliberately an explicit allowlist and never a "skip anything with no Secret"
+// fallback: a missing Secret is exactly how a LIVE database silently drops out
+// of the backup set, and making that loud is the point of this phase.
+var decommissioned = (Environment.GetEnvironmentVariable("DECOMMISSIONED_DATABASES") ?? "")
+  .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+  .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+var backupDir = "/backups";
+
+Console.WriteLine($"Starting PostgreSQL backup at {DateTime.UtcNow}");
+
+// Create backup directory
+Directory.CreateDirectory(backupDir);
+
+List<string> databases;
+{
+  // Get list of databases
+  var postgres = await GetSecret("postgres-user");
+  // NEVER log this -- the connection string embeds the plaintext password and
+  // pod stdout is shipped to Loki.
+  var connectionString = GetField(postgres, "postgres-user", "connection-string");
+  Console.WriteLine("Fetching list of databases...");
+  await using var dataSource = NpgsqlDataSource.Create(connectionString);
+  databases = await GetDatabases(dataSource);
+  Console.WriteLine($"Found databases: {string.Join(", ", databases)}");
+}
+
+// A listed database that no longer exists means the entry outlived its
+// database -- harmless, but it rots, so say so rather than letting the list
+// grow stale silently.
+var staleEntries = decommissioned.Except(databases, StringComparer.OrdinalIgnoreCase).ToList();
+if (staleEntries.Count > 0)
+{
+  Console.WriteLine($"Note: DECOMMISSIONED_DATABASES lists {string.Join(", ", staleEntries)}, which no longer exist in postgres -- remove the entries");
+}
+
+// Create individual database dumps
+var failed = new List<string>();
+var skipped = new List<string>();
+foreach (var db in databases)
+{
+  if (decommissioned.Contains(db))
+  {
+    // Printed every run, by name: a database leaving the backup set should be
+    // visible in the log of the job that stopped backing it up.
+    Console.WriteLine($"SKIPPING {db}: decommissioned, not backed up (DECOMMISSIONED_DATABASES)");
+    skipped.Add(db);
+    continue;
+  }
+
+  var backupFile = Path.Combine(backupDir, $"{db}.sql.gz");
+  // Dump to a sibling temp file and only replace the existing backup once pg_dump
+  // has exited 0. Writing straight to backupFile truncates the last known-good
+  // dump before the new one is known to be valid.
+  var stagingFile = $"{backupFile}.tmp";
+  try
+  {
+    var secretName = $"{db}-postgres";
+    var postgres = await GetSecret(secretName);
+
+    // Host/port/user only -- never the password or the full connection string.
+    Console.WriteLine($"Backing up database: {db} ({GetField(postgres, secretName, "username")}@{GetField(postgres, secretName, "hostname")}:{GetField(postgres, secretName, "port")})");
+    Directory.CreateDirectory(Path.GetDirectoryName(backupFile) ?? throw new InvalidOperationException("Failed to get directory name for backup file"));
+
+    await CreateDatabaseDump(postgres, secretName, db, stagingFile);
+    File.Move(stagingFile, backupFile, overwrite: true);
+
+    if (File.Exists(backupFile))
+    {
+      Console.WriteLine($"Successfully created backup: {backupFile}");
+    }
+    else
+    {
+      Console.Error.WriteLine($"Failed to create backup for database: {db}");
+      failed.Add(db);
+    }
+  }
+  catch (Exception ex)
+  {
+    Console.Error.WriteLine($"Error backing up database {db}: {ex.Message}");
+    failed.Add(db);
+  }
+  finally
+  {
+    if (File.Exists(stagingFile)) File.Delete(stagingFile);
+  }
+}
+
+if (failed.Count > 0)
+{
+  Console.Error.WriteLine($"PostgreSQL backup FAILED at {DateTime.UtcNow}: {failed.Count} of {databases.Count - skipped.Count} database(s) were not backed up: {string.Join(", ", failed)}");
+  return 1;
+}
+
+Console.WriteLine($"PostgreSQL backup completed successfully at {DateTime.UtcNow} ({databases.Count - skipped.Count} databases{(skipped.Count > 0 ? $", {skipped.Count} skipped: {string.Join(", ", skipped)}" : "")})");
+return 0;
+
+// Helper methods
+async Task<List<string>> GetDatabases(NpgsqlDataSource dataSource)
+{
+  var databases = new List<string>();
+  await using var connection = await dataSource.OpenConnectionAsync();
+  using var command = connection.CreateCommand();
+  command.CommandText = "SELECT datname FROM pg_database WHERE datistemplate = false;";
+  await using var reader = await command.ExecuteReaderAsync();
+  while (await reader.ReadAsync())
+  {
+    if (reader.GetString(0) is "postgres" or "app") continue;
+    databases.Add(reader.GetString(0));
+  }
+
+  return databases;
+}
+
+async Task CreateDatabaseDump(IDictionary<string, byte[]> postgres, string secretName, string database, string outputFile)
+{
+  var host = GetField(postgres, secretName, "hostname");
+  var port = GetField(postgres, secretName, "port");
+  var user = GetField(postgres, secretName, "username");
+  var password = GetField(postgres, secretName, "password");
+  var psi = new ProcessStartInfo
+  {
+    FileName = "pg_dump",
+    Arguments = $"-h {host} -p {port} -U {user} -d {database} --verbose --no-password --format=custom --no-privileges --no-owner",
+    UseShellExecute = false,
+    RedirectStandardOutput = true,
+    RedirectStandardError = true,
+    CreateNoWindow = true,
+  };
+  psi.Environment["PGPASSWORD"] = password;
+
+  using var process = Process.Start(psi);
+  if (process == null) throw new InvalidOperationException("Failed to start pg_dump process");
+
+  // --verbose writes progress to stderr throughout the dump. Drain it concurrently
+  // with stdout: reading it only after the process exits deadlocks once the stderr
+  // pipe buffer fills, because pg_dump then blocks before it can finish writing stdout.
+  var errorTask = process.StandardError.ReadToEndAsync();
+
+  // Compress the output
+  await using (var fileStream = File.Create(outputFile))
+  await using (var gzipStream = new GZipStream(fileStream, CompressionMode.Compress))
+  {
+    await process.StandardOutput.BaseStream.CopyToAsync(gzipStream);
+  }
+
+  await process.WaitForExitAsync();
+  var error = await errorTask;
+
+  if (process.ExitCode != 0)
+  {
+    throw new InvalidOperationException($"pg_dump failed: {error}");
+  }
+}

--- a/kubernetes/apps/database/postgres/kustomization.yaml
+++ b/kubernetes/apps/database/postgres/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./app/ks.yaml
+  - ./backups/ks.yaml

--- a/kubernetes/apps/database/valkey/definition.yaml
+++ b/kubernetes/apps/database/valkey/definition.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: Valkey
+  category: ${CLUSTER_TITLE}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/valkey.svg
+  access_policy:
+    groups:
+      - admins
+  # gatus:
+  #   - group: *category
+  #     url: tcp://valkey.database.svc.cluster.local:6379
+  #     conditions:
+  #     - "[CONNECTED] == true"

--- a/kubernetes/apps/database/valkey/helmrelease.yaml
+++ b/kubernetes/apps/database/valkey/helmrelease.yaml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app ${APP}
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  # the config can take a while to restore
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      *app :
+        containers:
+          *app :
+            image:
+              repository: ghcr.io/valkey-io/valkey
+              tag: 9.1-trixie@sha256:3acc0687f2a2e1091fae6450d7842dd658c941338cf0a873ddd9e14b9e4ea4dd
+            env:
+              VALKEY_PORT: &port 6379
+    persistence:
+      data:
+        accessMode: ReadWriteOnce
+        size: 4Gi
+        # Was `longhorn-local` (strict-local, 1 replica) until 2026-08-04. That
+        # class gives the PV a hard nodeAffinity to a single node, so any drain
+        # of that node left valkey unschedulable ("3 node(s) didn't match
+        # PersistentVolume's node affinity") and took immich, romm, dispatcharr,
+        # searxng, outline, pinepods and n8n down with it. `longhorn` is
+        # replicated (3 replicas, dataLocality best-effort), so the pod can move.
+        # The volume is pure cache/broker state and was recreated empty.
+        storageClass: longhorn
+    service:
+      *app :
+        controller: *app
+        ports:
+          *app :
+            port: *port

--- a/kubernetes/apps/database/valkey/ks.yaml
+++ b/kubernetes/apps/database/valkey/ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app valkey
+  namespace: &namespace database
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn: []
+  path: ./kubernetes/apps/database/valkey
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../components/failover/fast-node-eviction
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/database/valkey/kustomization.yaml
+++ b/kubernetes/apps/database/valkey/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./podmonitor.yaml
+  - ./definition.yaml

--- a/kubernetes/apps/database/valkey/podmonitor.yaml
+++ b/kubernetes/apps/database/valkey/podmonitor.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ${APP}
+spec:
+  selector:
+    matchLabels:
+      app: ${APP}
+  podTargetLabels: ["app"]
+  podMetricsEndpoints:
+    - port: metrics


### PR DESCRIPTION
## What

Copies `kubernetes/apps/database` verbatim from `equestria-cluster` (postgres app + backups, valkey, and the still-disabled neo4j — commented out in `resources:`, unchanged), as part of the namespace-by-namespace repo consolidation ([vault#84](https://github.com/david-driscoll/vault/issues/84) piece 21, Phase A).

Nested `Kustomization`s' `sourceRef.name` changed from `flux-system` to `home-operations`, matching the proven pattern.

## Companion PR

david-driscoll/equestria-cluster#3153 — **merge this PR first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)