### PR TITLE
feat(github-actions): add github-actions namespace tree (repo consolidation piece 21)

### DIFF
--- a/kubernetes/apps/github-actions/1password/kustomization.yaml
+++ b/kubernetes/apps/github-actions/1password/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./syndicates/ks.yaml

--- a/kubernetes/apps/github-actions/1password/syndicates/helmrelease.yaml
+++ b/kubernetes/apps/github-actions/1password/syndicates/helmrelease.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: onepassword-syndicates
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: connect
+      version: 2.4.1
+      sourceRef:
+        kind: HelmRepository
+        name: 1password
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    connect:
+      applicationName: onepassword-syndicates
+      host: onepassword-syndicates
+      annotations:
+        reloader.stakater.com/auto: "true"
+      serviceAnnotations:
+        reloader.stakater.com/auto: "true"
+      api:
+        serviceMonitor:
+          enabled: true
+          interval: 30s
+          path: "/metrics"
+          params: {}
+          annotations: {}
+
+      credentialsName: onepassword-syndicates
+      credentialsKey: 1password-credentials.json
+      imagePullPolicy: Always
+      ingress:
+        enabled: false
+    operator:
+      create: false

--- a/kubernetes/apps/github-actions/1password/syndicates/ks.yaml
+++ b/kubernetes/apps/github-actions/1password/syndicates/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app onepassword-syndicates
+  namespace: flux-system
+spec:
+  targetNamespace: &target-namespace github-actions
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/github-actions/1password/syndicates
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *target-namespace
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/github-actions/1password/syndicates/kustomization.yaml
+++ b/kubernetes/apps/github-actions/1password/syndicates/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/github-actions/1password/syndicates/secret.sops.yaml
+++ b/kubernetes/apps/github-actions/1password/syndicates/secret.sops.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-syndicates
+stringData:
+  access-token: ENC[AES256_GCM,data:LuEP+wELpv69m6ScCz9MGViBfWExm+S669ueDJzKa91vQD/ALmOtKiC/XEJro0G53MAS4TpqawB3ZYgHYMtfv5hdPRgQuCXke+B+08GqQnpzQSxlUf8W8cCeEjH2UbxLwNDixGzhtga6M9nbyI/D2BRN3GC7OQQ6fXWo/ikjRTn8qQdo6vi61uezxplun47we27ugK3ga2b4fOba12CtMIXSBswVZjEIaHMEPHURUO7yuE++uQjwz1oOjceq/Ry8xLEOEQF73gUYd9u8Y5i5sg9i4A+sbubMHKCbl81/JU3twHIQrz6GRuzlG7sAVD2FVsM/2NJztZnv+692ocHteFX2FEOUDEGaMzLvAo6MhdHtzwSYNRG+aZlCBKQ8h31Ix6Tduxxwaar+0HzY+bTEiPw9CZn3Wl0Fg7Tdz7Q0bzMa3XqubjG6/bhsKf4PwzOW9kLg2Y3p+SeUuuhwoKSOa8WMk3AyptjC1wPUtfjawBPZyE3vmSoVOmluWWdExSzw5GGqnKejFe8ECtUwNyhU+hwWokzhLQnTgxHp97uiiQp7JWp8RAuwTmooy0W8A3zGCzePq+QEVDGgp2GhIwoYYCIN9LhOdUniv84OWcXw+Inw1ZipU6WRyGJkQT4vNb+HKRChR4V8gqfCBkSPdhGrbWQ+9u5txU5dfEIAa8rbAOq80H6Ywb7fg7pyXHeOk+SUFSRwVOdRvmeei6xTIYugIBTZ8xrgsxZtdr8WUG6ErrMj5w8qggpaY00a6nz/Ck0In6XuwPHYo/+fhN0/dH2sx9huVpj2mGheSvFJ6+UF/5xvcGwyC1uHzSmn5wOD0PCaAzfw2bNGjeWn9F89+b/iAzOfxg==,iv:sTgwnfAF+yB0gnM6CTffkmcn6Y7Y9xTsZ8YUhYzWGJ0=,tag:uTis/2/CwtRjhgUjaauLqQ==,type:str]
+  1password-credentials.json: ENC[AES256_GCM,data:R0Wz7QE8eU9GYYkgR+nRO0QmuVxCo47RGlEJvb9R6YP7SPaa+exergIUgcX5Qme3AesR5af3iLc8ZoiECB/CvmTFBgtT6ZgNQQl+DM3fCuSdjsuIUyNGG07F5LjQU5pGjNZbysd/7o4UhfkSIHTHbSGJaW/ppaNO7+OuUDfNXpafP7RxL6O6rD3Iv8qbg12+q8EE/xotyMwcUmxGD0XTgnmGQeT55hgpyOxsWBXbEpVkYY+PlbTcSC6mbeWTbURPfMdaJFVSzBS5j6rq6K0lv1tSChSH/vF4i5CPKA719XmSz/MnQPmgMR76XYj6sXnkfoFQYVWcIj9awbo/aqrxRZ3vb76G9/Rnc1Ld3hAbjPUbIacCFYrx292K7qzGJl/gX9HtrwOH3WE/lDw5rc+Dw/sl+ZiCAsOtNm9uw83cke9TQ4BzGFmeS5BBTupQwb3r7yMhqvmoaxZ+nIHRcsis6Eb6MfhM5W6OaVBKxnuGB10P0wdXU1GpFjaqHZqw5zeu55tOmXeW+VMfjNyrCpy2msQeR5dfqTcciWHQKZusvoaeOttpe2PO5f+PbyakPYiy9rDII7p9hdlJHtutynG31SJgpXgbXpS4bdZl4+XIQkziMu74XOBhwpF6N/yXCvSKmuNhOVgpsXEHndnkfwq3S1yFBaT/AUQHD5po+i83vjTbJk21g6u8D1hK0V+iIMnbKOoy83lX2rww0e+vSKE1hvkCoemUqS1tDaFwf4nOkJ2wdFoXvf6N5lyiqRyL9/tmuI1gbw8G56xJGBNLew9xiToLva2fQvtUHOVGTwnQW/oEY2wgLNlC1zx/n5YpdcgfeCfyeYVd8oy6npplqViH/vMvUDSYzKjZi5lrc/lh+8/+TyMx+VMRXuxIbUV8JsNMVH+CwsfKHXxNVMoWbmC0p3kJ7F9l1fdy3V6+IDELkPcNcMhj04gpV19OElaPDZXvBbL4T5O+Ci7CF6GuWFTBbUTTIdu6ai8G5hSQQ5+LFkGmzrfxcxlnsyhsd5S+jO/RpNDZwPpn4bQN/eGlKbUKN4xoUgOsZo4Jws14hktncd4kvrOxnRrmm8o7kcoq2Ro3L2F7id4yOKLK1aUrcQ5bJiz19T1c7KXwSlSoVpijELLEeAL+9eQNTcvHsmhvr71olkwi/9EXc4zKRcjcdRkqgt7WZ2YbN/iYuzD2hdM3JA8nseQibE+bAOzPgagEUjpbHMvrVXqw+4Oo9dskBhDjvqKI9Y1PZatMlIA5ZDlGB59NHdxzNwdLy7vt4Y9hIcJEgh3LXWXIfGRyOYkptrERjGweySntRy5m8DEFLiGKr1ugzQxyK5fq0NC7rKtmfk9gV6s7qKkBAkiG0w9ynp5XspMibT+3fuozrQrTLyzPReTTvPALfzBs5FzmwXL8gEaf7vDHGGJVGfAxCIA3Ih/BQfak+rdufaDZDHkuowIeVkjYkqLPm/FBCjN8si5P8xX95vA9LpgAsYWw9OPnFnCq5/tV9iwIyxCQ4C4GxmtApfgxToI39xPaOy4Mamknx6yg/sp330If/p/9KmPdzALPdipVMq62oWOmmaTaoh6llGNlycyIpLLvYm15lJ5h50GuGtLZlvfSLs7xN0M7Y5/TCjdeFpV66Bj5JEfR85vVcl7Iuxtb+g1ikvGagq0srf7B+vWF+HYJFbSbNOSPgt+UzEAXczfUdroLloGQ8I0MwJTnVHCUOoo98G0UojocpwKfKSCWfmNzXLu+WxSGBccdkS9Gg6F0D7LgcWR0aFnlcKIxdT9E/c8wkfTtlUmVWEOamlW5+ScmuJ1rjyX6Rm6Huqy88Jl2r/KPMLtqjIaOr85tbb1trBguGB1FZAQzkK+iLHUn4K8DuAzPuKnB5mSOI5uVD/fOhq7By8ip8LGfhSJrF65UoM7Bm8rAFiEESglXTeIE0Y6YckH6arUK,iv:MPzZrLrxKZEJPF7gWC9tTGHpCiJSdJ0ZCsUlSFeAmSc=,tag:3+ICAmb91y5RFRtdssKnzw==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3RFZpMDNxMncveFhTb1pG
+        bFUvZjFVQjJTVm5JcjdZUjlHd3lJU1Z6azBFCklueHNnckFUSHZhQ2RERHFlZzhq
+        VTNwaHEramY1K2daL3NZbUozRVUwS28KLS0tIEphUEQ0UmtOVE9BazlmVnlHSVM4
+        a3dTWXY0SU1ESzRtYUZZZEN4WlY3bDQKt+9qvIv0SxAqdVhaNHwGPvpsk1893+oX
+        M1QH4wv+5nsdOGUYanHJvQInwQ/JM2R1V2T02mykIpAW1i3PFH6YSQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBud3dSaTZ1Q3FBaTQwZENl
+        NHBPZDJ1T3Y2VDE4N1A5UTliMDRHTkY3TUJnCnNXWDJsdy9JdE41TlZqWkJjckNS
+        N1hPVlplVkJibjJvUk04cFZmQlkvN0EKLS0tIGVhRldrZDJid01lTGo5UytOZGhy
+        SnA5Q3BmT0pIc2gxS2RjTW9WWXFKSDAK6x3vTWpoI/IFRWWfrOj8u4L1CRJSEDGp
+        F08PwfHAyzcPfGI9PPlGJcKrVy/3Lfu1RA/shB1jtyF0YI/TupYRPQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2025-12-22T00:31:11Z"
+  mac: ENC[AES256_GCM,data:tQyGkvyBvECspBpCae+80m5RigNIf22stya3nj+nE4aYJ/MMUkeQiFaiz/6G/EMkEa8cOtbrI7Mdyl6/voWNvA7DZvhgZkDXuw8JK5LRJYBY94NWRF1aC1jIjvOjw16l7/L1HaWBOI2gqrComGk/+c2Nf/bSdAtxWvWw/uhwj8E=,iv:9IbK2cgHF71koQGupVAzuxWldVF76e/S2E25aUvGWS8=,tag:ecQLBLmbQb9cWLT05uvJVQ==,type:str]
+  mac_only_encrypted: true
+  version: 3.11.0

--- a/kubernetes/apps/github-actions/controller/helmrelease.yaml
+++ b/kubernetes/apps/github-actions/controller/helmrelease.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app gha-arc-controller
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: gha-runner-scale-set-controller
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    crds: CreateReplace
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    fullnameOverride: *app
+    replicaCount: 1
+    metrics:
+      controllerManagerAddr: ":8080"
+      listenerAddr: ":8080"
+      listenerEndpoint: "/metrics"
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: &app gha-arc-controller
+  namespace: github-actions
+  labels: &labels
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  selector:
+    matchLabels:
+      <<: *labels
+  endpoints:
+    - port: "8080"
+      interval: 30m
+      scrapeTimeout: 30s
+      path: /metrics

--- a/kubernetes/apps/github-actions/controller/ks.yaml
+++ b/kubernetes/apps/github-actions/controller/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gha-arc-controller
+  namespace: &namespace github-actions
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/github-actions/controller
+  dependsOn:
+    - name: gha-repositories
+      namespace: github-actions
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/github-actions/controller/kustomization.yaml
+++ b/kubernetes/apps/github-actions/controller/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/github-actions/kustomization.yaml
+++ b/kubernetes/apps/github-actions/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: github-actions
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+components:
+  - ../../components/alerts
+  - ../../components/common
+  - ../../components/repos/app-template
+resources:
+  - ./1password
+  - ./controller/ks.yaml
+  - ./repositories/ks.yaml
+  - ./runners

--- a/kubernetes/apps/github-actions/repositories/gha-runner-scale-set-controller.yaml
+++ b/kubernetes/apps/github-actions/repositories/gha-runner-scale-set-controller.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gha-runner-scale-set-controller
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.2
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller

--- a/kubernetes/apps/github-actions/repositories/gha-runner-scale-set.yaml
+++ b/kubernetes/apps/github-actions/repositories/gha-runner-scale-set.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gha-runner-scale-set
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.2
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set

--- a/kubernetes/apps/github-actions/repositories/ks.yaml
+++ b/kubernetes/apps/github-actions/repositories/ks.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gha-repositories
+  namespace: &namespace github-actions
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/github-actions/repositories
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/github-actions/repositories/kustomization.yaml
+++ b/kubernetes/apps/github-actions/repositories/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./gha-runner-scale-set.yaml
+  - ./gha-runner-scale-set-controller.yaml

--- a/kubernetes/apps/github-actions/runners/base/helmrelease.yaml
+++ b/kubernetes/apps/github-actions/runners/base/helmrelease.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app generic-runner
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: gha-runner-scale-set
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    crds: CreateReplace
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: gha-arc-controller
+  values:
+    fullnameOverride: *app
+    runnerScaleSetName: *app
+    githubConfigUrl: "https://github.com/placeholder"
+    githubConfigSecret:
+      github_app_id: "placeholder"
+      github_app_installation_id: "placeholder"
+      github_app_private_key: "placeholder"
+    controllerServiceAccount:
+      name: gha-arc-controller
+      namespace: github-actions
+    containerMode:
+      type: kubernetes
+    kubernetesModeWorkVolumeClaim:
+      accessModes: ["ReadWriteOnce"]
+      storageClassName: longhorn-local
+      resources:
+        requests:
+          storage: 2Gi
+    kubernetesModeAdditionalRoleRules: []
+    template:
+      spec:
+        containers:
+          - name: runner
+            image: daviddriscoll/github-arc-runner-az-dotnet:latest@sha256:d50f9927ac4b41733e8ab25277a7266c37b4375b8f7b5668309590065cbe68b4
+            resources:
+              requests:
+                cpu: 500m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+            command: ["/home/runner/run.sh"]
+            env:
+              - name: ACTIONS_RUNNER_CONTAINER_HOOKS
+                value: /home/runner/k8s/index.js
+              - name: ACTIONS_RUNNER_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+                value: "true"
+            volumeMounts:
+              - name: work
+                mountPath: /home/runner/_work
+        volumes:
+          - name: work

--- a/kubernetes/apps/github-actions/runners/base/kustomization.yaml
+++ b/kubernetes/apps/github-actions/runners/base/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/kubernetes/apps/github-actions/runners/david-driscoll/ks.yaml
+++ b/kubernetes/apps/github-actions/runners/david-driscoll/ks.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app david-driscoll
+  namespace: &namespace github-actions
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: gha-arc-controller
+      namespace: github-actions
+    - name: gha-repositories
+      namespace: github-actions
+  path: ./kubernetes/apps/github-actions/runners/david-driscoll
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/github-actions/runners/david-driscoll/kustomization.yaml
+++ b/kubernetes/apps/github-actions/runners/david-driscoll/kustomization.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ./secret.yaml
+patches:
+  - target:
+      kind: HelmRelease
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: david-driscoll-runners
+      - op: replace
+        path: /spec/values/fullnameOverride
+        value: david-driscoll-runners
+      - op: replace
+        path: /spec/values/runnerScaleSetName
+        value: david-driscoll-runners
+      - op: replace
+        path: /spec/values/maxRunners
+        value: 2
+      - op: replace
+        path: /spec/values/minRunners
+        value: 0
+      # Repo-scoped, NOT account-scoped. `david-driscoll` is a User account, not
+      # an org, so a bare account URL makes ARC register against
+      # /orgs/david-driscoll/... which 404s and crash-loops the listener.
+      # Personal accounts only support repo-level runners — one scale set per
+      # repo. See ./vault for the sibling that serves the crew issue tracker.
+      - op: replace
+        path: /spec/values/githubConfigUrl
+        value: https://github.com/david-driscoll/crew
+      - op: replace
+        path: /spec/values/githubConfigSecret
+        value: david-driscoll-github-app

--- a/kubernetes/apps/github-actions/runners/david-driscoll/secret.yaml
+++ b/kubernetes/apps/github-actions/runners/david-driscoll/secret.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR.
+#
+# The ARC scale set reads this Secret through `githubConfigSecret`, which
+# requires the exact keys github_app_id / github_app_installation_id /
+# github_app_private_key. All seven of the operator's keys exist in OpenBao
+# under identical names, so no rewrite and no template are needed.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: david-driscoll-github-app
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: david-driscoll-github-app
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Github Actions Runner (david-driscoll)
+        key: shared/github-actions-runner-david-driscoll

--- a/kubernetes/apps/github-actions/runners/kustomization.yaml
+++ b/kubernetes/apps/github-actions/runners/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./david-driscoll/ks.yaml
+  - ./littles-tech/ks.yaml
+  - ./littles-tech-release/ks.yaml
+  - ./vault/ks.yaml

--- a/kubernetes/apps/github-actions/runners/littles-tech-release/ks.yaml
+++ b/kubernetes/apps/github-actions/runners/littles-tech-release/ks.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app littles-tech-release
+  namespace: &namespace github-actions
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: gha-arc-controller
+      namespace: github-actions
+    - name: littles-tech
+      namespace: github-actions
+  path: ./kubernetes/apps/github-actions/runners/littles-tech-release
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/github-actions/runners/littles-tech-release/kustomization.yaml
+++ b/kubernetes/apps/github-actions/runners/littles-tech-release/kustomization.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - target:
+      kind: HelmRelease
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: littles-tech-release-runners
+      - op: replace
+        path: /spec/values/githubConfigUrl
+        value: https://github.com/littlestechnology
+      - op: replace
+        path: /spec/values/githubConfigSecret
+        value: littles-tech-github-app
+      - op: replace
+        path: /spec/values/fullnameOverride
+        value: littles-tech-release-runners
+      - op: replace
+        path: /spec/values/runnerScaleSetName
+        value: littles-tech-release-runners
+      - op: replace
+        path: /spec/values/maxRunners
+        value: 3
+      - op: replace
+        path: /spec/values/minRunners
+        value: 1

--- a/kubernetes/apps/github-actions/runners/littles-tech/ks.yaml
+++ b/kubernetes/apps/github-actions/runners/littles-tech/ks.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app littles-tech
+  namespace: &namespace github-actions
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: gha-arc-controller
+      namespace: github-actions
+    - name: gha-repositories
+      namespace: github-actions
+  path: ./kubernetes/apps/github-actions/runners/littles-tech
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/github-actions/runners/littles-tech/kustomization.yaml
+++ b/kubernetes/apps/github-actions/runners/littles-tech/kustomization.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ./secret.yaml
+patches:
+  - target:
+      kind: HelmRelease
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: littles-tech-runners
+      - op: replace
+        path: /spec/values/githubConfigUrl
+        value: https://github.com/littlestechnology
+      - op: replace
+        path: /spec/values/githubConfigSecret
+        value: littles-tech-github-app
+      - op: replace
+        path: /spec/values/fullnameOverride
+        value: littles-tech-runners
+      - op: replace
+        path: /spec/values/runnerScaleSetName
+        value: littles-tech-runners
+      - op: replace
+        path: /spec/values/maxRunners
+        value: 4
+      - op: replace
+        path: /spec/values/minRunners
+        value: 1
+      - op: add
+        path: /spec/values/template/spec/containers/0/resources/limits/memory
+        value: "8Gi"
+      - op: add
+        path: /spec/values/template/spec/containers/0/resources/requests/cpu
+        value: "2"
+      - op: add
+        path: /spec/values/template/spec/containers/0/resources/requests/memory
+        value: "3Gi"

--- a/kubernetes/apps/github-actions/runners/littles-tech/secret.yaml
+++ b/kubernetes/apps/github-actions/runners/littles-tech/secret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR. Same shape as the
+# ./david-driscoll runner set; all seven keys exist in OpenBao under identical
+# names. Also read by the ../littles-tech-release overlay.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: littles-tech-github-app
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: littles-tech-github-app
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Github Actions Runner (littles-tech)
+        key: shared/github-actions-runner-littles-tech

--- a/kubernetes/apps/github-actions/runners/vault/ks.yaml
+++ b/kubernetes/apps/github-actions/runners/vault/ks.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vault
+  namespace: &namespace github-actions
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: gha-arc-controller
+      namespace: github-actions
+    - name: gha-repositories
+      namespace: github-actions
+  path: ./kubernetes/apps/github-actions/runners/vault
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/github-actions/runners/vault/kustomization.yaml
+++ b/kubernetes/apps/github-actions/runners/vault/kustomization.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ./secret.yaml
+patches:
+  - target:
+      kind: HelmRelease
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: vault-runners
+      - op: replace
+        path: /spec/values/fullnameOverride
+        value: vault-runners
+      - op: replace
+        path: /spec/values/runnerScaleSetName
+        value: vault-runners
+      - op: replace
+        path: /spec/values/maxRunners
+        value: 2
+      - op: replace
+        path: /spec/values/minRunners
+        value: 0
+      # Repo-scoped: `david-driscoll` is a User account, not an org, so runners
+      # can only register per-repo. vault is the crew's private issue tracker
+      # and the only repo whose workflows need a runner — crew-claude.yml runs
+      # here and checks out the other estate repos via an app token.
+      - op: replace
+        path: /spec/values/githubConfigUrl
+        value: https://github.com/david-driscoll/vault
+      - op: replace
+        path: /spec/values/githubConfigSecret
+        value: vault-github-app

--- a/kubernetes/apps/github-actions/runners/vault/secret.yaml
+++ b/kubernetes/apps/github-actions/runners/vault/secret.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 6 — converted from a OnePasswordItem CR.
+#
+# Same GitHub App as the ./david-driscoll scale set — a dedicated resource
+# (rather than reusing that overlay's Secret) keeps this overlay
+# self-contained, so pruning one runner set cannot break the other.
+#
+# The app installation MUST include david-driscoll/vault with
+# `Administration: read & write` (or Self-hosted runners), or the listener
+# will 404 on the runner registration-token call.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: vault-github-app
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: vault-github-app
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Github Actions Runner (david-driscoll)
+        key: shared/github-actions-runner-david-driscoll


### PR DESCRIPTION
## What

Copies `kubernetes/apps/github-actions` verbatim from `equestria-cluster` (1password/syndicates, ARC controller, repositories, and the four runner scale sets), as part of the namespace-by-namespace repo consolidation ([vault#84](https://github.com/david-driscoll/vault/issues/84) piece 21, Phase A).

Nested `Kustomization`s' `sourceRef.name` changed from `flux-system` to `home-operations` (7 files), matching the proven pattern.

## Companion PR

david-driscoll/equestria-cluster#3154 — **merge this PR first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)