### PR TITLE
feat(kube-system): add kube-system namespace tree (repo consolidation piece 21)

### DIFF
--- a/kubernetes/apps/kube-system/1password/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/1password/helmrelease.yaml
@@ -1,0 +1,71 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: onepassword-connect
+spec:
+  chart:
+    spec:
+      chart: connect
+      version: 2.4.1
+      sourceRef:
+        kind: HelmRepository
+        name: 1password
+        namespace: flux-system
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    connect:
+      applicationName: onepassword-connect
+      host: onepassword-connect
+      annotations:
+        reloader.stakater.com/auto: "true"
+      serviceAnnotations:
+        reloader.stakater.com/auto: "true"
+      api:
+        serviceMonitor:
+          enabled: true
+          interval: 30s
+          path: "/metrics"
+          params: {}
+          annotations: {}
+
+      credentialsName: onepassword-connect
+      credentialsKey: 1password-credentials.json
+      imagePullPolicy: IfNotPresent
+      ingress:
+        enabled: true
+        ingressClassName: internal
+        annotations:
+          reloader.stakater.com/auto: "true"
+          external-dns.alpha.kubernetes.io/target: "${INTERNAL_DOMAIN}"
+          traefik.ingress.kubernetes.io/router.entrypoints: websecure
+        hosts:
+          - host: "op-connect.${CLUSTER_DOMAIN}"
+    operator:
+      create: true
+      autoRestart: true
+      imagePullPolicy: IfNotPresent
+      pollingInterval: 600
+      token:
+        name: onepassword-connect
+        key: access-token

--- a/kubernetes/apps/kube-system/1password/httproute.yaml
+++ b/kubernetes/apps/kube-system/1password/httproute.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: onepassword-connect
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+      kind: Gateway
+  hostnames:
+    - op-connect.${CLUSTER_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: onepassword-connect
+          port: 8080

--- a/kubernetes/apps/kube-system/1password/ks.yaml
+++ b/kubernetes/apps/kube-system/1password/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app onepassword-connect
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/1password
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/1password/kustomization.yaml
+++ b/kubernetes/apps/kube-system/1password/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  # - ./httproute.yaml
+  - ./secret.sops.yaml
+  - ./uptime.yaml

--- a/kubernetes/apps/kube-system/1password/secret.sops.yaml
+++ b/kubernetes/apps/kube-system/1password/secret.sops.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect
+  annotations:
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reloader.stakater.com/auto: "true"
+stringData:
+  access-token: ENC[AES256_GCM,data:e7UOrWxz2vaEkkM1guiRjexd7AJE2CUaMiwE/X33xWn+mamEkX5k436VYLlEGOszJbCit2UYAzniSo0zhl5Yj6K/UP91IAo8Qp7yS/TyzRwW7zDTMcSzyfdFuLsSt3S/IQELI2CZtkPykq3H+XvBJQDDjwReGmWnVIScJUzOoUuAoElZkE29Dlv9EAd547XMUWTp3j8/wfRsq8XLYCiCvT25bS4W2noX/o1BpaTnIhsboCrftn/UvRm0bk24W3LmVmreFYU5+2n17iQc1ZEKJnl6tXoyc6MlW13+eac2EzMYez2M78ZH9n2iOZ8kicfDPU6coQGimsoQQqwYcvzFlZfdfLGOA6AKAVyJ3lUfNNaObbqQPe6n/GA7OPLcHMF6Xf677u4IghVXswU7mNDaXDh1E4OPXAcRdKwNORq5QqLUoHDZI358SI8TTkZMXRrIsyOMvtriLEgZuKtcnLOtDcV/54ZbsACJDEAtdTPXsXRQ67Ydp5zv5EXzI1q0VEO3Jj9AQvlu/YlD3XwoY7fztexniqt4l5FizYRkKTYbH4a+5mfN0xOjfGTlMD5KwhlPpZn8mTHQk+RIUWynGQ5e6E26QoIdf7TWi6oGOL2n7myHRBSczFo5eyLDTwUojzyRQ2RaA5Vnpm5SC7/Xoj1RaWtaY/lNTzlT+egMC8sbN1nDGpAv9BGm46h2YnxJRNXbSL762u6coL3dpzNA/Qc3XbhFOzLI3XP2ZDpzKaEsA28/w1JdkWYph1Xw+X+W3aMnZAL7FhdTk4MNVSBvBcg9LKT8n7Ve2PajAZsI/8ATZDj4vn91kJsmFKn8BRYI1qrOZKrgmi3lO9wjX1/Wc4H7U8082w==,iv:fR02X52dVcjbQGvjD7WW4m8HF6T46tsrMFVgSOJg+Xc=,tag:OgjFyOIZe0JlHKPzoOrL1Q==,type:str]
+  1password-credentials.json: ENC[AES256_GCM,data:vlmXeomYymLxVoMOxVw62z5g442sWLO4XYYwh8+7115eFzNZiP1XwMHjLa7AtbmvPuNXWwa91JzaztTrUmX9+HDTNN5U3VzUrF9gxQkYP3XqZJXjTV5vtMuQb3W326IiUfQAhsM0I+/I/tl5aMR7O7sWFtWHwftuEriRigoZBbIpEToW1c/DhRwfk4CxrH9pHaogl0XuPY9z3Zu6UUBJJkmEL/QOKWl5tZbhTk97jdcs7ObVtD/p6FSLKAJ/ad6yBWg69Mku3XLwpfy0UtcpldLJIHB9UTTaJ9CJM5lyV86BdF7C2tZz4f6fqI9hDA7MvGeSpEWCyxJ0RgxXoBQazbQp79br/XlfztdJyf6r+X7wx1qbaAq6yfLmugszdcpD7yZQZ7TtlMxTBD45n894DlBbkDcVU97yRf+3KhI3pnXmkSKWeuIHydmPIMMTUgjHu01ReRLHlN6BQWFViWiqZpNTaflvPvHRqk2ZhCTyNsGbmW/wmhijYSSs7FFbWyJY9dFhNdRViRsMcV2yvfpHuZF62Y9rEb6AjsnW6RNSM9E2nkAgo+EQW9wY74vw+C/m2IxmbfRQECcgxk74uhFg4WKZBo5AwwxJwVO1JTmgoadUPV/ZmkvpyINe+uqPKgRMPLR000ZgL58ER+PU3C1l4CMYSBqyunzTsAqXBzvPJ2Qiopn5l2+ErPy5A8PDG4qZcGC6tfayJaSbEHUODH/7INwviyXDy0UalI1fV5YEk9Mnit1fc+duPyUWQ5Q9DbLN60hR0MqbqIJJqejk2b5MaFwBf/LWiMnc3UGEQUNeUpYC3sr9vrJSPRwGlrjQ5TuWloBIQOtcTWVIf487gUImiNOKjW+E0qZAYL89D5TrNoh26/2l4oNm4j5A0A3y1/jJMzvoxhyCkdOyWCEm/Pqih2L/GMzU4adwmM92mbOivYn1hdJ2XOIrEAIpxoaXjeD0uVEubA0lzsZFslchfqw9YAcjhPymVZFviljEAn8gIMssPBNadT+VNb2IpnQY7capVp3XqV12aZYfhiDKpIP9/0Iv6zNRDoNzzaF3gRSEjK2fV8JU7AAvtZUqPHwWmczHZotpvFKqxOvqM/TD6mNCZAO0nFvxEsHlJ+03Tnd7vKjG+wFSvS55CRVTSaOirUkEG+5/PX/0RljvioVxtf/9PNo3jSw5RNrMXu2PsILWgWIQjQv8emUQEW58EwBT+ccL+LSwLYAZ81Uz6VB3NxlzXPGsQmkcUJ9mnctHna0Yyt7q9/IcVAtdM9MH6pN7MRdVrJ0Ey47MuYLZ5fTzn/ImPTTSb2uhxYhzaGySlfo6vZoxOazGEVWhaR8DWPF2wWWsAo/Ct+KK2I3SGJeD/BbnRjK54hZr1E5lQi8StcexJ2BliHLaL8bLWoqjN1oKG8MU7tlBZJi+ZtyjJnVNuVBez2UntQmY34KaeTkM/3w6+BA=,iv:gQwuo3G0ijmJ/Td/0XqTCYcQjG1P7b8Yaag8NVS6wfQ=,tag:2RXxN1AdNpPyChTfOkX3rw==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrUFBjcisxTStoUjFZaWx1
+        TGR3RWErNlRyMlhPVmFPdGF0T3VGbGVrVW53CjU4bHo2UnlxOEpYWWd5YVR2L2Vh
+        OTJyZ1B0TkhFNko5eFFwVkhoZWgxOGMKLS0tIDRIZ0w4V2VWcEprZGRKOHJXQ253
+        emdwZjFNdVBFL2RCYVJ2ZnhlendWUGMKZew8wt2T1e9sjd1kd84i/BjjFLTOsV6H
+        8eJ1oCIRRTHLhw1K+8VYQvXJjdS2rwt7+wG3rVfFVRGcJxohTKp3sg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBub3dKM05FQXhDMFMwdWpw
+        NnVVcnVhNzFZVUJuK05oZVZXOU5FajB3SVh3ClJmM3hMWmhUYTF3cU03UVNoMExZ
+        NHRqcjlLeGh4ekxoRUh1YkxZWlBqd2cKLS0tIHlnOGN4Rk1Eckl5V0V3ZWZhdFBj
+        YlQ1UGFjMWZCMHpGZUhQcENJamV5WncK/ol6oA3PdtqaIVMSsJRMJT7HukskuGDz
+        g4Aw2ebmUqr25rIgT8IdahuptXQnACtViGPTvRa/LvJi6dXj1BXORA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-03-07T02:51:46Z"
+  mac: ENC[AES256_GCM,data:twFkmSIA3+ifgbSTMsftLTXAH77pZwisBFZ00MncKiPiyyiYjiXCDaZCTeplsw0D1MeISBX+XRRrHaQ16QxdOzeVLBb4J/jZu4LBwMmKQJGgXyZeJjweSWV/lS/TNSNaYU5Pl4Nl2PXARHyJ+ut1uQJmBoR5c69ZvWfpU8JVCp4=,iv:6Q2zsqz3hsVkUEP4Ko+B6/jlAFPPjw322CddK8rPjHM=,tag:XJDEmV8iGvaTb/G3W967ZQ==,type:str]
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/kube-system/1password/uptime.yaml
+++ b/kubernetes/apps/kube-system/1password/uptime.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: 1Password Connect
+  category: ${CLUSTER_TITLE}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/1password.svg
+  access_policy:
+    groups:
+      - admins
+  gatus:
+    - group: "System"
+      url: https://op-connect.${CLUSTER_DOMAIN}/health
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/kube-system/cilium/definition.yaml
+++ b/kubernetes/apps/kube-system/cilium/definition.yaml
@@ -1,0 +1,25 @@
+# ---
+# # yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+# apiVersion: driscoll.dev/v1
+# kind: ApplicationDefinition
+# metadata:
+#   name: ${APP}
+# spec:
+#   name: Cilium Hubble
+#   category: ${CLUSTER_TITLE}
+#   description: Access to the Cilium Hubble dashboard
+#   url: &url https://hubble.${CLUSTER_DOMAIN}
+#   icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/cilium.svg
+#   access_policy:
+#     groups:
+#       - admins
+#   authentik:
+#     proxy:
+#       mode: "forward_single"
+#       externalHost: *url
+#   gatus:
+#     - group: *category
+#       url: *url
+#       method: GET
+#       conditions:
+#         - "[STATUS] == 200"

--- a/kubernetes/apps/kube-system/cilium/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/kube-system/cilium/helm/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/kubernetes/apps/kube-system/cilium/helm/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/helm/values.yaml
@@ -1,0 +1,106 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/cilium/cilium/refs/tags/v1.19.3/install/kubernetes/cilium/values.schema.json
+# Ref: https://docs.cilium.io/en/stable/operations/upgrade/#version-specific-notes
+# Required for safe upgrades from pre-1.19 versions to minimize datapath disruption
+upgradeCompatibility: "1.18"
+autoDirectNodeRoutes: true
+bpf:
+  masquerade: true
+  # Ref: https://github.com/siderolabs/talos/issues/10002
+  hostLegacyRouting: true
+cni:
+  # Required for pairing with Multus CNI
+  exclusive: false
+cgroup:
+  automount:
+    enabled: false
+  hostRoot: /sys/fs/cgroup
+# NOTE: devices might need to be set if you have more than one active NIC on your hosts
+# devices: eno+ eth+
+endpointRoutes:
+  enabled: true
+envoy:
+  enabled: false
+dashboards:
+  enabled: true
+hubble:
+  enabled: true
+  relay:
+    enabled: false
+  metrics:
+    enabled:
+      - dns
+      - drop
+      - flow
+      - icmp
+      - iperf3
+      - l7
+      - tcp
+      - udp
+    dashboards:
+      enabled: true
+    enableOpenMetrics: true
+    serviceMonitor:
+      enabled: true
+  ui:
+    enabled: false
+    ingress:
+      enabled: true
+      ingressClassName: internal
+      annotations:
+        external-dns.alpha.kubernetes.io/target: "${INTERNAL_DOMAIN}"
+        external-dns.alpha.kubernetes.io/hostname: hubble.${CLUSTER_DOMAIN}
+        traefik.ingress.kubernetes.io/router.entrypoints: websecure
+      hosts:
+        - hubble.${CLUSTER_DOMAIN}
+ipam:
+  mode: kubernetes
+ipv4NativeRoutingCIDR: "${CLUSTER_NETWORK}"
+k8sServiceHost: 127.0.0.1
+k8sServicePort: 7445
+kubeProxyReplacement: true
+kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
+l2announcements:
+  enabled: true
+loadBalancer:
+  algorithm: maglev
+  mode: dsr
+localRedirectPolicy: true
+operator:
+  dashboards:
+    enabled: true
+  prometheus:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+  replicas: 1
+  rollOutPods: true
+prometheus:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    trustCRDsExist: true
+rollOutCiliumPods: true
+routingMode: native
+securityContext:
+  capabilities:
+    ciliumAgent:
+      - CHOWN
+      - KILL
+      - NET_ADMIN
+      - NET_RAW
+      - IPC_LOCK
+      - SYS_ADMIN
+      - SYS_RESOURCE
+      - PERFMON
+      - BPF
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
+    cleanCiliumState:
+      - NET_ADMIN
+      - SYS_ADMIN
+      - SYS_RESOURCE
+socketLB:
+  hostNamespaceOnly: true

--- a/kubernetes/apps/kube-system/cilium/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/helmrelease.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: cilium
+  namespace: kube-system # Required for Renovate lookups
+spec:
+  interval: 1h
+  url: https://helm.cilium.io
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app cilium
+  namespace: &namespace kube-system
+spec:
+  chart:
+    spec:
+      chart: cilium
+      version: 1.20.0
+      sourceRef:
+        kind: HelmRepository
+        name: *app
+        namespace: *namespace
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  valuesFrom:
+    - kind: ConfigMap
+      name: cilium-values

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cilium
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/cilium
+  prune: true
+  wait: false
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 15m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/cilium/kustomization.yaml
+++ b/kubernetes/apps/kube-system/cilium/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./networks.yaml
+  - ./definition.yaml
+configMapGenerator:
+  - name: cilium-values
+    files:
+      - values.yaml=./helm/values.yaml
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/kube-system/cilium/networks.yaml
+++ b/kubernetes/apps/kube-system/cilium/networks.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/cilium.io/ciliumloadbalancerippool_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: pool
+spec:
+  allowFirstLastIPs: "No"
+  blocks:
+    - start: ${LOADBALANCER_RANGE}.100
+      stop: ${LOADBALANCER_RANGE}.200
+    - start: ${LOADBALANCER_RANGE}.202
+      stop: ${LOADBALANCER_RANGE}.252
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/cilium.io/ciliuml2announcementpolicy_v2alpha1.json
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: l2-policy
+spec:
+  loadBalancerIPs: true
+  # NOTE: interfaces might need to be set if you have more than one active NIC on your hosts
+  interfaces:
+    - ^ens[0-9]+
+    - ^enp[0-9]+s[0-9]+
+    - ^eth[0-9]+
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/os: linux

--- a/kubernetes/apps/kube-system/coredns/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/kube-system/coredns/helm/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/kubernetes/apps/kube-system/coredns/helm/values.yaml
+++ b/kubernetes/apps/kube-system/coredns/helm/values.yaml
@@ -1,0 +1,135 @@
+---
+fullnameOverride: coredns
+image:
+  repository: mirror.gcr.io/coredns/coredns
+k8sAppLabelOverride: kube-dns
+serviceAccount:
+  create: true
+service:
+  name: kube-dns
+  clusterIP: "${CLUSTER_IP}"
+replicaCount: 2
+servers:
+  - zones:
+      - zone: .
+        scheme: dns://
+        use_tcp: true
+    port: 53
+    plugins:
+      - name: errors
+      - name: health
+        configBlock: |-
+          lameduck 5s
+      - name: ready
+      - name: log
+        configBlock: |-
+          class error
+      - name: prometheus
+        parameters: 0.0.0.0:9153
+      - name: kubernetes
+        parameters: cluster.local in-addr.arpa ip6.arpa
+        configBlock: |-
+          pods insecure
+          fallthrough in-addr.arpa ip6.arpa
+      - name: forward
+        parameters: . /etc/resolv.conf
+      - name: cache
+        parameters: 30
+      - name: loop
+      - name: reload
+      - name: loadbalance
+  # Technitium cluster node names: rewrite <node>.dns.driscoll.tech to the
+  # node's tailnet name (dns-<node>) and resolve it via the tailscale operator
+  # nameserver, which maps it to the in-cluster egress service ClusterIP. This
+  # is what lets the in-cluster technitium secondary reach its cluster peers
+  # (heartbeat/config sync) without hardcoded addresses.
+  - zones:
+      - zone: dns.driscoll.tech
+        scheme: dns://
+        use_tcp: false
+    port: 53
+    plugins:
+      - name: errors
+      - name: cache
+        parameters: 30
+      - name: rewrite
+        parameters: name regex ([a-z0-9-]+)\.dns\.driscoll\.tech dns-{1}.${TAILSCALE_DOMAIN} answer auto
+      - name: forward
+        parameters: . "${TAILSCALE_NAMESERVER_IP}"
+  # Dockge hosts by their canonical names: dockge-*.driscoll.tech resolves to
+  # tailnet IPs on the estate's split-horizon DNS, which cluster nodes cannot
+  # route. Same trick as the dns.driscoll.tech block above — exact-name zones,
+  # rewritten to the tailnet name and resolved via the tailscale operator
+  # nameserver to the in-cluster egress service ClusterIP
+  # (tailscale-system/services/*.yaml, which carry the matching ports).
+  # This is what lets Home Assistant use dockge-luna.driscoll.tech for the
+  # voice pipeline (llm 8080 / stt 10300 / tts 10200) and
+  # dockge-celestia.driscoll.tech for llama-agent (8081); the other two hosts
+  # get their standard 443/22 egress under the same names.
+  #
+  # Deliberately exact names rather than a driscoll.tech catch-all: the apex
+  # also carries this cluster's own *.<cluster>.driscoll.tech ingresses, other
+  # clusters' VIPs (e.g. alertmanager.driscoll.tech), and the ACME lookups
+  # cert-manager depends on. CoreDNS's rewrite has no NXDOMAIN fallthrough, so
+  # a catch-all would hard-fail every name that has no tailnet counterpart.
+  - zones:
+      - zone: dockge-celestia.driscoll.tech
+        scheme: dns://
+        use_tcp: false
+      - zone: dockge-luna.driscoll.tech
+        scheme: dns://
+        use_tcp: false
+      - zone: dockge-as.driscoll.tech
+        scheme: dns://
+        use_tcp: false
+      - zone: dockge-skystar.driscoll.tech
+        scheme: dns://
+        use_tcp: false
+    port: 53
+    plugins:
+      - name: errors
+      - name: cache
+        parameters: 30
+      - name: rewrite
+        parameters: name regex (dockge-[a-z0-9-]+)\.driscoll\.tech {1}.${TAILSCALE_DOMAIN} answer auto
+      - name: forward
+        parameters: . "${TAILSCALE_NAMESERVER_IP}"
+  # Tailscale DNS stub zone for ts.net domains
+  - zones:
+      - zone: ts.net
+        scheme: dns://
+        use_tcp: false
+    port: 53
+    plugins:
+      - name: errors
+      - name: health
+        configBlock: |-
+          lameduck 5s
+      - name: ready
+      - name: log
+        configBlock: |-
+          class all
+      - name: prometheus
+        parameters: 0.0.0.0:9153
+      - name: forward
+        parameters: . "${TAILSCALE_NAMESERVER_IP}"
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: "kubernetes.io/hostname"
+    whenUnsatisfiable: "DoNotSchedule"
+    labelSelector:
+      matchLabels:
+        k8s-app: kube-dns
+tolerations:
+  - key: CriticalAddonsOnly
+    operator: Exists
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule

--- a/kubernetes/apps/kube-system/coredns/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/helmrelease.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: coredns
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  url: oci://ghcr.io/coredns/charts/coredns
+  ref:
+    tag: 1.47.0
+    digest: sha256:e85b145c62884d3ff38143303775d58a43cd2fa02013a476785bb535bce9c9bd
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: coredns
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: coredns
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  valuesFrom:
+    - kind: ConfigMap
+      name: coredns-values

--- a/kubernetes/apps/kube-system/coredns/ks.yaml
+++ b/kubernetes/apps/kube-system/coredns/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app coredns
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/coredns
+  prune: true
+  wait: false
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/coredns/kustomization.yaml
+++ b/kubernetes/apps/kube-system/coredns/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./poddisruptionbudget.yaml
+configMapGenerator:
+  - name: coredns-values
+    files:
+      - values.yaml=./helm/values.yaml
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/kube-system/coredns/poddisruptionbudget.yaml
+++ b/kubernetes/apps/kube-system/coredns/poddisruptionbudget.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns

--- a/kubernetes/apps/kube-system/coredns/uptime.yaml
+++ b/kubernetes/apps/kube-system/coredns/uptime.yaml
@@ -1,0 +1,14 @@
+# ---
+# # yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+# apiVersion: driscoll.dev/v1
+# kind: ApplicationDefinition
+# metadata:
+#   name: ${APP}
+# spec:
+#   config:
+#     type: dns
+#     name: CoreDNS (${CLUSTER_TITLE})
+#     url: https://op-connect.${CLUSTER_DOMAIN}/health
+#     method: GET
+#     accepted_statuscodes: ["200"]
+#     parent_name: "system"

--- a/kubernetes/apps/kube-system/descheduler/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/descheduler/helmrelease.yaml
@@ -1,0 +1,83 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: descheduler
+  namespace: kube-system
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/descheduler/
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: descheduler
+  namespace: kube-system
+spec:
+  chart:
+    spec:
+      chart: descheduler
+      version: 0.36.0
+      sourceRef:
+        kind: HelmRepository
+        name: descheduler
+        namespace: kube-system
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    kind: CronJob
+    schedule: "*/2 * * * *"
+    successfulJobsHistoryLimit: 1
+    failedJobsHistoryLimit: 1
+    priorityClassName: system-cluster-critical
+    deschedulerPolicy:
+      apiVersion: "descheduler/v1alpha2"
+      kind: "DeschedulerPolicy"
+      profiles:
+        - name: DefaultProfile
+          plugins:
+            evict:
+              enabled:
+                - DefaultEvictor
+            balance:
+              enabled:
+                - RemoveDuplicates
+                - RemovePodsViolatingTopologySpreadConstraint
+                - LowNodeUtilization
+          pluginConfig:
+            - name: DefaultEvictor
+              args:
+                evictSystemCriticalPods: false
+                evictLocalStoragePods: false
+            - name: RemoveDuplicates
+            - name: RemovePodsViolatingTopologySpreadConstraint
+            - name: LowNodeUtilization
+              args:
+                thresholds:
+                  cpu: 20
+                  memory: 20
+                  pods: 20
+                targetThresholds:
+                  cpu: 50
+                  memory: 50
+                  pods: 50

--- a/kubernetes/apps/kube-system/descheduler/ks.yaml
+++ b/kubernetes/apps/kube-system/descheduler/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app descheduler
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/descheduler
+  prune: true
+  wait: false
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/descheduler/kustomization.yaml
+++ b/kubernetes/apps/kube-system/descheduler/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/etcd/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/etcd/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: talos-etcd-restic-keys
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: talos-etcd-restic-keys
+    creationPolicy: Owner
+  data:
+    - secretKey: RESTIC_PASSWORD
+      remoteRef:
+        # was: Volsync Password
+        key: shared/volsync-password
+        property: credential

--- a/kubernetes/apps/kube-system/etcd/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/etcd/helmrelease.yaml
@@ -1,0 +1,160 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app etcd-tasks
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  values:
+    controllers:
+      backup:
+        type: cronjob
+        cronjob:
+          schedule: "12 4 * * *"
+          parallelism: 1
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+
+        initContainers:
+          talosctl:
+            image:
+              repository: ghcr.io/siderolabs/talosctl
+              tag: v1.13.8@sha256:4ef662a5e264af865e9d8ce665d0d5b9073c2d08bd7e72bce27d3cce5ae1550a
+            args:
+              - --talosconfig
+              - /var/run/secrets/talos.dev/config
+              - -n
+              - "$(CP_NODE_IP)"
+              - -e
+              - "$(CP_NODE_IP)"
+              - etcd
+              - snapshot
+              - /data/etcd.snapshot
+            env:
+              - name: CP_NODE_IP
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.hostIP
+
+        containers:
+          restic:
+            image:
+              repository: ghcr.io/ahinko/restic
+              tag: 0.18.1@sha256:fa719796676a241c783aa789c0053c92dc92e5d5818722cefb03c5ce163fb904
+            workingDir: /data
+            args:
+              - backup
+              - --host
+              - kubernetes # set a consistent hostname to avoid restic rescans
+              - . # use workingDir to get relative paths in backup
+            envFrom:
+              - secretRef:
+                  name: talos-etcd-restic-keys
+            env:
+              - name: RESTIC_REPOSITORY
+                value: /repository/etcd
+
+        pod:
+          hostNetwork: true
+          hostPID: true
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: ""
+      defrag:
+        type: cronjob
+        cronjob:
+          schedule: "3 9 * * *" # daily at 09:03
+          parallelism: 1
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+
+        containers:
+          defrag:
+            image:
+              repository: ghcr.io/ahrtr/etcd-defrag
+              tag: v0.42.0@sha256:22521435b870c41f0faca42197e0b4caf37822370ebd7ec84df492d21488ede9
+            args:
+              - --endpoints=https://127.0.0.1:2379
+              - --cluster
+              - --cacert=/certs/ca.crt
+              - --cert=/certs/server.crt
+              - --key=/certs/server.key
+              # Defrag when DB quota usage > 50% OR free space > 100MB
+              - --defrag-rule=dbQuotaUsage > 0.5 || dbSizeFree > 100*1024*1024
+              # Move leader during defrag (safe for single-node)
+              - --move-leader
+              # Wait 30s between defrags
+              - --wait-between-defrags=30s
+              # Match the quota-backend-bytes set in Talos config
+              - --etcd-storage-quota-bytes=8589934592
+              # Auto-disalarm space quota alarms
+              - --auto-disalarm
+              - --disalarm-threshold=0.8
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              privileged: true
+              runAsUser: 0
+
+        pod:
+          hostNetwork: true
+          hostPID: true
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: ""
+      prune:
+        type: cronjob
+        cronjob:
+          schedule: "32 5 1 * *"
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+
+        containers:
+          restic:
+            image:
+              repository: ghcr.io/ahinko/restic
+              tag: 0.18.1@sha256:fa719796676a241c783aa789c0053c92dc92e5d5818722cefb03c5ce163fb904
+            args:
+              - forget
+              - --keep-last=7 # change me - set retention policy
+              - --keep-weekly=4 # see: https://restic.readthedocs.io/en/latest/060_forget.html
+              - --prune
+            envFrom:
+              - secretRef:
+                  name: talos-etcd-restic-keys
+            env:
+              - name: RESTIC_REPOSITORY
+                value: /repository/etcd
+    defaultPodOptions:
+      automountServiceAccountToken: true
+    persistence:
+      serviceaccount:
+        type: secret
+        name: etcd-talos
+        advancedMounts:
+          backup:
+            talosctl:
+              - path: /var/run/secrets/talos.dev
+                readOnly: true
+      certs:
+        type: hostPath
+        hostPath: /system/secrets/etcd
+        advancedMounts:
+          defrag:
+            defrag:
+              - path: /certs
+                readOnly: true
+      backupdata:
+        type: emptyDir
+        globalMounts:
+          - path: /data
+      repository:
+        type: nfs
+        server: "10.10.10.10"
+        path: "/mnt/stash/backup/${CLUSTER_CNAME}/volsync"

--- a/kubernetes/apps/kube-system/etcd/ks.yaml
+++ b/kubernetes/apps/kube-system/etcd/ks.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app etcd-backup
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/etcd
+  dependsOn:
+    - name: external-secrets
+      namespace: kube-system
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/kube-system/etcd/kustomization.yaml
+++ b/kubernetes/apps/kube-system/etcd/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./serviceaccount.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/etcd/serviceaccount.yaml
+++ b/kubernetes/apps/kube-system/etcd/serviceaccount.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-talos
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: etcd-talos
+    namespace: system-upgrade
+---
+apiVersion: talos.dev/v1alpha1
+kind: ServiceAccount
+metadata:
+  name: etcd-talos
+spec:
+  roles: ["os:admin"]

--- a/kubernetes/apps/kube-system/external-secrets/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/app/helmrelease.yaml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-secrets
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: external-secrets
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    installCRDs: true
+    image:
+      repository: ghcr.io/external-secrets/external-secrets
+    replicaCount: 1
+    log:
+      level: debug
+    leaderElect: false
+    serviceMonitor:
+      enabled: true
+    certController:
+      image:
+        repository: ghcr.io/external-secrets/external-secrets
+      serviceMonitor:
+        enabled: true
+    webhook:
+      image:
+        repository: ghcr.io/external-secrets/external-secrets
+      serviceMonitor:
+        enabled: true
+    reloader:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 128Mi
+        limits:
+          # cpu: 500m
+          memory: 512Mi

--- a/kubernetes/apps/kube-system/external-secrets/app/ks.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/app/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app external-secrets
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/external-secrets/app
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system

--- a/kubernetes/apps/kube-system/external-secrets/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ocirepository.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/kube-system/external-secrets/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: external-secrets
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 2.9.0
+    digest: sha256:3c542c7746c3ff1ab1a21c3acc7e5c0c0b48a5c651529a7c5220f3854048b393
+  url: oci://ghcr.io/external-secrets/charts/external-secrets

--- a/kubernetes/apps/kube-system/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./app/ks.yaml
+  - ./reloader/ks.yaml
+  - ./stores/ks.yaml

--- a/kubernetes/apps/kube-system/external-secrets/reloader/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/reloader/helmrelease.yaml
@@ -1,0 +1,316 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app external-secrets-reloader
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: true
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  dependsOn: []
+  values:
+    global:
+      labels:
+        app.kubernetes.io/name: *app
+        driscoll.dev/name: *app
+        control-plane: controller-manager
+
+    serviceAccount:
+      *app :
+        forceRename: &controller-manager reloader-controller-manager
+    rbac:
+      roles:
+        &election-role reloader-leader-election-role:
+          forceRename: *election-role
+          type: Role
+          rules:
+            - apiGroups:
+              - ""
+              resources:
+              - configmaps
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+            - apiGroups:
+              - coordination.k8s.io
+              resources:
+              - leases
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+            - apiGroups:
+              - ""
+              resources:
+              - events
+              verbs:
+              - create
+              - patch
+        &manager-role reloader-manager-role:
+          forceRename: *manager-role
+          type: ClusterRole
+          rules:
+          - apiGroups:
+            - ""
+            resources:
+            - secrets
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - apps
+            resources:
+            - deployments
+            verbs:
+            - get
+            - list
+            - patch
+            - update
+            - watch
+          - apiGroups:
+            - coordination.k8s.io
+            resources:
+            - leases
+            verbs:
+            - create
+            - get
+            - patch
+            - update
+          - apiGroups:
+            - external-secrets.io
+            resources:
+            - externalsecrets
+            - pushsecrets
+            verbs:
+            - get
+            - list
+            - patch
+            - update
+            - watch
+          - apiGroups:
+            - reloader.external-secrets.io
+            resources:
+            - configs
+            - configs/status
+            verbs:
+            - get
+            - list
+            - patch
+            - update
+            - watch
+          - apiGroups:
+            - reloader.external-secrets.io
+            resources:
+            - configs/finalizers
+            verbs:
+            - update
+          - apiGroups:
+            - workflows.external-secrets.io
+            resources:
+            - workflowruntemplates
+            verbs:
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        &metrics-auth-role reloader-metrics-auth-role:
+          forceRename: *metrics-auth-role
+          type: ClusterRole
+          rules:
+          - apiGroups:
+            - authentication.k8s.io
+            resources:
+            - tokenreviews
+            verbs:
+            - create
+          - apiGroups:
+            - authorization.k8s.io
+            resources:
+            - subjectaccessreviews
+            verbs:
+            - create
+        &metrics-reader reloader-metrics-reader:
+          forceRename: *metrics-reader
+          type: ClusterRole
+          rules:
+          - nonResourceURLs:
+            - /metrics
+            verbs:
+            - get
+        &editor-role reloader-editor-role:
+          forceRename: *editor-role
+          type: ClusterRole
+          rules:
+          - apiGroups:
+            - reloader.external-secrets.io
+            resources:
+            - config
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+          - apiGroups:
+            - reloader.external-secrets.io
+            resources:
+            - config/status
+            verbs:
+            - get
+        &viewer-role reloader-viewer-role:
+          forceRename: *viewer-role
+          type: ClusterRole
+          rules:
+          - apiGroups:
+            - reloader.external-secrets.io
+            resources:
+            - config
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - reloader.external-secrets.io
+            resources:
+            - config/status
+            verbs:
+            - get
+      bindings:
+        &election-rolebinding reloader-leader-election-rolebinding:
+          forceRename: *election-rolebinding
+          type: RoleBinding
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: *election-role
+          subjects:
+            - kind: ServiceAccount
+              name: *controller-manager
+              namespace: ${NAMESPACE}
+        &manager-rolebinding reloader-manager-rolebinding:
+          forceRename: *manager-rolebinding
+          type: ClusterRoleBinding
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: *manager-role
+          subjects:
+            - kind: ServiceAccount
+              name: *controller-manager
+              namespace: ${NAMESPACE}
+        &metrics-auth-rolebinding reloader-metrics-auth-rolebinding:
+          forceRename: *metrics-auth-rolebinding
+          type: ClusterRoleBinding
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: *metrics-auth-role
+          subjects:
+            - kind: ServiceAccount
+              name: *controller-manager
+              namespace: ${NAMESPACE}
+    service:
+      &metrics-service reloader-controller-manager-metrics-service:
+        forceRename: *metrics-service
+        ports:
+          https:
+            port: 8443
+            protocol: TCP
+            targetPort: 8443
+      &manager-socket reloader-controller-manager-socket:
+        forceRename: *manager-socket
+        ports:
+          sock:
+            port: 8000
+            protocol: TCP
+            targetPort: 8000
+      &webhook-service reloader-controller-manager-webhook:
+        forceRename: *webhook-service
+        ports:
+          http:
+            port: 8090
+            protocol: TCP
+            targetPort: 8090
+
+    controllers:
+      *app :
+        replicas: 1
+        pod:
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 30
+          automountServiceAccountToken: true
+        containers:
+          manager:
+            args:
+            - --metrics-bind-address=:8443
+            - --leader-elect
+            - --health-probe-bind-address=:8081
+            command:
+            - /bin/reloader
+            image:
+              repository: ghcr.io/external-secrets-inc/reloader
+              tag: 0.0.5-29.gfb00e3b@sha256:1a7d0fc9fe831c265420bc1fb3af297ad03a599c4802956c97d6e2de9deeabbf
+            probes:
+              liveness:
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+              readiness:
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                # cpu: 100m
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              runAsNonRoot: true
+        serviceAccount:
+          name: *controller-manager

--- a/kubernetes/apps/kube-system/external-secrets/reloader/ks.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/reloader/ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app external-secrets-reloader
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/external-secrets/reloader
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  dependsOn:
+    - name: external-secrets
+      namespace: kube-system
+    - name: onepassword-connect
+      namespace: kube-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/external-secrets/reloader/kustomization.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/reloader/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+  - ./helmrelease.yaml
+  - ./reloader.yaml

--- a/kubernetes/apps/kube-system/external-secrets/reloader/reloader.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/reloader/reloader.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: reloader.external-secrets.io/v1alpha1
+kind: Config
+metadata:
+  name: ${APP}-reloader
+spec:
+  notificationSources:
+    - type: KubernetesSecret
+      kubernetesSecret:
+        ## Watch secrets internal to the cluster
+        serverURL: https://kubernetes.default.svc
+  destinationsToWatch:
+  ## Trigger rollout to any deployments using them
+  - type: Deployment
+    deployment:
+      labelSelectors:
+        matchLabels: {}
+  ## Trigger rollout to any external-secrets using them
+  - type: ExternalSecret
+    externalSecret:
+      labelSelectors:
+        matchLabels: {}

--- a/kubernetes/apps/kube-system/external-secrets/stores/ks.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app external-secrets-stores
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/external-secrets/stores
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  dependsOn:
+    - name: external-secrets
+      namespace: kube-system
+    - name: onepassword-connect
+      namespace: kube-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/external-secrets/stores/kubernetes.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/kubernetes.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernetes-external-secrets
+rules:
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - selfsubjectrulesreviews
+  verbs:
+  - create
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-secrets
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubernetes-external-secrets
+subjects:
+- kind: ServiceAccount
+  name: external-secrets
+  namespace: kube-system
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/external-secrets.io/clustersecretstore_v1.json
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: backup
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: backup
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          namespace: kube-system
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: "external-secrets"
+          namespace: kube-system
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/external-secrets.io/clustersecretstore_v1.json
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: database
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: database
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          namespace: kube-system
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: "external-secrets"
+          namespace: kube-system
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/external-secrets.io/clustersecretstore_v1.json
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: network
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: network
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          namespace: kube-system
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: "external-secrets"
+          namespace: kube-system
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/external-secrets.io/clustersecretstore_v1.json
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: cluster
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: ${CLUSTER_CNAME}
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          namespace: kube-system
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: "external-secrets"
+          namespace: kube-system

--- a/kubernetes/apps/kube-system/external-secrets/stores/kustomization.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./onepassword-store.yaml
+  - ./openbao-store.yaml
+  - ./kubernetes.yaml

--- a/kubernetes/apps/kube-system/external-secrets/stores/onepassword-store.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/onepassword-store.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/external-secrets.io/clustersecretstore_v1.json
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-connect
+spec:
+  provider:
+    onepassword:
+      connectHost: http://onepassword-connect.kube-system.svc.cluster.local:8080
+      vaults:
+        Eris: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect
+            key: access-token
+            namespace: kube-system

--- a/kubernetes/apps/kube-system/external-secrets/stores/openbao-store.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/openbao-store.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/external-secrets.io/clustersecretstore_v1.json
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: openbao
+spec:
+  provider:
+    vault:
+      # openbao-active, not openbao: the chart labels the leader pod and this
+      # Service selects only it. The general `openbao` Service also routes to
+      # standbys, which answer reads with a 307 redirect to the leader — extra
+      # hops for no benefit, and a source of confusing intermittent failures.
+      server: http://openbao-active.kube-system.svc.cluster.local:8200
+      # The kv-v2 mount holding real secrets. `docs/` and `meta/` are separate
+      # mounts and would each need their own store if anything ever consumes
+      # them from in-cluster (nothing does today — see PLAN.md §A).
+      path: secrets
+      version: v2
+      auth:
+        # Kubernetes auth rather than a stored token or AppRole: ESO presents
+        # its own ServiceAccount token and OpenBao validates it against the
+        # cluster's API. Nothing to rotate and nothing to leak, and it is why
+        # OpenBao lives in kube-system alongside ESO.
+        kubernetes:
+          mountPath: kubernetes
+          # Bound in OpenBao to this exact ServiceAccount + namespace, and
+          # carries the `eso-equestria` policy: read on secrets/shared/* and
+          # secrets/clusters/equestria/*. See vault:bootstrap/openbao/equestria-init.sh.
+          role: eso-equestria
+          serviceAccountRef:
+            name: external-secrets
+            namespace: kube-system

--- a/kubernetes/apps/kube-system/features/amd/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/features/amd/helmrelease.yaml
@@ -1,0 +1,61 @@
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: amd-device-plugin
+  namespace: kube-system
+spec:
+  interval: 1h
+  url: https://rocm.github.io/k8s-device-plugin/
+  timeout: 3m
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: amd
+handler: amd
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app amd-device-plugin
+  namespace: &namespace kube-system
+spec:
+  chart:
+    spec:
+      chart: amd-gpu
+      version: 0.21.0
+      sourceRef:
+        kind: HelmRepository
+        name: *app
+        namespace: *namespace
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    labeller:
+      enabled: true
+    nfd:
+      enabled: false
+    securityContext:
+      allowPrivilegeEscalation: true
+    node_selector_enabled: true

--- a/kubernetes/apps/kube-system/features/amd/ks.yaml
+++ b/kubernetes/apps/kube-system/features/amd/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app amd-device-plugin
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/features/amd
+  prune: true
+  wait: false
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system

--- a/kubernetes/apps/kube-system/features/amd/kustomization.yaml
+++ b/kubernetes/apps/kube-system/features/amd/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/features/intel-gpu/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/features/intel-gpu/helmrelease.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: intel-device-plugins-gpu
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.34.1
+  url: oci://ghcr.io/home-operations/charts-mirror/intel-device-plugins-gpu
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: intel-gpu-plugin
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: intel-device-plugins-gpu
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    name: intel-gpu-plugin
+    nodeFeatureRule: true
+    sharedDevNum: 5 # Allow 5 containers per GPU (10 total slots across 2 nodes)
+    allocationPolicy: balanced # Spread workloads evenly across available GPUs

--- a/kubernetes/apps/kube-system/features/intel-gpu/ks.yaml
+++ b/kubernetes/apps/kube-system/features/intel-gpu/ks.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app intel-device-plugin-gpu
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: intel-device-plugin-operator
+      namespace: kube-system
+  healthCheckExprs:
+    - apiVersion: deviceplugin.intel.com/v1
+      kind: GpuDevicePlugin
+      failed: status.desiredNumberScheduled != status.numberReady
+      current: status.desiredNumberScheduled == status.numberReady
+  path: ./kubernetes/apps/kube-system/features/intel-gpu
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/features/intel-gpu/kustomization.yaml
+++ b/kubernetes/apps/kube-system/features/intel-gpu/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/features/intel/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/features/intel/helmrelease.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: intel-device-plugins-operator
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.34.1
+  url: oci://ghcr.io/home-operations/charts-mirror/intel-device-plugins-operator
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: intel-device-plugin-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: intel-device-plugins-operator
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    manager:
+      devices:
+        gpu: true

--- a/kubernetes/apps/kube-system/features/intel/ks.yaml
+++ b/kubernetes/apps/kube-system/features/intel/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app intel-device-plugin-operator
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/features/intel
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system

--- a/kubernetes/apps/kube-system/features/intel/kustomization.yaml
+++ b/kubernetes/apps/kube-system/features/intel/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/features/kustomization.yaml
+++ b/kubernetes/apps/kube-system/features/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./node-feature-discovery/ks.yaml
+  - ./amd/ks.yaml
+  - ./nvidia/ks.yaml
+  - ./intel/ks.yaml
+  - ./intel-gpu/ks.yaml

--- a/kubernetes/apps/kube-system/features/node-feature-discovery/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/features/node-feature-discovery/helmrelease.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: node-feature-discovery
+  namespace: kube-system
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app node-feature-discovery
+  namespace: &namespace kube-system
+spec:
+  chart:
+    spec:
+      chart: node-feature-discovery
+      version: 0.19.0
+      interval: 1h
+      sourceRef:
+        kind: HelmRepository
+        name: *app
+        namespace: *namespace
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false

--- a/kubernetes/apps/kube-system/features/node-feature-discovery/ks.yaml
+++ b/kubernetes/apps/kube-system/features/node-feature-discovery/ks.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app node-feature-discovery
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/features/node-feature-discovery
+  prune: true
+  wait: false
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace

--- a/kubernetes/apps/kube-system/features/node-feature-discovery/kustomization.yaml
+++ b/kubernetes/apps/kube-system/features/node-feature-discovery/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/features/nvidia/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/features/nvidia/helmrelease.yaml
@@ -1,0 +1,59 @@
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: nvidia-device-plugin
+  namespace: kube-system
+spec:
+  interval: 1h
+  url: https://nvidia.github.io/k8s-device-plugin
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: nvidia
+handler: nvidia
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app nvidia-device-plugin
+  namespace: &namespace kube-system
+spec:
+  chart:
+    spec:
+      chart: nvidia-device-plugin
+      version: 0.19.3
+      interval: 1h
+      sourceRef:
+        kind: HelmRepository
+        name: *app
+        namespace: *namespace
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    gfd:
+      enabled: true
+    nfd:
+      enabled: false
+    runtimeClassName: nvidia

--- a/kubernetes/apps/kube-system/features/nvidia/ks.yaml
+++ b/kubernetes/apps/kube-system/features/nvidia/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app nvidia-device-plugin
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/features/nvidia
+  prune: true
+  wait: false
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system

--- a/kubernetes/apps/kube-system/features/nvidia/kustomization.yaml
+++ b/kubernetes/apps/kube-system/features/nvidia/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+components:
+  - ../../components/alerts
+  - ../../components/common
+  - ../../components/repos/app-template
+resources:
+  - ./1password/ks.yaml
+  - ./cilium/ks.yaml
+  - ./coredns/ks.yaml
+  - ./descheduler/ks.yaml
+  - ./metrics-server/ks.yaml
+  - ./reloader/ks.yaml
+  - ./features
+  - ./secrets
+  - ./spegel/ks.yaml
+  - ./reflector/ks.yaml
+  - ./snapshot-controller/ks.yaml
+  - ./external-secrets
+  - ./registry/ks.yaml
+  - ./etcd/ks.yaml
+  - ./headlamp/ks.yaml
+  - ./multus/ks.yaml
+  - ./openbao/ks.yaml
+  - ./openbao-replica/ks.yaml
+  - ./vsc-retention/ks.yaml

--- a/kubernetes/apps/kube-system/metrics-server/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/helmrelease.yaml
@@ -1,0 +1,57 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: metrics-server
+  namespace: kube-system
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/metrics-server
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app metrics-server
+  namespace: &namespace kube-system
+spec:
+  chart:
+    spec:
+      chart: metrics-server
+      version: 3.13.1
+      sourceRef:
+        kind: HelmRepository
+        name: *app
+        namespace: *namespace
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    args:
+      - --kubelet-insecure-tls
+      - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+      - --kubelet-use-node-status-port
+      - --metric-resolution=10s
+      - --kubelet-request-timeout=2s
+    metrics:
+      enabled: true
+    serviceMonitor:
+      enabled: true

--- a/kubernetes/apps/kube-system/metrics-server/ks.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app metrics-server
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/metrics-server
+  prune: true
+  wait: false
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/metrics-server/kustomization.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/multus/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/multus/helmrelease.yaml
@@ -1,0 +1,59 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: multus
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.3.2
+  url: oci://ghcr.io/bjw-s-labs/helm/multus
+  verify:
+    provider: cosign
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app multus
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: multus
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: true
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  dependsOn: []
+  values:
+    cni-plugins:
+      image:
+        repository: ghcr.io/home-operations/cni-plugins
+        tag: 1.9.1@sha256:8ed5338f49966ca08b79d4ca754bc16af449b5375867f922890a680da2a4402d
+      # resources: {}
+
+    multus:
+      image:
+        repository: ghcr.io/k8snetworkplumbingwg/multus-cni
+        tag: v4.3.0@sha256:ec4e5dfe12b675e4dcbf4e9cd14892f7b4c8ac27aa0dc93cf2e9be0bdd7d764a
+      # resources: {}

--- a/kubernetes/apps/kube-system/multus/ks.yaml
+++ b/kubernetes/apps/kube-system/multus/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app multus
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/multus
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/multus/kustomization.yaml
+++ b/kubernetes/apps/kube-system/multus/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/openbao-replica/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/openbao-replica/externalsecret.yaml
@@ -1,0 +1,82 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+#
+# PG_URI for the nightly dump — the same generated `openbao-postgres` uri the
+# openbao app itself consumes, read through ClusterSecretStore/database.
+# Referenced, never copied: it rotates with the role and nothing here needs a
+# second edit (see the openbao app's externalsecret.yaml for the full
+# reasoning, including why this is not a bootstrap cycle).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openbao-replica-db
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: openbao-replica-db
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        PG_URI: "{{ .uri }}"
+  dataFrom:
+    - extract:
+        key: openbao-postgres
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+#
+# The estate's rclone SFTP client key. This is the SAME keypair
+# home-operations' DockgeLxc seeds onto every dockge host: its public half is
+# already in /opt/stacks-data/rclone-sftp/keys/authorized_keys on dockge-as,
+# which the bao-standby dump receiver mounts read-only — so shipping dumps
+# needs no new key material anywhere.
+#
+# Store ref is onepassword-connect, deliberately: 1Password stays the
+# authoritative store until Phase 11, and ClusterSecretStore/openbao does not
+# exist until the Phase 6 ESO cutover. Swap the ref then, with all the others.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openbao-replica-sftp
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  target:
+    name: openbao-replica-sftp
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        # OpenSSH refuses a key file without a trailing newline; DockgeLxc
+        # appends one for the same reason (DockgeLxc.ts:247).
+        id_ed25519: |
+          {{ .private_key }}
+  dataFrom:
+    - extract:
+        # was: Rclone SFTP Key
+        key: shared/rclone-sftp-key
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _

--- a/kubernetes/apps/kube-system/openbao-replica/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/openbao-replica/helmrelease.yaml
@@ -1,0 +1,253 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+#
+# Phase 5 break-glass replication — two cronjobs, one trust boundary:
+#
+#   dump          nightly: pg_dump the `openbao` database, age-encrypt it to
+#                 the three estate recipients, ship it to the bao-standby dump
+#                 receiver on alpha-site over SFTP, prune to 30 days.
+#
+#   restore-test  monthly: pull the newest dump BACK from alpha-site, decrypt,
+#                 restore into a scratch Postgres sidecar, start a throwaway
+#                 bao against it, let it unseal via transit, read a canary key
+#                 with a purpose-made AppRole, and report to Gatus. An
+#                 unverified backup is not a backup (RUNBOOK Scenario D).
+#
+# Both run HERE, not on alpha-site, and that placement is load-bearing: the
+# dump must never be decryptable on alpha-site alone (that host also holds the
+# transit key), so no age identity may ever land there. The cluster already
+# holds an age identity (Flux's sops-age), so decrypting here adds no new
+# exposure — and the restore test doubles as proof the dump actually left the
+# building and can be fetched back.
+#
+# Both containers use the OpenBao image: the restore test needs the `bao`
+# binary anyway, the dump job gets an image the estate already pins, and the
+# missing client tools (pg_dump/psql 17, age, rclone, curl, jq) are installed
+# at runtime — the same pattern as the postgres-backup cronjob in
+# database/postgres/backups.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app openbao-replica
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  dependsOn:
+    - name: openbao
+      namespace: kube-system
+    - name: external-secrets
+      namespace: kube-system
+  values:
+    controllers:
+      dump:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        type: cronjob
+        cronjob:
+          # PLAN §E: nightly at 03:00, an hour after the general postgres
+          # backup at 02:00 so the two never contend for the database.
+          schedule: "0 3 * * *"
+          backoffLimit: 3
+          concurrencyPolicy: Forbid
+          startingDeadlineSeconds: 300
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+          suspend: false
+        containers:
+          main:
+            image: &baoImage
+              repository: ghcr.io/openbao/openbao
+              tag: 2.6.1@sha256:5b2486ab0fb90bbc788cc345b0a08616dfb375873ee8be5df3a2fd4d378a67e0
+              pullPolicy: IfNotPresent
+            # Root: apk needs it. kube-system is a privileged-PSS namespace.
+            securityContext: &rootCtx
+              runAsUser: 0
+              runAsGroup: 0
+            envFrom:
+              # PG_URI — the generated `openbao-postgres` uri, referenced via
+              # ClusterSecretStore/database exactly like the openbao app itself.
+              - secretRef:
+                  name: openbao-replica-db
+            env:
+              SFTP_HOST: dockge-as.${TAILSCALE_DOMAIN}
+              SFTP_PORT: "2023"
+              SFTP_KEY_FILE: /secrets/sftp/id_ed25519
+              RETENTION_DAYS: "30"
+              GATUS_URL: https://uptime.${ROOT_DOMAIN}
+              # Pods have no route to the tailnet and no DNS answer for
+              # uptime.${ROOT_DOMAIN} that they can reach — Gatus is reported
+              # to through the dockge-as egress on 443, with --connect-to
+              # keeping the Host/SNI intact so Traefik routes and the LE cert
+              # validates.
+              GATUS_CONNECT_TO: uptime.${ROOT_DOMAIN}:443:dockge-as.${TAILSCALE_DOMAIN}:443
+              GATUS_TOKEN: openbao-break-glass_nightly-dump
+            command:
+              - /bin/sh
+              - -c
+              - >-
+                set -eu;
+                apk add --no-cache bash postgresql17-client age rclone curl
+                && exec bash /scripts/dump.sh
+            resources:
+              requests:
+                memory: 256Mi
+                cpu: 20m
+              limits:
+                memory: 512Mi
+                cpu: 500m
+
+      restore-test:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        type: cronjob
+        cronjob:
+          # Monthly, two hours after that night's dump.
+          schedule: "0 5 1 * *"
+          backoffLimit: 2
+          concurrencyPolicy: Forbid
+          startingDeadlineSeconds: 3600
+          successfulJobsHistory: 1
+          failedJobsHistory: 3
+          suspend: false
+        initContainers:
+          # Native sidecar (restartPolicy: Always on an init container): stays
+          # up while main runs, dies with the pod, and — unlike a plain second
+          # container — does not stop the Job from ever completing.
+          postgres:
+            image:
+              # Same major as the CNPG cluster (17.5) so the restored dump is
+              # read by the engine version that wrote it.
+              repository: docker.io/library/postgres
+              tag: 18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
+              pullPolicy: IfNotPresent
+            restartPolicy: Always
+            env:
+              # Scratch database, lives exactly as long as this pod, holds
+              # only ciphertext OpenBao already encrypted. The password guards
+              # nothing an attacker inside the pod does not already have.
+              POSTGRES_USER: &scratchUser openbao
+              POSTGRES_PASSWORD: &scratchPw restore-test
+              POSTGRES_DB: &scratchDb openbao
+            resources:
+              requests:
+                memory: 256Mi
+                cpu: 50m
+              limits:
+                memory: 1Gi
+                cpu: "1"
+        containers:
+          main:
+            image: *baoImage
+            securityContext: *rootCtx
+            env:
+              SFTP_HOST: dockge-as.${TAILSCALE_DOMAIN}
+              SFTP_PORT: "2023"
+              SFTP_KEY_FILE: /secrets/sftp/id_ed25519
+              GATUS_URL: https://uptime.${ROOT_DOMAIN}
+              GATUS_CONNECT_TO: uptime.${ROOT_DOMAIN}:443:dockge-as.${TAILSCALE_DOMAIN}:443
+              GATUS_TOKEN: openbao-break-glass_restore-test
+              # The estate age identity, from the same Secret/sops-age the
+              # common component stamps into every namespace for Flux. The
+              # cluster already holds this material; mounting it here adds no
+              # new exposure — and it is exactly the key RUNBOOK Scenario B
+              # says a human will use, so the test exercises the real path.
+              AGE_KEY_FILE: /secrets/sops-age/age.agekey
+              # A dump older than this is treated as a FAILED test even if it
+              # restores cleanly — it means replication has silently stopped
+              # and the "latest" backup is stale.
+              MAX_DUMP_AGE_DAYS: "3"
+              SCRATCH_PG_URI: postgres://openbao:restore-test@localhost:5432/openbao
+              SCRATCH_PG_USER: *scratchUser
+              SCRATCH_PG_PASSWORD: *scratchPw
+              SCRATCH_PG_DB: *scratchDb
+              # Same transit path the real cluster unseals through.
+              TRANSIT_ADDR: http://dockge-as.${TAILSCALE_DOMAIN}:8200
+              CANARY_PATH: secrets/data/shared/cloudflare-driscoll-tech
+              VAULT_TRANSIT_SEAL_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    # Owned by the openbao app — referenced, not copied, so a
+                    # re-minted token never needs a second edit here.
+                    name: openbao-seal
+                    key: transit-token
+              BAO_ROLE_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: openbao-replica-restore
+                    key: role-id
+              BAO_SECRET_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: openbao-replica-restore
+                    key: secret-id
+            command:
+              - /bin/sh
+              - -c
+              - >-
+                set -eu;
+                apk add --no-cache bash coreutils postgresql17-client age rclone curl jq
+                && exec bash /scripts/restore-test.sh
+            resources:
+              requests:
+                memory: 512Mi
+                cpu: 50m
+              limits:
+                memory: 1Gi
+                cpu: "1"
+
+    persistence:
+      scripts:
+        type: configMap
+        name: openbao-replica-scripts
+        defaultMode: 493
+        globalMounts:
+          - path: /scripts
+      sftp-key:
+        type: secret
+        name: openbao-replica-sftp
+        defaultMode: 256
+        advancedMounts:
+          dump:
+            main:
+              - path: /secrets/sftp
+          restore-test:
+            main:
+              - path: /secrets/sftp
+      sops-age:
+        type: secret
+        name: sops-age
+        defaultMode: 256
+        advancedMounts:
+          restore-test:
+            main:
+              - path: /secrets/sops-age
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      pgdata:
+        type: emptyDir
+        advancedMounts:
+          restore-test:
+            postgres:
+              - path: /var/lib/postgresql/data

--- a/kubernetes/apps/kube-system/openbao-replica/ks.yaml
+++ b/kubernetes/apps/kube-system/openbao-replica/ks.yaml
@@ -1,0 +1,59 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app openbao-replica
+  namespace: &namespace kube-system
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/openbao-replica
+  # Break-glass replication (migration Phase 5): a nightly age-encrypted
+  # pg_dump of the `openbao` database shipped to alpha-site, and a monthly
+  # restore test that proves the dump is actually usable. See
+  # vault/bootstrap/RUNBOOK.md Scenarios B and D.
+  #
+  # NO `components: - ../../../components/postgres` here, deliberately: this
+  # app reads the existing `openbao` database with the credential the postgres
+  # generator already provisions for the openbao app. Adding the component
+  # would make components/postgres/Update.cs provision a SECOND database
+  # named after this app.
+  dependsOn:
+    # The database being dumped, and the app that owns it. Depending on the
+    # openbao ks (not just postgres) means we never dump a half-initialised
+    # database during a bootstrap.
+    - name: openbao
+      namespace: kube-system
+    # ClusterSecretStore/database (the dump credential) and
+    # ClusterSecretStore/onepassword-connect (the SFTP key — dual-run: 1Password
+    # is still authoritative for estate credentials until Phase 11).
+    - name: external-secrets-stores
+      namespace: kube-system
+    # Both jobs cross to alpha-site only through the dockge-as egress Service:
+    # port 2023 (dump receiver), 8200 (transit unseal for the restore test) and
+    # 443 (Gatus heartbeat reports) are declared in
+    # apps/tailscale-system/services/Update.cs.
+    - name: tailscale-services
+      namespace: tailscale-system
+  prune: true
+  wait: false
+  force: false
+  suspend: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/openbao-replica/kustomization.yaml
+++ b/kubernetes/apps/kube-system/openbao-replica/kustomization.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./secret.sops.yaml
+configMapGenerator:
+  - name: openbao-replica-scripts
+    files:
+      - dump.sh=./resources/dump.sh
+      - restore-test.sh=./resources/restore-test.sh
+      - age-recipients.txt=./resources/age-recipients.txt
+generatorOptions:
+  disableNameSuffixHash: true
+#
+# Credential routing, because three different trust roots meet here:
+#
+#   externalsecret.yaml   PG_URI from the generated `openbao-postgres` secret
+#                         via ClusterSecretStore/database (same reasoning as
+#                         the openbao app: referenced, never copied), and the
+#                         SFTP private key from 1Password ("Rclone SFTP Key" —
+#                         the same keypair DockgeLxc seeds into every
+#                         rclone-sftp receiver). Dual-run: the store ref moves
+#                         to OpenBao at Phase 6, the key itself is already
+#                         migrated data.
+#
+#   secret.sops.yaml      The restore-test AppRole (minted by
+#                         vault/bootstrap/openbao/restore-test.sh —
+#                         placeholders until that runs). SOPS because it has
+#                         no other in-cluster source.
+#
+#   Referenced, not copied: the transit seal token comes from the existing
+#   `openbao-seal` Secret owned by the openbao app, and the age identity for
+#   decrypting dumps comes from the `sops-age` Secret the common component
+#   already stamps into this namespace.

--- a/kubernetes/apps/kube-system/openbao-replica/resources/age-recipients.txt
+++ b/kubernetes/apps/kube-system/openbao-replica/resources/age-recipients.txt
@@ -1,0 +1,11 @@
+# The three estate age recipients — the same set as .sops.yaml in this repo,
+# vault, and stargate-command-cluster. MUST stay identical to those files: a
+# divergent set is how a dump becomes undecryptable by the one key that
+# survives (vault/bootstrap/RUNBOOK.md, "Things that will bite you").
+#
+# No alpha-site-resident key is ever added here. The whole point of this
+# layer is that the host holding the ciphertext (and the transit key) cannot
+# decrypt it alone.
+age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+age1klzrc4tp666ykn8u4y2nt80n0tcx52lvezrr54zswz55w2pdsgyqhcdfyr
+age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6

--- a/kubernetes/apps/kube-system/openbao-replica/resources/dump.sh
+++ b/kubernetes/apps/kube-system/openbao-replica/resources/dump.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# dump.sh — nightly break-glass replication of the `openbao` database to
+# alpha-site (migration Phase 5; PLAN §E, RUNBOOK Scenario B).
+#
+#   pg_dump → age encrypt → SFTP to the bao-standby dump receiver → prune 30d
+#
+# The age layer is ON TOP of OpenBao's own encryption, deliberately:
+# alpha-site also hosts the transit key, so possession of that one host must
+# never be enough to read the estate's secrets. Recipients are the three
+# estate age keys plus the dedicated restore-test key — see
+# age-recipients.txt, which is the authoritative list.
+#
+# Environment (set in helmrelease.yaml):
+#   PG_URI            connection string for the openbao database
+#   SFTP_HOST/PORT    the bao-standby dump receiver on dockge-as (port 2023)
+#   SFTP_KEY_FILE     the estate rclone SFTP client key
+#   RETENTION_DAYS    prune horizon on alpha-site (30)
+#   GATUS_URL, GATUS_CONNECT_TO, GATUS_TOKEN   heartbeat reporting
+#
+# NOTE for editors: this file is delivered through a Flux-substituted
+# ConfigMap. Keep every shell variable lowercase or $unbraced — a $${UPPERCASE}
+# that collides with a cluster substitution variable would be rewritten at
+# deploy time.
+set -Eeuo pipefail
+
+report() {
+  # Report failures loudly, successes quietly. Never let the report itself
+  # fail the job (|| true): Gatus's heartbeat catches a job that could not
+  # even report.
+  local success="$1" msg="${2:-}"
+  local url="$GATUS_URL/api/v1/endpoints/$GATUS_TOKEN/external?success=$success"
+  if [ "$success" != "true" ] && [ -n "$msg" ]; then
+    url="$url&error=$(printf '%s' "$msg" | head -c 512 | od -An -tx1 -v | tr -d ' \n' | sed 's/../%&/g')"
+  fi
+  curl -sf -X POST \
+    --connect-to "$GATUS_CONNECT_TO" \
+    -H "Authorization: Bearer $GATUS_TOKEN" \
+    "$url" >/dev/null || echo "WARN: failed to report to Gatus"
+}
+
+fail() {
+  echo "FAILED: $*" >&2
+  report false "$*"
+  exit 1
+}
+trap 'fail "dump.sh aborted at line $LINENO"' ERR
+
+stamp="$(date -u +%Y%m%d-%H%M%S)"
+name="openbao-$stamp.sql.age"
+plain=/tmp/openbao.sql
+enc="/tmp/$name"
+
+# rclone remote for the dump receiver. No host-key pinning, matching the
+# estate's other rclone-over-sftp jobs (Playground.cs, backrest preSync).
+export RCLONE_CONFIG=/tmp/rclone.conf
+export RCLONE_CONFIG_BAO_TYPE=sftp
+export RCLONE_CONFIG_BAO_HOST="$SFTP_HOST"
+export RCLONE_CONFIG_BAO_PORT="$SFTP_PORT"
+export RCLONE_CONFIG_BAO_USER=sftp
+export RCLONE_CONFIG_BAO_KEY_FILE="$SFTP_KEY_FILE"
+
+# 1. Dump. --schema=openbao because that is where every OpenBao table lives
+#    (the role's search_path puts them there — see STATUS.md, "tables live in
+#    the openbao schema"). --no-owner/--no-privileges so the dump restores
+#    into a scratch server that has no CNPG roles. Plain format on purpose:
+#    RUNBOOK Scenario B pipes it straight into psql.
+pg_dump "$PG_URI" --schema=openbao --format=plain --no-owner --no-privileges > "$plain"
+
+# A dump of a healthy openbao database is never tiny. An empty-ish file here
+# means we dumped the wrong thing (or a wiped database) — do not ship it over
+# the last known-good ones.
+size="$(wc -c < "$plain")"
+[ "$size" -ge 65536 ] || fail "dump is only $size bytes — refusing to ship it"
+
+# 2. Encrypt. -R takes the recipients file; comments and blank lines are fine.
+age -R /scripts/age-recipients.txt -o "$enc" "$plain"
+rm -f "$plain"
+
+# 3. Ship, then read it back from the listing — the upload only counts if the
+#    receiver actually has it at the right size.
+rclone copyto "$enc" "bao:$name"
+remote_size="$(rclone lsl bao: --include "$name" | awk '{print $1}')"
+[ "$remote_size" = "$(wc -c < "$enc")" ] || fail "uploaded size mismatch for $name (local $(wc -c < "$enc"), remote ${remote_size:-missing})"
+
+# 4. Prune to the 30-day retention. Scoped to our own filename pattern so a
+#    stray file in the receiver directory can never be collateral.
+rclone delete bao: --min-age "$RETENTION_DAYS"d --include 'openbao-*.sql.age'
+
+count="$(rclone lsf bao: --include 'openbao-*.sql.age' | wc -l | tr -d ' ')"
+echo "shipped $name ($size bytes plaintext); $count dump(s) retained on alpha-site"
+report true

--- a/kubernetes/apps/kube-system/openbao-replica/resources/restore-test.sh
+++ b/kubernetes/apps/kube-system/openbao-replica/resources/restore-test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# restore-test.sh — monthly proof that the break-glass backup works
+# (migration Phase 5; RUNBOOK Scenario D: an unverified backup is not a
+# backup).
+#
+# This is Scenario B as a drill, end to end, with nothing mocked:
+#
+#   1. fetch the NEWEST dump back from alpha-site over the same SFTP path the
+#      nightly job ships through — proving the dump left the building and is
+#      retrievable
+#   2. refuse a stale dump (older than MAX_DUMP_AGE_DAYS) — a clean restore
+#      of last month's data is still a failed backup
+#   3. age-decrypt with the estate identity — the exact key a human would use
+#   4. restore into the scratch Postgres sidecar
+#   5. start a throwaway bao against it and let it unseal via the SAME
+#      transit key on alpha-site the real cluster uses
+#   6. log in with the restore-test AppRole and read the canary key
+#   7. report to Gatus — which alerts on failure AND on silence
+#
+# Environment (set in helmrelease.yaml): SFTP_HOST/PORT/KEY_FILE,
+# AGE_KEY_FILE, MAX_DUMP_AGE_DAYS, SCRATCH_PG_URI/USER/PASSWORD/DB,
+# TRANSIT_ADDR, VAULT_TRANSIT_SEAL_TOKEN, BAO_ROLE_ID, BAO_SECRET_ID,
+# CANARY_PATH, GATUS_URL/CONNECT_TO/TOKEN.
+#
+# NOTE for editors: delivered through a Flux-substituted ConfigMap — keep
+# shell expansions $unbraced so no $${UPPERCASE} can collide with a cluster
+# substitution variable.
+set -Eeuo pipefail
+
+bao_pid=""
+
+report() {
+  local success="$1" msg="${2:-}"
+  local url="$GATUS_URL/api/v1/endpoints/$GATUS_TOKEN/external?success=$success"
+  if [ "$success" != "true" ] && [ -n "$msg" ]; then
+    url="$url&error=$(printf '%s' "$msg" | head -c 512 | od -An -tx1 -v | tr -d ' \n' | sed 's/../%&/g')"
+  fi
+  curl -sf -X POST \
+    --connect-to "$GATUS_CONNECT_TO" \
+    -H "Authorization: Bearer $GATUS_TOKEN" \
+    "$url" >/dev/null || echo "WARN: failed to report to Gatus"
+}
+
+cleanup() { [ -n "$bao_pid" ] && kill "$bao_pid" 2>/dev/null || true; }
+
+fail() {
+  echo "RESTORE TEST FAILED: $*" >&2
+  echo "Treat the backup as UNTRUSTED until this passes — RUNBOOK Scenario D." >&2
+  report false "$*"
+  cleanup
+  exit 1
+}
+trap 'fail "restore-test.sh aborted at line $LINENO"' ERR
+
+# ── 1. Fetch the newest dump back from alpha-site ───────────────────────────
+export RCLONE_CONFIG=/tmp/rclone.conf
+export RCLONE_CONFIG_BAO_TYPE=sftp
+export RCLONE_CONFIG_BAO_HOST="$SFTP_HOST"
+export RCLONE_CONFIG_BAO_PORT="$SFTP_PORT"
+export RCLONE_CONFIG_BAO_USER=sftp
+export RCLONE_CONFIG_BAO_KEY_FILE="$SFTP_KEY_FILE"
+
+latest="$(rclone lsf bao: --include 'openbao-*.sql.age' | sort | tail -1)"
+[ -n "$latest" ] || fail "no dumps found on alpha-site at all"
+echo "newest dump on alpha-site: $latest"
+
+# ── 2. Freshness gate ───────────────────────────────────────────────────────
+# The timestamp is authoritative from the FILENAME (openbao-YYYYMMDD-HHMMSS),
+# which the dump job wrote from its own clock — mtime over sftp is not
+# trustworthy enough to gate on.
+dump_date="$(printf '%s' "$latest" | sed -n 's/^openbao-\([0-9]\{8\}\)-.*/\1/p')"
+[ -n "$dump_date" ] || fail "cannot parse a date out of dump name '$latest'"
+# Epoch arithmetic instead of `date -d "-N days"` — that flag does not exist
+# in busybox and this container's date is coreutils only because the command
+# wrapper installs it.
+cutoff="$(date -u -d "@$(( $(date -u +%s) - MAX_DUMP_AGE_DAYS * 86400 ))" +%Y%m%d)"
+[ "$dump_date" -ge "$cutoff" ] || fail "newest dump $latest is older than $MAX_DUMP_AGE_DAYS days — nightly replication has stopped"
+
+rclone copyto "bao:$latest" /tmp/dump.sql.age
+
+# ── 3. Decrypt with the estate identity ─────────────────────────────────────
+age --decrypt -i "$AGE_KEY_FILE" -o /tmp/dump.sql /tmp/dump.sql.age
+size="$(wc -c < /tmp/dump.sql)"
+[ "$size" -ge 65536 ] || fail "decrypted dump is only $size bytes"
+
+# ── 4. Restore into the scratch sidecar ─────────────────────────────────────
+export PGPASSWORD="$SCRATCH_PG_PASSWORD"
+for _ in $(seq 1 60); do
+  pg_isready -h localhost -U "$SCRATCH_PG_USER" -d "$SCRATCH_PG_DB" >/dev/null 2>&1 && break
+  sleep 2
+done
+pg_isready -h localhost -U "$SCRATCH_PG_USER" -d "$SCRATCH_PG_DB" >/dev/null || fail "scratch postgres never became ready"
+
+# ON_ERROR_STOP: a partial restore that limps into a working-looking bao is
+# the worst possible outcome for a verification job.
+psql "$SCRATCH_PG_URI" -q -v ON_ERROR_STOP=1 -f /tmp/dump.sql
+tables="$(psql "$SCRATCH_PG_URI" -tA -c "select count(*) from information_schema.tables where table_schema='openbao'")"
+echo "restored $tables table(s) into schema openbao"
+entries="$(psql "$SCRATCH_PG_URI" -tA -c "select count(*) from openbao.openbao_kv_store")"
+[ "$entries" -gt 0 ] || fail "openbao_kv_store restored empty"
+echo "openbao_kv_store has $entries rows"
+
+# ── 5. Throwaway bao, unsealed via the real transit path ────────────────────
+# Single node, no HA, no service registration. connection_url and the transit
+# token arrive via BAO_PG_CONNECTION_URL / VAULT_TRANSIT_SEAL_TOKEN — the
+# same env-beats-config behaviour the production config relies on.
+cat > /tmp/config.hcl <<EOF
+listener "tcp" {
+  address     = "127.0.0.1:8200"
+  tls_disable = true
+}
+storage "postgresql" {
+  table      = "openbao_kv_store"
+  ha_enabled = "false"
+}
+seal "transit" {
+  address    = "$TRANSIT_ADDR"
+  key_name   = "openbao-equestria-unseal"
+  mount_path = "transit/"
+}
+EOF
+export BAO_PG_CONNECTION_URL="$SCRATCH_PG_URI?sslmode=disable"
+bao server -config=/tmp/config.hcl &
+bao_pid=$!
+
+# Auto-unseal happens during startup; then there is a window where non-status
+# requests 500 while the (single) node elects itself — the same ~30s window
+# equestria-init.sh waits out. Gate on health 200 = initialised, unsealed,
+# active.
+export BAO_ADDR=http://127.0.0.1:8200
+unsealed=""
+for _ in $(seq 1 90); do
+  code="$(curl -s -o /tmp/health.json -w '%{http_code}' "$BAO_ADDR/v1/sys/health" || true)"
+  if [ "$code" = "200" ]; then unsealed=yes; break; fi
+  kill -0 "$bao_pid" 2>/dev/null || fail "bao server exited during startup — transit seal unreachable or restored keyring unusable"
+  sleep 2
+done
+[ -n "$unsealed" ] || fail "bao never reached health 200 (last: $(cat /tmp/health.json 2>/dev/null || echo none)) — transit unseal of the RESTORED data failed"
+echo "throwaway bao is unsealed and active (via $TRANSIT_ADDR)"
+
+# ── 6. Canary read with the restore-test AppRole ────────────────────────────
+# The AppRole lives INSIDE the backup (minted against the live cluster by
+# vault/bootstrap/openbao/restore-test.sh), so a successful login also proves
+# the auth backends survived the round trip.
+token="$(curl -sf -X POST "$BAO_ADDR/v1/auth/approle/login" \
+  -d "{\"role_id\":\"$BAO_ROLE_ID\",\"secret_id\":\"$BAO_SECRET_ID\"}" | jq -r '.auth.client_token // empty')"
+[ -n "$token" ] || fail "approle login failed against the restored instance — was vault/bootstrap/openbao/restore-test.sh ever run?"
+
+canary="$(curl -sf -H "X-Vault-Token: $token" "$BAO_ADDR/v1/$CANARY_PATH" | jq -r '.data.data | length')"
+[ -n "$canary" ] && [ "$canary" -gt 0 ] || fail "canary read of $CANARY_PATH returned no data"
+echo "canary read OK ($canary field(s) at $CANARY_PATH)"
+
+# ── 7. Report ───────────────────────────────────────────────────────────────
+cleanup
+echo "restore test PASSED: $latest restores, unseals via transit, and serves reads"
+report true

--- a/kubernetes/apps/kube-system/openbao-replica/secret.sops.yaml
+++ b/kubernetes/apps/kube-system/openbao-replica/secret.sops.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.2/secret.json
+#
+# The restore-test AppRole: read-only on the single canary path, used by the
+# monthly restore test to prove a restored dump actually serves reads
+# (RUNBOOK Scenario D). Minted by vault/bootstrap/openbao/restore-test.sh
+# against the LIVE cluster — the credential rides along inside every nightly
+# dump, which is exactly why logging in with it against the restored copy is
+# a meaningful check.
+#
+# The values below are PLACEHOLDERS until that script runs; the job fails
+# loudly at approle login (and Gatus alerts) until they are replaced:
+#
+#   sops set kubernetes/apps/kube-system/openbao-replica/secret.sops.yaml \
+#     '["stringData"]["role-id"]' '"<role_id>"'
+#   sops set kubernetes/apps/kube-system/openbao-replica/secret.sops.yaml \
+#     '["stringData"]["secret-id"]' '"<secret_id>"'
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openbao-replica-restore
+type: Opaque
+stringData:
+  role-id: ENC[AES256_GCM,data:3g2jMtnhlIBIHo+jOXIZxh2LwCznX5gCoIFMOCgMW05Tf2YW,iv:0jwJb4XqVZnjoR7kitfHqL425lfNMrbDgpoVXuB04CM=,tag:GrvwW+UYYoCeDJGWmfsQ6g==,type:str]
+  secret-id: ENC[AES256_GCM,data:fJD2ji7J2pP/RkSEGZHUz1GHV9kLB4GC9R1qPxnhb6GYnwET,iv:hbGh5lql8Q/E9eKw68/s4Zeag1ayBBogYHpr7++ik6g=,tag:HCCF0xAtEwKrRzHzenuj9A==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhalRpNWdQcmhjN01zSjd2
+        MGNQeFB2MCtJdjNBSkdESEM5Z3plL0NWSUE4CnFyUzZxbFlYbkZYNmtra1dyenhq
+        dnIrMm1uZXZ0QnQyYWo2a3Y1VlpDWjgKLS0tIEd1Q241aUhMY1QzbzlXcy9zQ3Ey
+        L0UvTTZ5T1h6TFhueFlNbjJuSTBJeFkKvXBMi9ZleoQOTbbQ9WVRFY5smpcxA8sD
+        ljonZiEWNcPCFScNoRf6TXfPxUxYVEunz3CTTobbmdto1XoJG281uA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhdi95N0twVUZTM09qV3B4
+        ZlcvTG9tbXp6V3FDRnNVWG5RcXd1N05tVmpjCmxGWUdKMDlyZ3ZtcEtrSi91ZXF0
+        R1ZkQjZzU0pQQ0VEemxFNHcxQ2RYR0EKLS0tIDN2cFhwRVRucDBmNk5ZNFF6K1R1
+        SHFxZytZRnV1WjRhZE5LMjRvU24xd0UKc6EeYaUb74sfngrJitwtJi5JX3e5cZwe
+        9PM5ubd3YAXIaQbSH2Dq7jm3J++CsmJJE9Snj+2SzJ6s5wsk3s01aQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T19:40:26Z"
+  mac: ENC[AES256_GCM,data:Z7Wm/8Ek0ipPq2OAzHmsZTn47dFZ4Sx7+kNK+Si8zxE7eDkaVdIp+UJdsLpZ9hNz4+gkwJP9/6LQfbLWx+rF14jt8Nr+JAgV9sJ3OCP/JSNIOabPuKWGiA2SFIRUNthOnPVz1F0dvOAvbNn8NOqeXxYb7nt2egMvo8VWCwxQ94U=,iv:iTzyl7PtCk4kZHZO/rvt126va9Fgorvtba2ijOHQQjc=,tag:t2uTUBpO59fpw4N9IXWkiw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/kube-system/openbao/definition.yaml
+++ b/kubernetes/apps/kube-system/openbao/definition.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: OpenBao
+  category: Applications
+  description: Secrets management — source of truth for the estate
+  url: https://bao.${CLUSTER_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/svg/openbao.svg
+  access_policy:
+    groups:
+      - admins
+      - family
+  authentik:
+    oauth2:
+      clientType: confidential
+      allowedRedirectUris:
+        # The UI login callback. The path segment appears twice by design:
+        # /auth/<mount-path>/oidc/callback with the default mount path "oidc".
+        - url: "https://bao.${CLUSTER_DOMAIN}/ui/vault/auth/oidc/oidc/callback"
+        # `bao login -method=oidc` runs a local listener on 8250 for the CLI flow.
+        - url: "http://localhost:8250/oidc/callback"
+      propertyMappings:
+        - email
+        - openid
+        # profile carries the `groups` claim, which the OpenBao roles bind on:
+        # admins -> policy admin, family -> policy viewer (see
+        # vault:bootstrap/openbao/equestria-init.sh `oidc`).
+        - profile
+      includeClaimsInIdToken: true
+      subMode: user_email
+  gatus:
+    # Probe the health endpoint rather than the UI root, which redirects.
+    # standbyok=true so a standby answering the probe reports 200 instead of
+    # 429 — without it this alerts every time the route lands on a non-leader.
+    # A sealed node still returns 503 and an uninitialised one 501, so the
+    # cases worth being paged for continue to fail.
+    - url: "https://bao.${CLUSTER_DOMAIN}/v1/sys/health?standbyok=true"
+      method: GET
+      interval: 1m
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/kube-system/openbao/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/openbao/externalsecret.yaml
@@ -1,0 +1,56 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+#
+# BAO_PG_CONNECTION_URL, taken from the generated `${APP}-postgres` secret
+# rather than copied into secret.sops.yaml. `task update` writes that role's
+# password once, in passwords.sops.yaml; a second hand-maintained copy would
+# fork from it the next time the role rotates and nothing would catch the
+# mismatch until OpenBao failed to reach its own storage.
+#
+# The `uri` key is already exactly the form the Postgres backend wants:
+#   postgres://openbao:<pw>@postgres-rw.database.svc.cluster.local:5432/openbao?sslmode=disable
+#
+# This does NOT reintroduce the bootstrap cycle the ks.yaml comment warns about.
+# ClusterSecretStore/database is a `kubernetes` provider reading the `database`
+# namespace directly — it is not backed by 1Password and will not be backed by
+# OpenBao, so OpenBao is never a link in the chain that starts OpenBao. The only
+# new coupling is ordering: external-secrets must be running first, which is why
+# it is now a dependsOn in ks.yaml.
+#
+# The transit token has no such source and stays in secret.sops.yaml.
+#
+# Named `-storage`, not `-postgres`: the generated secret this reads from is
+# already called `openbao-postgres` over in the `database` namespace, and two
+# different objects under one name across two namespaces is a trap.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-storage
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-storage
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        pg-connection-url: "{{ .postgres_uri }}"
+  dataFrom:
+    - extract:
+        key: ${APP}-postgres
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "postgres_$1"

--- a/kubernetes/apps/kube-system/openbao/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/openbao/helmrelease.yaml
@@ -1,0 +1,182 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app openbao
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  maxHistory: 3
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  uninstall:
+    keepHistory: false
+  values:
+    global:
+      enabled: true
+    # The agent injector and the CSI provider are alternative ways to get
+    # secrets into pods. This estate uses external-secrets for that, so both
+    # stay off — they would only add another moving part with its own webhook.
+    injector:
+      enabled: false
+    csi:
+      enabled: false
+    ui:
+      enabled: true
+    server:
+      # The whole config below is delivered as a ConfigMap, and OpenBao reads it
+      # once at process start. A config-only change therefore leaves the
+      # StatefulSet's pod template untouched, so nothing rolls and the running
+      # servers keep serving the OLD config indefinitely — Flux reports success
+      # the entire time. That bit us on the OIDC bootstrap: the generate-root
+      # listener toggle sat in the mounted file for 15h while every request
+      # still 403'd. Reloader (estate-wide convention) watches the mounted
+      # ConfigMap and rolls the StatefulSet when it changes.
+      #
+      # RollingUpdate is the other half, and without it the annotation above is
+      # inert: the chart defaults to updateStrategyType OnDelete, under which
+      # the StatefulSet controller never replaces a pod on its own — not even
+      # when the pod template changes, which is exactly what reloader patches.
+      # (`kubectl rollout restart` also refuses outright on an OnDelete
+      # StatefulSet, so that workaround was never going to work either.)
+      #
+      # OnDelete is the right default for upstream Vault, where a Shamir-sealed
+      # server needs a human to unseal every restarted pod. That reasoning does
+      # not apply here: this cluster auto-unseals through the transit seal
+      # against bao-transit, so a restarted pod comes back unsealed on its own.
+      # With 3 HA replicas replaced one at a time, rolling is safe.
+      updateStrategyType: RollingUpdate
+      statefulSet:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      ha:
+        enabled: true
+        replicas: 3
+        # Storage is Postgres, not the integrated Raft backend. Leader election
+        # happens through the openbao_ha_locks table instead of Raft consensus,
+        # so there is no quorum to maintain here.
+        raft:
+          enabled: false
+        disruptionBudget:
+          maxUnavailable: 1
+        # The two secret-bearing values — the Postgres password inside
+        # connection_url, and the transit token — are injected as environment
+        # variables below rather than written here, so this config stays
+        # reviewable in git. Both are documented as env-overridable and both
+        # were confirmed against the OpenBao source, not just the docs:
+        #   BAO_PG_CONNECTION_URL       physical/postgresql/postgresql.go:282
+        #   VAULT_TRANSIT_SEAL_TOKEN    go-kms-wrapping transit_client.go:31
+        # In every case the environment variable takes precedence over the
+        # config file, so omitting the field here is the intended usage.
+        config: |
+          ui = true
+
+          listener "tcp" {
+            address     = "0.0.0.0:8200"
+            // TLS terminates at the internal gateway and this listener is only
+            // reachable in-cluster, matching the other kube-system services.
+            tls_disable = true
+
+            // Do NOT add disable_unauthed_generate_root_endpoints here again.
+            //
+            // It was opened twice (#3067, #3078) because minting a root token
+            // from the recovery shares had no other route: `bao operator
+            // generate-root` speaks only sys/generate-root-token/*, which needs
+            // a token holding capabilities there, and no policy had any. The
+            // deprecated unauthenticated sys/generate-root/* was the only way
+            // in, and exposing it meant two pod rolls and a public
+            // root-generation endpoint in between.
+            //
+            // That is fixed. vault:bootstrap/openbao/break-glass-approle.sops.yaml
+            // holds an AppRole whose ONLY capability is opening an attempt on
+            // the authenticated endpoint — verified to grant `deny` on secret
+            // reads and on policy writes. Completing an attempt still requires
+            // 3 of the 5 recovery shares, so the AppRole alone mints nothing.
+            //
+            // Break-glass procedure is now in vault:bootstrap/RUNBOOK.md and
+            // needs no cluster change at all.
+          }
+
+          storage "postgresql" {
+            // connection_url comes from BAO_PG_CONNECTION_URL.
+            table      = "openbao_kv_store"
+            ha_enabled = "true"
+            ha_table   = "openbao_ha_locks"
+          }
+
+          seal "transit" {
+            // token comes from VAULT_TRANSIT_SEAL_TOKEN.
+            //
+            // The address is not secret, and it is deliberately a MagicDNS name
+            // rather than a tailnet IP. Pods here have no route to the tailnet —
+            // both 100.111.10.9:8200 and 100.111.10.200:8200 were probed from a
+            // pod in this namespace and neither is reachable. Tailnet hosts are
+            // reached only through the tailscale-operator egress Services in
+            // tailscale-system, and the operator's nameserver resolves the
+            // MagicDNS name to that egress proxy's ClusterIP: from a pod,
+            // dockge-as.opossum-yo.ts.net and
+            // dockge-as.tailscale-system.svc.cluster.local both answer
+            // 10.196.81.163. The egress proxy forwards only the ports declared
+            // in the Service's spec.ports, so 8200 is declared for dockge-as in
+            // apps/tailscale-system/services/Update.cs.
+            //
+            // This previously read "http://${ALPHA_SITE_TAILSCALE_IP}:8200",
+            // which was wrong twice: that variable is the alpha-site Proxmox
+            // host, while bao-transit runs in the dockge-as LXC — and a raw
+            // tailnet IP could not have worked from a pod regardless.
+            //
+            // Careful: leaving the address unset would NOT be harmless. The
+            // wrapper falls back to api.DefaultConfig(), which reads BAO_ADDR /
+            // VAULT_ADDR — pointing the seal at this pod's own listener and
+            // deadlocking the unseal. It must be set explicitly.
+            address    = "http://dockge-as.${TAILSCALE_DOMAIN}:8200"
+            key_name   = "openbao-equestria-unseal"
+            mount_path = "transit/"
+            disable_renewal = "false"
+          }
+
+          // Lets OpenBao label its own pods active/standby so the chart's
+          // -active and -standby Services route correctly.
+          service_registration "kubernetes" {}
+      # Two different sources, on purpose.
+      #
+      # The connection URL comes from externalsecret.yaml, which reads the
+      # generated `openbao-postgres` secret through ClusterSecretStore/database
+      # — a `kubernetes` provider, not 1Password and not OpenBao, so this is not
+      # the bootstrap cycle. One source of truth for that password means it
+      # rotates without a second edit.
+      #
+      # The transit token comes from secret.sops.yaml because nothing in the
+      # cluster can produce it: it is minted against bao-transit on alpha-site.
+      # SOPS is the one source guaranteed available before OpenBao is.
+      extraSecretEnvironmentVars:
+        - envName: BAO_PG_CONNECTION_URL
+          secretName: openbao-storage
+          secretKey: pg-connection-url
+        - envName: VAULT_TRANSIT_SEAL_TOKEN
+          secretName: openbao-seal
+          secretKey: transit-token
+      # No PVCs: all state lives in the CNPG cluster.
+      dataStorage:
+        enabled: false
+      auditStorage:
+        enabled: false
+      # Ingress is an HTTPRoute on the internal gateway (httproute.yaml), the
+      # same as every other internal service here.
+      ingress:
+        enabled: false
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 512Mi

--- a/kubernetes/apps/kube-system/openbao/httproute.yaml
+++ b/kubernetes/apps/kube-system/openbao/httproute.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ${APP}
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "${INTERNAL_DOMAIN}"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+      kind: Gateway
+  hostnames:
+    - "bao.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        # The plain service fronts every replica. Standbys forward writes to the
+        # active node, so this is correct for both reads and writes; the chart
+        # also emits an ${APP}-active service if you would rather pin to the
+        # leader and skip the forwarding hop.
+        - name: ${APP}
+          port: 8200

--- a/kubernetes/apps/kube-system/openbao/ks.yaml
+++ b/kubernetes/apps/kube-system/openbao/ks.yaml
@@ -1,0 +1,80 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app openbao
+  namespace: &namespace kube-system
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/openbao
+  # Storage is the shared CNPG cluster, so postgres has to be up first.
+  #
+  # external-secrets IS a dependency, for the Postgres connection URL only. That
+  # is not the loop this migration exists to remove: ClusterSecretStore/database
+  # is a `kubernetes` provider reading the `database` namespace directly, so it
+  # is not backed by 1Password today and will not be backed by OpenBao later —
+  # OpenBao is never a link in the chain that starts OpenBao. The seal token,
+  # which genuinely has no in-cluster source, still comes from secret.sops.yaml.
+  #
+  # tailscale-services is a dependency because the unseal path runs through it:
+  # these pods reach bao-transit on alpha-site only via the tailscale-operator
+  # egress Service for dockge-as, and that Service forwards port 8200 only
+  # because it is declared in apps/tailscale-system/services/Update.cs. Without
+  # this ordering the pods can come up before the port exists and sit
+  # crash-looping on a seal they cannot reach.
+  dependsOn:
+    - name: postgres
+      namespace: database
+    # The stores ks, not the controller ks — ClusterSecretStore/database is
+    # defined there. Note it currently dependsOn onepassword-connect, so until
+    # Phase 11 drops that, OpenBao transitively waits on 1Password Connect at
+    # boot. Irritating but not circular, and it resolves itself at cutover.
+    - name: external-secrets-stores
+      namespace: kube-system
+    - name: tailscale-services
+      namespace: tailscale-system
+  # SUSPENDED UNTIL BOOTSTRAP IS COMPLETE. All four preconditions now hold:
+  #   1. DONE — `bao-transit` is initialised and unsealed on alpha-site, with
+  #      the transit key `openbao-equestria-unseal` and the `equestria-unseal`
+  #      policy in place (migration Phase 2).
+  #   2. DONE — `task update` has been run: the `openbao` role exists in
+  #      kubernetes/apps/database/postgres/app/resources/values.yaml, its
+  #      password in passwords.sops.yaml, and the generated `openbao-postgres`
+  #      secret is live in the `database` namespace. The components entry below
+  #      is what makes components/postgres/Update.cs discover this app — do not
+  #      remove it as a tidy-up, it silently drops the whole database.
+  #   3. DONE — secret.sops.yaml exists here with the transit token, and
+  #      externalsecret.yaml supplies the connection URL.
+  #   4. DONE — port 8200 is declared on the dockge-as egress Service, so these
+  #      pods can actually reach bao-transit. Verified by port-scanning the
+  #      egress proxy from a pod in this namespace.
+  #
+  # What remains is the deliberate go-live decision. Flipping this to `false`
+  # creates the StatefulSet, which will initialise the `openbao` database and
+  # take the transit seal live. Reverting after that point is no longer just a
+  # `git revert` — the database will have been written to.
+  suspend: false
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 15m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../components/postgres
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/openbao/kustomization.yaml
+++ b/kubernetes/apps/kube-system/openbao/kustomization.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./definition.yaml
+  - ./externalsecret.yaml
+  - ./secret.sops.yaml
+  #
+  # The two secret-bearing values arrive by different routes, and the split is
+  # deliberate:
+  #
+  #   externalsecret.yaml  pg-connection-url → BAO_PG_CONNECTION_URL, read from
+  #                        the generated `openbao-postgres` secret via
+  #                        ClusterSecretStore/database. Not copied, so it
+  #                        rotates with the role.
+  #
+  #   secret.sops.yaml     transit-token → VAULT_TRANSIT_SEAL_TOKEN. An orphan
+  #                        periodic token carrying only update on
+  #                        transit/encrypt/openbao-equestria-unseal and
+  #                        transit/decrypt/openbao-equestria-unseal. Minted
+  #                        against bao-transit; nothing here can regenerate it,
+  #                        so it is mirrored at
+  #                        vault/bootstrap/openbao/transit-token.sops.yaml per
+  #                        that repo's INVENTORY.md.
+  #
+  # Everything else about the server config is plaintext in helmrelease.yaml.

--- a/kubernetes/apps/kube-system/openbao/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/openbao/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: openbao
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.29.1
+    digest: sha256:d9dcbe6a36bda395c67f87d4bfdf06fe1be3363895527d679983be0e04a2398e
+  url: oci://ghcr.io/openbao/charts/openbao

--- a/kubernetes/apps/kube-system/openbao/secret.sops.yaml
+++ b/kubernetes/apps/kube-system/openbao/secret.sops.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.2/secret.json
+#
+# The one value OpenBao needs that nothing in the cluster can produce for it.
+#
+#   transit-token -> VAULT_TRANSIT_SEAL_TOKEN  (go-kms-wrapping transit_client.go:31)
+#
+# Minted against bao-transit on alpha-site by vault/bootstrap/openbao/bao-transit.sh
+# and mirrored at vault/bootstrap/openbao/transit-token.sops.yaml. It is orphan
+# and periodic (768h); the transit wrapper renews it itself via a LifetimeWatcher,
+# so it does not expire while any pod is running.
+#
+# BAO_PG_CONNECTION_URL is NOT here — see externalsecret.yaml. Copying that
+# password into this file would fork it from the generated `openbao-postgres`
+# secret and silently drift the next time the role is rotated.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openbao-seal
+type: Opaque
+stringData:
+  transit-token: ENC[AES256_GCM,data:g0sDOtTT1jlHHyQSNWFw10V6QdHDeVTa0yM=,iv:/HNJkcKkQOPgsNGbozDYlcKEOpMWms5mBclA9H22moE=,tag:MPhF+RXQ/4gCV56zC3JXwg==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjWXZvL0UyQnZCeVZtVFAy
+        MXhoV3lkTEpCMGN3YU5RanhvOWdleXFOQVVZCkhyNGxtVC81bTlud1lBaE9TbHFm
+        SmdnRjRobldzSWhtVUZjWHNUazZXZWMKLS0tIGVZNkx5eWpic0NOajA4NVBOVm5M
+        ZkpyUmNuK2ZDRVNNbmw1OWdyamczQ3cK0OzYC6dTgD9flB4/Y82rYniywGUDObMW
+        jLJxasSDmURcovgODp5zjIaSe1Oy7x+9+2isHCA1VDCB5sNJXuAGUA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOb1kvVC95RjBvcEhRZ2RE
+        dFp4dkxlL2htSzVqaFpOT1VFNW9zVThkQW40Ck1TQjJ1bFRqREpLcEVBR3pybWNj
+        UXZYSWdUYXFGV2I0eWdHVi9JOUdteTQKLS0tIHdPdGcvRG11eVlqcm1vQU5sK09a
+        dXVWVy9BaWloNlB5ZitlSnRFRFFHOWsKUb5oMB4E/PawgJb3asTbkNWUeiRTA45Q
+        YmDJPd5cJD9ZYZua+ELJSWBbNMr+xlI/3Ml8+C3SCfJuCcX9fWQU0Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-07T17:22:26Z"
+  mac: ENC[AES256_GCM,data:11kHY48I0RNRy8iSX2mhvKTU+8pr88kNx228bjJgDOTJDLz9lD3dw9QigIbe8N+vtXxkCd4qIt9aJZX/yx3Fwk8HN0QQbIBcRMFEuf3gk51DHJlHShWEpifIwWYFZiDi0jmTYNiV4zMLoGN9RnOuwzxKPUFsF83vhJZUVUXTB9Y=,iv:KQgPngAAadZgqFDmtNPCtMTxRaVREVLrDqfOYnoWM2o=,tag:QyvDZ92i90UYhuMHa7QmYg==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/kube-system/reflector/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reflector/helmrelease.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: reflector
+spec:
+  interval: 1h
+  url: https://emberstack.github.io/helm-charts/
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: reflector
+spec:
+  chart:
+    spec:
+      chart: reflector
+      version: 10.0.64
+      sourceRef:
+        kind: HelmRepository
+        name: reflector
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    configuration:
+      logging:
+        minimumLevel: Information

--- a/kubernetes/apps/kube-system/reflector/ks.yaml
+++ b/kubernetes/apps/kube-system/reflector/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app reflector
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/reflector
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/reflector/kustomization.yaml
+++ b/kubernetes/apps/kube-system/reflector/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/registry/definition.yaml
+++ b/kubernetes/apps/kube-system/registry/definition.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: Container Registry Mirror
+  category: ${CLUSTER_TITLE}
+  description: A container registry mirror for faster image pulls
+  url: &url https://registry.${CLUSTER_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/zot-registry.svg
+  access_policy:
+    groups:
+      - admins
+  gatus:
+    - url: https://registry.${CLUSTER_DOMAIN}/livez
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/kube-system/registry/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/registry/externalsecret.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: registry-values
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  refreshPolicy: Periodic
+  refreshInterval: 1m
+  target:
+    name: registry-values
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      templateFrom:
+      - target: Data
+        configMap:
+          name: registry-values
+          items:
+          - key: config.json
+            templateAs: Values
+          - key: credentials.json
+            templateAs: Values
+  dataFrom:
+    - extract:
+        # was: Docker Hub
+        key: shared/docker-hub
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "docker_$1"

--- a/kubernetes/apps/kube-system/registry/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/registry/helmrelease.yaml
@@ -1,0 +1,160 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app registry
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  driftDetection:
+    mode: enabled
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: true
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  dependsOn: []
+  values:
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        pod:
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            # fsGroupChangePolicy: OnRootMismatch
+            supplementalGroups:
+              - 65542 # gladius:external-services
+        initContainers:
+          fix-permissions:
+            image:
+              repository: busybox
+              tag: 1.38.0@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616
+            command:
+              - /bin/sh
+              - -c
+              - |
+                chown -R 568:568 /var/lib/registry
+            securityContext:
+              runAsUser: 0
+              runAsGroup: 0
+              capabilities:
+                add:
+                  - CHOWN
+                  - FOWNER
+        containers:
+          *app :
+            image:
+              repository: ghcr.io/project-zot/zot
+              tag: v2.1.20@sha256:542e25be4d32e7879c0cfad93492a93c81b1e059cbd2d30d485d4bd567318234
+            env: []
+            envFrom: []
+            resources:
+              requests:
+                cpu: 50m
+                memory: 512Mi
+              limits:
+                # cpu: 1
+                memory: 1Gi
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 5
+                  httpGet:
+                    path: /livez
+                    port: &port 8080
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  httpGet:
+                    path: /readyz
+                    port: *port
+              startup:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  failureThreshold: 3
+                  httpGet:
+                    path: /startupz
+                    port: *port
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+
+    service:
+      app:
+        controller: *app
+        type: ClusterIP
+        ports:
+          http:
+            port: *port
+
+    route:
+      internal:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "registry.${CLUSTER_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: local-user
+
+    persistence:
+      config-file:
+        type: configMap
+        name: registry-values
+        globalMounts:
+          - path: /etc/zot/config.json
+            subPath: config.json
+            readOnly: true
+          - path: /etc/credentials/credentials.json
+            subPath: credentials.json
+            readOnly: true
+      registry:
+        existingClaim: ${APP}
+        globalMounts:
+          - path: /var/lib/registry
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/kube-system/registry/ks.yaml
+++ b/kubernetes/apps/kube-system/registry/ks.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app registry
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: external-secrets
+      namespace: kube-system
+    - name: volsync
+      namespace: volsync-system
+  path: ./kubernetes/apps/kube-system/registry
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  components:
+    - ../../../components/failover/fast-node-eviction
+    - ../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_CAPACITY: 60Gi
+      VOLSYNC_ACCESSMODES: ReadWriteMany

--- a/kubernetes/apps/kube-system/registry/kustomization.yaml
+++ b/kubernetes/apps/kube-system/registry/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./definition.yaml
+configMapGenerator:
+  - name: registry-values
+    files:
+      - config.json=./resources/config.json
+      - credentials.json=./resources/credentials.json
+    options:
+      disableNameSuffixHash: true

--- a/kubernetes/apps/kube-system/registry/resources/config.json
+++ b/kubernetes/apps/kube-system/registry/resources/config.json
@@ -1,0 +1,168 @@
+{
+  "distSpecVersion": "1.1.0",
+  "storage": {
+    "rootDirectory": "/var/lib/registry",
+    "commit": true,
+    "gc": true,
+    "gcDelay": "1h",
+    "gcInterval": "6h",
+    "retention": {
+      "dryRun": false,
+      "delay": "12h",
+      "policies": [
+        {
+          "repositories": ["**"],
+          "deleteUntagged": true,
+          "keepTags": [{ "patterns": [".*"] }]
+        }
+      ]
+    }
+  },
+  "http": {
+    "address": "0.0.0.0",
+    "port": "8080"
+  },
+  "log": { "level": "info" },
+  "extensions": {
+    "ui": {
+      "enable": true
+    },
+    "search": {
+      "enable": true,
+      "cve": {
+        "updateInterval": "168h"
+      }
+    },
+    "scrub": {
+      "enable": true,
+      "interval": "24h"
+    },
+    "metrics": {
+      "enable": true,
+      "prometheus": {
+        "path": "/metrics"
+      }
+    },
+    "sync": {
+      "enable": true,
+      "registries": [
+        {
+          "urls": ["https://index.docker.io", "https://registry-1.docker.io"],
+          "tlsVerify": true,
+          "onDemand": true,
+          "maxRetries": 3,
+          "retryDelay": "15m",
+          "onlySigned": false,
+          "content": [
+            {
+              "prefix": "library/**",
+              "destination": "/docker.io"
+            },
+            {
+              "prefix": "**",
+              "destination": "/docker.io"
+            }
+          ]
+        },
+        {
+          "urls": ["https://quay.io"],
+          "tlsVerify": true,
+          "onDemand": true,
+          "maxRetries": 3,
+          "retryDelay": "15m",
+          "onlySigned": false,
+          "content": [
+            {
+              "prefix": "**",
+              "destination": "/quay.io"
+            }
+          ]
+        },
+        {
+          "urls": ["https://gcr.io"],
+          "tlsVerify": true,
+          "onDemand": true,
+          "maxRetries": 3,
+          "retryDelay": "15m",
+          "onlySigned": false,
+          "content": [
+            {
+              "prefix": "**",
+              "destination": "/gcr.io"
+            }
+          ]
+        },
+        {
+          "urls": ["https://ghcr.io"],
+          "tlsVerify": true,
+          "onDemand": true,
+          "maxRetries": 3,
+          "retryDelay": "15m",
+          "onlySigned": false,
+          "content": [
+            {
+              "prefix": "**",
+              "destination": "/ghcr.io"
+            }
+          ]
+        },
+        {
+          "urls": ["https://registry.k8s.io"],
+          "tlsVerify": true,
+          "onDemand": true,
+          "maxRetries": 3,
+          "retryDelay": "15m",
+          "onlySigned": false,
+          "content": [
+            {
+              "prefix": "**",
+              "destination": "/registry.k8s.io"
+            }
+          ]
+        },
+        {
+          "urls": ["https://public.ecr.aws"],
+          "tlsVerify": true,
+          "onDemand": true,
+          "maxRetries": 3,
+          "retryDelay": "15m",
+          "onlySigned": false,
+          "content": [
+            {
+              "prefix": "**",
+              "destination": "/public.ecr.aws"
+            }
+          ]
+        },
+        {
+          "urls": ["https://cgr.dev"],
+          "tlsVerify": true,
+          "onDemand": true,
+          "maxRetries": 3,
+          "retryDelay": "15m",
+          "onlySigned": false,
+          "content": [
+            {
+              "prefix": "**",
+              "destination": "/cgr.dev"
+            }
+          ]
+        },
+        {
+          "urls": ["https://mcr.microsoft.com"],
+          "tlsVerify": true,
+          "onDemand": true,
+          "maxRetries": 3,
+          "retryDelay": "15m",
+          "onlySigned": false,
+          "content": [
+            {
+              "prefix": "**",
+              "destination": "/mcr.microsoft.com"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/kubernetes/apps/kube-system/registry/resources/credentials.json
+++ b/kubernetes/apps/kube-system/registry/resources/credentials.json
@@ -1,0 +1,10 @@
+{
+  "registry-1.docker.io": {
+    "username": "{{ .docker_username }}",
+    "password": "{{ .docker_password }}"
+  },
+  "index.docker.io": {
+    "username": "{{ .docker_username }}",
+    "password": "{{ .docker_password }}"
+  }
+}

--- a/kubernetes/apps/kube-system/reloader/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reloader/helmrelease.yaml
@@ -1,0 +1,55 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: reloader
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 2.2.16
+    digest: sha256:af2e01b729b9460048ed9482bf6c391154270903072f0e7b1e01db9aba9ea7a5
+  url: oci://ghcr.io/stakater/charts/reloader
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: reloader
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: reloader
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    nameOverride: reloader
+    fullnameOverride: reloader
+    reloader:
+      enableHA: true
+      readOnlyRootFileSystem: true
+      podMonitor:
+        enabled: true
+        namespace: "{{ .Release.Namespace }}"
+      # reloadStrategy: annotations

--- a/kubernetes/apps/kube-system/reloader/ks.yaml
+++ b/kubernetes/apps/kube-system/reloader/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app reloader
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/reloader
+  prune: true
+  wait: false
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/reloader/kustomization.yaml
+++ b/kubernetes/apps/kube-system/reloader/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/secrets/docker-hub-auth/docker-hub-auth.yaml
+++ b/kubernetes/apps/kube-system/secrets/docker-hub-auth/docker-hub-auth.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: docker-hub-auth
+  namespace: kube-system
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: docker-hub-auth
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: kubernetes.io/dockerconfigjson
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      data:
+        .dockerconfigjson: |
+          {
+            "auths": {
+              "https://index.docker.io/v1/": {
+                "username": "{{ .username }}",
+                "password": "{{ .password }}",
+                "auth": "{{ printf "%s:%s" .username .password | b64enc }}"
+              }
+            }
+          }
+  dataFrom:
+    - extract:
+        # was: Docker Hub
+        key: shared/docker-hub
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _

--- a/kubernetes/apps/kube-system/secrets/docker-hub-auth/ks.yaml
+++ b/kubernetes/apps/kube-system/secrets/docker-hub-auth/ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app docker-hub-auth
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/secrets/docker-hub-auth
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  dependsOn:
+    - name: external-secrets
+      namespace: kube-system
+    - name: onepassword-connect
+      namespace: kube-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/secrets/docker-hub-auth/kustomization.yaml
+++ b/kubernetes/apps/kube-system/secrets/docker-hub-auth/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./docker-hub-auth.yaml

--- a/kubernetes/apps/kube-system/secrets/github-auth/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/secrets/github-auth/externalsecret.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-app
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: github-app
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: Opaque
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        GITHUB_APP_ID: "{{ .appid }}"
+        GITHUB_PRIV_KEY: "{{ .private_key }}"
+        GITHUB_INSTALLATION_ID: "{{ .installationid }}"
+  dataFrom:
+    - extract:
+        key: 'David Driscoll Github App'
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _

--- a/kubernetes/apps/kube-system/secrets/github-auth/github-auth.yaml
+++ b/kubernetes/apps/kube-system/secrets/github-auth/github-auth.yaml
@@ -1,0 +1,139 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app github-auth
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  dependsOn:
+    - name: onepassword-connect
+      namespace: kube-system
+    - name: external-secrets
+      namespace: kube-system
+  values:
+    controllers:
+      *app :
+        serviceAccount:
+          name: *app
+        annotations:
+          reloader.stakater.com/auto: "true"
+        cronjob:
+          backoffLimit: 6
+          concurrencyPolicy: Forbid
+          failedJobsHistory: 2
+          schedule: "0 4 * * *"
+          startingDeadlineSeconds: 30
+          successfulJobsHistory: 3
+          suspend: false
+        type: cronjob
+        containers:
+          main: &job
+            securityContext:
+              allowPrivilegeEscalation: true
+            image:
+              repository: golang
+              tag: 1.26.5-bookworm@sha256:53eeac89074db483fdf0ab3be1df32bf6e47562263d2d0d6baa7f26acb4957dd
+              pullPolicy: IfNotPresent
+            envFrom:
+              - secretRef:
+                  name: github-app
+            command:
+              - /scripts/github-auth-script.sh
+
+            # resources:
+            #   requests:
+            #     memory: 128Mi
+            #     cpu: 10m
+            #   limits:
+            #     memory: 256Mi
+            #     cpu: 20m
+      init:
+        serviceAccount:
+          name: *app
+        annotations:
+          reloader.stakater.com/auto: "true"
+        type: job
+        job:
+          backoffLimit: 6
+          activeDeadlineSeconds: 3600
+          ttlSecondsAfterFinished: 3600
+          parallelism: 1
+          completions: 1
+        containers:
+          main:
+            <<: *job
+
+    defaultPodOptions:
+      automountServiceAccountToken: true
+      serviceAccountName: *app
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: "OnRootMismatch"
+        runAsGroup: 0
+        runAsNonRoot: false
+        runAsUser: 0
+        seccompProfile:
+          type: RuntimeDefault
+      shareProcessNamespace: true
+
+    persistence:
+      script:
+        type: configMap
+        name: github-auth-script
+        defaultMode: 493
+        globalMounts:
+          - path: /scripts/github-auth-script.sh
+            subPath: github-auth-script.sh
+
+    serviceAccount:
+      *app :
+        forceRename: *app
+    rbac:
+      roles:
+        *app :
+          forceRename: *app
+          type: Role
+          rules:
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: [""]
+              resources: ["secrets"]
+              verbs: ["get", "create", "update", "patch"]
+            - apiGroups: [""]
+              resources: ["configmaps"]
+              verbs: ["get", "create", "update", "patch"]
+      bindings:
+        *app :
+          type: RoleBinding
+          forceRename: *app
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: *app
+          subjects:
+            - kind: ServiceAccount
+              name: *app
+              namespace: ${NAMESPACE}

--- a/kubernetes/apps/kube-system/secrets/github-auth/ks.yaml
+++ b/kubernetes/apps/kube-system/secrets/github-auth/ks.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app github-auth
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/secrets/github-auth
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  dependsOn:
+    - name: external-secrets
+      namespace: kube-system
+    - name: onepassword-connect
+      namespace: kube-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/secrets/github-auth/kustomization.yaml
+++ b/kubernetes/apps/kube-system/secrets/github-auth/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./github-auth.yaml
+configMapGenerator:
+  - files:
+      - github-auth-script.sh=./resources/github-auth-script.sh
+    name: github-auth-script
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/kube-system/secrets/github-auth/resources/github-auth-script.sh
+++ b/kubernetes/apps/kube-system/secrets/github-auth/resources/github-auth-script.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Required environment variables (to be set as secrets):
+# GITHUB_APP_ID - GitHub App ID
+# GITHUB_PRIV_KEY - GitHub App Private Key (PEM format) - note the variable name for go-github-apps
+# GITHUB_INSTALLATION_ID - Installation ID for the GitHub App
+# GITHUB_USERNAME - Username for docker registry authentication (can be any value for GitHub)
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.35/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.35/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list
+chmod 644 /etc/apt/sources.list.d/kubernetes.list
+
+apt-get update
+apt-get install -y curl jq ca-certificates kubectl
+kubectl version
+
+# Set defaults for optional variables
+SECRET_NAME="ghcr-auth"
+DOCKER_SERVER="ghcr.io"
+DOCKER_USERNAME=${GITHUB_USERNAME:-github}
+
+# Install go-github-apps tool with better error handling
+echo "Installing go-github-apps..."
+# renovate: datasource=github-releases depName=nabeken/go-github-apps
+VERSION=v0.2.6
+
+curl -4 -sSLf https://raw.githubusercontent.com/nabeken/go-github-apps/master/install-via-release.sh | bash -s -- -v ${VERSION}
+
+if [ ! -f "./go-github-apps" ]; then
+    echo "Error: go-github-apps binary not found after installation"
+    exit 1
+fi
+
+echo "Getting installation access token using go-github-apps..."
+# Use go-github-apps to get the token (it reads GITHUB_PRIV_KEY automatically)
+access_token=$(./go-github-apps -app-id "$GITHUB_APP_ID" -inst-id "$GITHUB_INSTALLATION_ID")
+
+if [ -z "$access_token" ] || [ "$access_token" = "null" ]; then
+    echo "Error: Failed to get installation access token"
+    exit 1
+fi
+
+echo "Installation access token obtained successfully"
+
+# Create docker-registry secret
+echo "Creating docker-registry secret: $SECRET_NAME"
+
+kubectl_cmd="kubectl create secret docker-registry $SECRET_NAME \
+    --namespace=kube-system \
+    --docker-server=$DOCKER_SERVER \
+    --docker-username=$DOCKER_USERNAME \
+    --docker-password=$access_token \
+    --docker-email=noreply@github.com"
+
+# Execute with dry-run first, then apply
+$kubectl_cmd --dry-run=client -o yaml | kubectl apply -f -
+
+# Add annotations for reflection and reloading
+echo "Adding annotations to secret..."
+kubectl annotate secret $SECRET_NAME reloader.stakater.com/auto='true' --namespace=kube-system --overwrite
+kubectl annotate secret $SECRET_NAME reflector.v1.k8s.emberstack.com/reflection-allowed='true' --namespace=kube-system --overwrite
+kubectl annotate secret $SECRET_NAME reflector.v1.k8s.emberstack.com/reflection-auto-enabled='true' --namespace=kube-system --overwrite
+
+echo "Docker registry secret '$SECRET_NAME' created successfully!"
+echo "To use this secret in a pod, add the following to your pod spec:"
+echo "  imagePullSecrets:"
+echo "  - name: $SECRET_NAME"

--- a/kubernetes/apps/kube-system/secrets/kustomization.yaml
+++ b/kubernetes/apps/kube-system/secrets/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./docker-hub-auth/ks.yaml
+  # - ./github-auth/ks.yaml

--- a/kubernetes/apps/kube-system/snapshot-controller/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/helmrelease.yaml
@@ -1,0 +1,72 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: snapshot-controller
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.2.0
+    digest: sha256:4e398ea7535735d3da18029dcad3bf488ac556525005453bb634657ad517b1ad
+  url: oci://ghcr.io/piraeusdatastore/helm-charts/snapshot-controller
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: snapshot-controller
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: snapshot-controller
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    # Chart v5 enables webhook by default; disable to avoid TLS setup
+    webhook:
+      enabled: false
+    # Ensure CRDs are installed as part of the chart
+    installCRDs: true
+    controller:
+      replicaCount: 2
+      serviceMonitor:
+        create: true
+    # Chart v5 expects volumeSnapshotClasses at the top-level
+    volumeSnapshotClasses:
+      - name: longhorn-snapclass
+        annotations:
+          snapshot.storage.kubernetes.io/is-default-class: "true"
+        driver: driver.longhorn.io
+        # Must be Delete. VolSync's restic mover snapshots the source PVC, backs
+        # it up, then deletes the VolumeSnapshot. Under Retain the
+        # VolumeSnapshotContent -- and the Longhorn snapshot behind it -- was
+        # never reclaimed, so every VolSync-protected volume grew one permanent
+        # Longhorn snapshot per day until it hit snapshotMaxCount and deadlocked.
+        # See vault#123.
+        deletionPolicy: Delete
+        parameters:
+          # needed for successful VolumeSnapshots
+          # see: https://github.com/longhorn/longhorn/issues/2534#issuecomment-1010508714
+          type: snap

--- a/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app snapshot-controller
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
+  path: ./kubernetes/apps/kube-system/snapshot-controller
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/snapshot-controller/kustomization.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/spegel/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/kube-system/spegel/helm/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/kubernetes/apps/kube-system/spegel/helm/values.yaml
+++ b/kubernetes/apps/kube-system/spegel/helm/values.yaml
@@ -1,0 +1,14 @@
+---
+grafanaDashboard:
+  enabled: true
+service:
+  registry:
+    hostPort: 29999
+serviceMonitor:
+  enabled: true
+spegel:
+  appendMirrors: true
+  logLevel: "DEBUG"
+  debugWebEnabled: true
+  containerdSock: /run/containerd/containerd.sock
+  containerdRegistryConfigPath: /etc/cri/conf.d/hosts

--- a/kubernetes/apps/kube-system/spegel/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/spegel/helmrelease.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: spegel
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.7.4
+    digest: sha256:eaf39cc0967adead1cb6b8c48080c0ecc301016870be7aa43f3e6a8fb8e78000
+  url: oci://ghcr.io/spegel-org/helm-charts/spegel
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: spegel
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: spegel
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  valuesFrom:
+    - kind: ConfigMap
+      name: spegel-values

--- a/kubernetes/apps/kube-system/spegel/ks.yaml
+++ b/kubernetes/apps/kube-system/spegel/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app spegel
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/spegel
+  prune: true
+  wait: false
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/spegel/kustomization.yaml
+++ b/kubernetes/apps/kube-system/spegel/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: spegel-values
+    files:
+      - values.yaml=./helm/values.yaml
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/kube-system/vsc-retention/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/vsc-retention/helmrelease.yaml
@@ -1,0 +1,144 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app vsc-retention
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    serviceAccount:
+      *app : {}
+
+    rbac:
+      roles:
+        *app :
+          type: ClusterRole
+          rules:
+            - apiGroups: ["snapshot.storage.k8s.io"]
+              resources: ["volumesnapshotcontents"]
+              verbs: ["get", "list", "patch", "delete"]
+            - apiGroups: ["snapshot.storage.k8s.io"]
+              resources: ["volumesnapshots"]
+              verbs: ["get", "list"]
+      bindings:
+        *app :
+          type: ClusterRoleBinding
+          roleRef:
+            identifier: *app
+          subjects:
+            - identifier: *app
+
+    controllers:
+      *app :
+        type: cronjob
+        pod:
+          automountServiceAccountToken: true
+        serviceAccount:
+          identifier: *app
+        cronjob:
+          # Before either of Longhorn's own snapshot-cleanup (10:00)/snapshot-delete
+          # (11:00) RecurringJobs -- this operates on a different object class
+          # (CSI VolumeSnapshotContent, not Longhorn's native snapshots.longhorn.io)
+          # but there's no reason to race them.
+          schedule: "30 2 * * *"
+          concurrencyPolicy: Forbid
+          backoffLimit: 2
+          activeDeadlineSeconds: 600
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+        containers:
+          main:
+            image:
+              repository: bitnami/kubectl
+              tag: latest
+              digest: sha256:558420daf32bbc382e3e9af4537f4073085b336ddd47399a3b70e70087115978
+              pullPolicy: IfNotPresent
+            env:
+              RETENTION_DAYS: "7"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -eu
+                # vault#123 was a Longhorn snapshot leak (a VolumeSnapshotClass defaulted to
+                # deletionPolicy: Retain) that grew to 5,532 dangling VolumeSnapshotContents
+                # before anyone noticed. vault#134's follow-up cleanup then stalled for 10
+                # days before anyone re-checked by hand. #123's fix (longhorn-snapclass:
+                # deletionPolicy Delete, confirmed live and still the cluster's only/default
+                # class) stops that specific leak at the source -- this job is the backstop
+                # for the general case: any VolumeSnapshotContent, on ANY VolumeSnapshotClass
+                # policy, that no VolumeSnapshot references anymore is dead weight, and one
+                # that's sat orphaned for RETENTION_DAYS is safe to reclaim regardless of why
+                # it was created. See docs/cluster-consolidation/11-volumesnapshotcontents-trim.md.
+                #
+                # Deliberately narrow: only ORPHANED (no live VolumeSnapshot pointing at it)
+                # AND aged objects are touched. A VSC with a live VolumeSnapshot is never
+                # touched here no matter how old -- that's someone's deliberate retention,
+                # not a leak, and this job has no way to know it's safe to remove.
+                #
+                # Known gap, not solved here: an object stuck in Terminating behind a stale
+                # finalizer (the vault#134 case) won't be caught by a plain `kubectl delete`
+                # -- that needs a finalizer strip, which is a human decision, not something
+                # this job does unattended. The growth alert (VolumeSnapshotContentsGrowing)
+                # is what catches that class of stall.
+                RETENTION_DAYS="${RETENTION_DAYS:-7}"
+                CUTOFF_EPOCH=$(date -u -d "-${RETENTION_DAYS} days" +%s)
+                echo "Reclaiming orphaned VolumeSnapshotContents older than ${RETENTION_DAYS} days (cutoff epoch ${CUTOFF_EPOCH})"
+
+                live_vscs=$(kubectl get volumesnapshots.snapshot.storage.k8s.io -A \
+                  -o custom-columns='VSC:.status.boundVolumeSnapshotContentName' --no-headers 2>/dev/null \
+                  | grep -v '<none>' || true)
+
+                out=$(kubectl get volumesnapshotcontents \
+                  -o custom-columns='NAME:.metadata.name,CREATED:.metadata.creationTimestamp,POLICY:.spec.deletionPolicy,PHASE:.metadata.deletionTimestamp' \
+                  --no-headers)
+                count=0
+                echo "$out" | while read -r name created policy deleting; do
+                  # Already being deleted (e.g. a stuck finalizer case) -- not this job's job.
+                  if [ "$deleting" != "<none>" ]; then
+                    continue
+                  fi
+                  # A live VolumeSnapshot still references this VSC -- never touch it.
+                  if echo "$live_vscs" | grep -qx "$name"; then
+                    continue
+                  fi
+                  created_epoch=$(date -u -d "$created" +%s)
+                  if [ "$created_epoch" -gt "$CUTOFF_EPOCH" ]; then
+                    continue
+                  fi
+                  echo "Reclaiming orphaned VolumeSnapshotContent $name (created $created, policy $policy)"
+                  if [ "$policy" != "Delete" ]; then
+                    kubectl patch volumesnapshotcontent "$name" --type=merge -p '{"spec":{"deletionPolicy":"Delete"}}'
+                  fi
+                  kubectl delete volumesnapshotcontent "$name" --wait=false
+                  sleep 1
+                done
+                echo "Done."
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi

--- a/kubernetes/apps/kube-system/vsc-retention/ks.yaml
+++ b/kubernetes/apps/kube-system/vsc-retention/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vsc-retention
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: snapshot-controller
+      namespace: kube-system
+  path: ./kubernetes/apps/kube-system/vsc-retention
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/vsc-retention/kustomization.yaml
+++ b/kubernetes/apps/kube-system/vsc-retention/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml


### PR DESCRIPTION
## What

Copies `kubernetes/apps/kube-system` verbatim from `equestria-cluster` (19 child Kustomizations: 1password, cilium, coredns, descheduler, metrics-server, reloader, features/*, secrets, spegel, reflector, snapshot-controller, external-secrets/*, registry, etcd, headlamp, multus, openbao, openbao-replica, vsc-retention), as part of the namespace-by-namespace repo consolidation ([vault#84](https://github.com/david-driscoll/vault/issues/84) piece 21, Phase A).

`sourceRef.name` changed from `flux-system` to `home-operations` throughout — verified via `diff -r` against source that nothing else changed.

This is the namespace with `ClusterSecretStore/openbao` and OpenBao itself. Per the piece 21 doc, the `secret-store` component definition is already identical in both repos, so this carries the same store equestria already runs, verbatim — no divergent definition to reconcile.

## Known pre-existing issue (not introduced or fixed by this PR)

`vsc-retention`'s Kustomization is `Ready: False` live today — `envsubst error: variable not set (strict mode): "RETENTION_DAYS"`. Confirmed via diff this is unrelated to the sourceRef change; carried over as-is. Out of scope for piece 21.

## Companion PR

david-driscoll/equestria-cluster#3158 — **merge this PR first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)