### PR TITLE
hotfix(kube-system): restore missing headlamp/ tree, fix root cause in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ bin/
 # APM dependencies
 apm_modules/
 stacks/unifi-network/tailscale-acl.json
-headlamp/
+/headlamp/
 # Crew: ignore runtime state (logs, inbox, sessions)
 # Note: .crew/casting/* is identity and MUST be committed to main, not ignored
 .crew/orchestration-log/

--- a/kubernetes/apps/kube-system/headlamp/definition.yaml
+++ b/kubernetes/apps/kube-system/headlamp/definition.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: Headlamp
+  category: ${CLUSTER_TITLE}
+  description: Kubernetes Dashboard and Management UI
+  url: &url https://${APP}.${CLUSTER_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/svg/headlamp.svg
+  authentik:
+    oauth2:
+      clientType: confidential
+      allowedRedirectUris:
+      - url: "https://${APP}.${CLUSTER_DOMAIN}/oidc-callback"
+      propertyMappings:
+        - email
+        - openid
+        - profile
+      includeClaimsInIdToken: true
+      subMode: user_email
+  access_policy:
+    groups:
+      - admins
+  gatus:
+    - url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/kube-system/headlamp/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/headlamp/externalsecret.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-oidc
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-oidc
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        OIDC_CLIENT_ID: "{{ .oidc_client_id }}"
+        OIDC_CLIENT_SECRET: "{{ .oidc_client_secret }}"
+        OIDC_ISSUER_URL: "{{ .oidc_issuer }}"
+        OIDC_SCOPES: "openid profile email"
+  dataFrom:
+    - extract:
+        # was: '${CLUSTER_CNAME}-${APP}-oidc-credentials'
+        key: 'clusters/${CLUSTER_CNAME}/apps/${APP}/oidc'
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "oidc_$1"

--- a/kubernetes/apps/kube-system/headlamp/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/headlamp/helmrelease.yaml
@@ -1,0 +1,104 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: headlamp
+  namespace: kube-system # Required for Renovate lookups
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/headlamp
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app headlamp
+  namespace: &namespace kube-system
+  annotations:
+    # renovate: datasource=helm depName=headlamp registryUrl=https://kubernetes-sigs.github.io/headlamp
+    renovate.flux.cluster.local/chart: headlamp
+spec:
+  chart:
+    spec:
+      chart: headlamp
+      version: 0.44.0
+      sourceRef:
+        kind: HelmRepository
+        name: *app
+        namespace: *namespace
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    replicaCount: 2
+    podAnnotations:
+      reloader.stakater.com/auto: "true"
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      fsGroup: 1000
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+    volumeMounts:
+      - name: config
+        mountPath: /home/headlamp/.config
+      - name: tmp
+        mountPath: /tmp
+    volumes:
+      - name: config
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 20m
+        memory: 128Mi
+    autoscaling:
+      enabled: false
+    config:
+      watchPlugins: true
+      oidc:
+        externalSecret:
+          enabled: true
+          name: headlamp-oidc
+    pluginsManager:
+      enabled: true
+      baseImage: node:lts-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43
+      version: latest
+      configContent: |
+        plugins:
+          - name: headlamp_cert-manager
+            source: https://artifacthub.io/packages/headlamp/headlamp-plugins/headlamp_cert-manager
+            version: 0.1.0
+          - name: external-secrets-operator
+            source: https://artifacthub.io/packages/headlamp/external-secrets-operator-headlamp-plugin/external-secrets-operator
+            version: 0.1.0-beta7
+          - name: headlamp_flux
+            source: https://artifacthub.io/packages/headlamp/headlamp-plugins/headlamp_flux
+            version: 0.5.0
+        installOptions:
+          parallel: true
+          maxConcurrent: 2

--- a/kubernetes/apps/kube-system/headlamp/httproute.yaml
+++ b/kubernetes/apps/kube-system/headlamp/httproute.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ${APP}
+  annotations:
+    reloader.stakater.com/auto: "true"
+    external-dns.alpha.kubernetes.io/target: "${INTERNAL_DOMAIN}"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+      kind: Gateway
+  hostnames:
+    - "${APP}.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: headlamp
+          port: 80
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: local-user

--- a/kubernetes/apps/kube-system/headlamp/ks.yaml
+++ b/kubernetes/apps/kube-system/headlamp/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app headlamp
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/headlamp
+  prune: true
+  wait: false
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  dependsOn:
+    - name: external-secrets
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/headlamp/kustomization.yaml
+++ b/kubernetes/apps/kube-system/headlamp/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./definition.yaml
+  - ./httproute.yaml


### PR DESCRIPTION
## 🚨 Active outage — kube-system has zero Cilium/CoreDNS/OpenBao pods right now

Found while watching the kube-system migration (#773, merged) roll out.

## What's broken

`kubernetes/apps/kube-system/kustomization.yaml` references `./headlamp/ks.yaml`, but that directory was never actually committed in #773 — `kube-system-ref`'s `kustomize build` fails outright:

```
kustomize build failed: accumulating resources: accumulation err='accumulating resources from './headlamp/ks.yaml': open .../kubernetes/apps/kube-system/headlamp/ks.yaml: no such file or directory'
```

A build failure blocks the **entire** Kustomization from applying anything — not just headlamp. Confirmed live: `kubectl get pods -n kube-system -l k8s-app=cilium|kube-dns` and the OpenBao selector all return **zero pods**. The old equestria-cluster-owned Kustomizations for kube-system were already pruned by the redirect flip; the replacement can never succeed because it can't even build. Nodes are still `Ready` only because existing eBPF datapath state persists after the Cilium agent DaemonSet pods are gone — this is one node event or reschedule away from a full outage, not a near-miss.

## Root cause

`.gitignore` line 18 was a bare `headlamp/` pattern. Git matches unanchored patterns at **any depth**, not just repo root — so it silently ignored `kubernetes/apps/kube-system/headlamp/` too. That line was added in `1a32b13a` ("exclude headlamp"), bundled with unrelated b2-sdk changes, almost certainly meant to ignore a local scratch/dev-tool directory — not an in-repo Flux app directory. `git add` on the original kube-system migration silently dropped the whole directory, with zero signal: no error, and `git status` never lists ignored paths as untracked, so my own diff-verification pass (which checked `sourceRef` correctness across files) never had anything to see.

## Fix

- Anchored the gitignore rule to repo root (`/headlamp/`) so it can't collide with an in-repo path again.
- Recovered the app content verbatim from `equestria-cluster` at the commit immediately before its own kube-system redirect (`bbd8ffcaf^`), `sourceRef` updated to `home-operations` matching the established pattern.
- Build-validated: `kustomize build kubernetes/apps/kube-system` now succeeds.

## This is time-sensitive — recommend merging immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)