### PR TITLE
feat(mise): add the cnpg kubectl plugin

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -2,6 +2,11 @@
 [tools]
 python = "3.14.7"
 kubectl = "1.36.3"
+# kubectl plugin (invoked as `kubectl cnpg ...`) for CNPG replica surgery and
+# planned primary switchovers -- see docs/cluster-consolidation/*.md, which
+# repeatedly calls out `kubectl cnpg destroy`/`promote` over touching a PVC or
+# forcing a failover by hand.
+"github:cloudnative-pg/cloudnative-pg" = { version = "v1.30.0", bin = "kubectl-cnpg" }
 powershell-core = "7.6.4"
 1password-cli = "2.38.1"
 yq = "4.53.3"


### PR DESCRIPTION
## Why

\`kubectl cnpg\` wasn't declared as a mise tool anywhere, so replica surgery and planned primary switchovers (\`kubectl cnpg destroy\`/\`promote\`) needed a manual, undeclared install. The cluster-consolidation migration's plan docs call for exactly these commands repeatedly, in preference to touching a PVC directly or forcing a failover by hand.

## What

Adds \`kubectl-cnpg\` via mise's \`github:\` backend, same pattern as the three existing entries (\`microsoft/apm\`, \`eljulians/skillfile\`, \`home-operations/flate\`).

Verified live: \`mise install "github:cloudnative-pg/cloudnative-pg"\` resolves and installs the correct \`darwin_arm64\` asset, the shim lands at \`kubectl-cnpg\`, and \`kubectl cnpg status postgres -n database --context admin@equestria\` runs successfully against the live cluster through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)