### PR TITLE
fix(flux): deletionPolicy Orphan on database and cloudnative-pg Kustomizations

### DIFF
--- a/kubernetes/apps/cloudnative-pg/barman/ks.yaml
+++ b/kubernetes/apps/cloudnative-pg/barman/ks.yaml
@@ -16,6 +16,11 @@ spec:
       namespace: *namespace
   path: ./kubernetes/apps/cloudnative-pg/barman
   prune: true
+  # Never cascade-delete what this manages on a Kustomization ownership
+  # change. On 2026-08-13 an external-secrets CRD cascade took the CNPG
+  # Cluster CR *and its PVCs* with it -- see
+  # docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/cloudnative-pg/operator/ks.yaml
+++ b/kubernetes/apps/cloudnative-pg/operator/ks.yaml
@@ -13,6 +13,11 @@ spec:
       driscoll.dev/name: *app
   path: ./kubernetes/apps/cloudnative-pg/operator
   prune: true
+  # Never cascade-delete what this manages on a Kustomization ownership
+  # change. On 2026-08-13 an external-secrets CRD cascade took the CNPG
+  # Cluster CR *and its PVCs* with it -- see
+  # docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/database/neo4j/ks.yaml
+++ b/kubernetes/apps/database/neo4j/ks.yaml
@@ -17,6 +17,11 @@ spec:
   dependsOn: []
   path: ./kubernetes/apps/database/neo4j
   prune: true
+  # Never cascade-delete what this manages on a Kustomization ownership
+  # change. On 2026-08-13 an external-secrets CRD cascade took the CNPG
+  # Cluster CR *and its PVCs* with it -- see
+  # docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/database/postgres/app/ks.yaml
+++ b/kubernetes/apps/database/postgres/app/ks.yaml
@@ -21,6 +21,11 @@ spec:
     - name: external-secrets
       namespace: kube-system
   prune: true
+  # Never cascade-delete what this manages on a Kustomization ownership
+  # change. On 2026-08-13 an external-secrets CRD cascade took the CNPG
+  # Cluster CR *and its PVCs* with it -- see
+  # docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   suspend: false

--- a/kubernetes/apps/database/postgres/backups/ks.yaml
+++ b/kubernetes/apps/database/postgres/backups/ks.yaml
@@ -21,6 +21,11 @@ spec:
     - name: external-secrets
       namespace: kube-system
   prune: true
+  # Never cascade-delete what this manages on a Kustomization ownership
+  # change. On 2026-08-13 an external-secrets CRD cascade took the CNPG
+  # Cluster CR *and its PVCs* with it -- see
+  # docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   suspend: false

--- a/kubernetes/apps/database/valkey/ks.yaml
+++ b/kubernetes/apps/database/valkey/ks.yaml
@@ -17,6 +17,11 @@ spec:
   dependsOn: []
   path: ./kubernetes/apps/database/valkey
   prune: true
+  # Never cascade-delete what this manages on a Kustomization ownership
+  # change. On 2026-08-13 an external-secrets CRD cascade took the CNPG
+  # Cluster CR *and its PVCs* with it -- see
+  # docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h


### PR DESCRIPTION
## What

Extends #778's protection to the two namespaces it missed — which is exactly where the next incident landed.

Covers `database/{postgres app, postgres backups, valkey, neo4j}` and `cloudnative-pg/{operator, barman}`.

## Why

At 21:40Z on 2026-08-13, a Helm uninstall of `external-secrets` deleted its own CRDs, and the cascade took the `database/postgres` CNPG Cluster CR **and its PVCs** with it. Only valkey's PVC survived in that namespace. Same failure class as [26](docs/cluster-consolidation/26-bootstrap-apps-to-pulumi.md)/[27](docs/cluster-consolidation/27-migration-churn-failure-modes.md); `database` and `cloudnative-pg` simply weren't in the protected set when #778 landed at 22:19Z, 39 minutes too late.

## Data status

Recoverable — verified from the surviving `ObjectStore/postgres-backups` CR, whose status reports `lastSuccessfulBackupTime: 2026-08-13T16:01:43Z` and `firstRecoverabilityPoint: 2026-08-03T16:01:09Z` against `s3://cnpg-equestria/barman/equestria`. That's object storage, independent of the deleted PVCs. This PR is about not needing that recovery a second time.

## Companion PR

david-driscoll/equestria-cluster#3162 (same annotation on the `database`/`cloudnative-pg` redirect stubs — `deletionPolicy` is evaluated on the object actually being deleted, so the stubs need it too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)