### PR TITLE
fix(postgres): make the restore path work + document the archive-collision trap and bootstrap deadlock

### DIFF
--- a/docs/cluster-consolidation/28-postgres-restore-and-bootstrap-deadlock.md
+++ b/docs/cluster-consolidation/28-postgres-restore-and-bootstrap-deadlock.md
@@ -1,0 +1,207 @@
+# 28 — Restoring CNPG postgres, and the OpenBao bootstrap deadlock
+
+New, 2026-08-13. **Unfiled** — standalone, like [24](24-power-states.md),
+[25](25-unseal-key-scope.md), [26](26-bootstrap-apps-to-pulumi.md) and
+[27](27-migration-churn-failure-modes.md).
+
+Written from an actual restore performed on 2026-08-13, not from theory.
+Everything below was executed live and the failures are real ones that were
+hit, not anticipated ones.
+
+## What happened
+
+At **21:40Z** a Helm uninstall of `external-secrets` deleted its own CRDs
+(the failure class in [26](26-bootstrap-apps-to-pulumi.md)), and the cascade
+took the `database/postgres` CNPG `Cluster` CR **and its PVCs** with it. Only
+`valkey`'s PVC survived in that namespace. `kube-system/openbao` was
+separately uninstalled in the same window (`Helm uninstall succeeded for
+release kube-system/openbao.v9`).
+
+**The data survived.** CNPG archives via the barman-cloud plugin to Minio —
+object storage, entirely independent of the PVC lifecycle. The
+`ObjectStore/postgres-backups` CR also survived, and its status is the
+authoritative proof of restorability:
+
+```console
+kubectl get objectstores.barmancloud.cnpg.io -n database postgres-backups \
+  -o jsonpath='{.status.serverRecoveryWindow}'
+# firstRecoverabilityPoint: 2026-08-03T16:01:09Z
+# lastSuccessfulBackupTime: 2026-08-13T16:01:43Z
+```
+
+**Check that field first in any future incident.** It answers "is this
+recoverable" in one command, and it survives the loss of the Cluster CR.
+The absence of `Backup`/`ScheduledBackup` CRs is *not* evidence of a problem:
+those are created by the Cluster CR and die with it.
+
+## Two things were wrong with the restore path before it could be used
+
+### 1. The `recovery:` block pointed at the wrong place, by the wrong mechanism
+
+It read `method: object_store`, bucket `<db>-restore`, path `/`,
+`clusterName: "restore"`. Backups actually go to `cnpg-<cluster>` at
+`/barman/<cluster>` — a bucket nothing had ever written to, via the
+deprecated in-core `barmanObjectStore` path rather than the plugin the
+backups have used since chart 0.8.x. The chart routes the two through
+entirely different templates (`_external_clusters.tpl`:
+`objectStoreRecoveryCluster` vs `pluginRecoveryCluster`), so this would not
+have worked even with the bucket corrected.
+
+Fixed in this piece's companion commit: `method: plugin`,
+`clusterName: "postgres"` (the serverName the archive is keyed by — read it
+off `status.serverRecoveryWindow`, which is a map keyed by server name), and
+the same bucket/path the backups block writes to.
+
+### 2. The archive-collision trap — the one that actually blocks a restore
+
+This is the important one, and it is not obvious.
+
+`barman-cloud-check-wal-archive` runs before the restored cluster is allowed
+to archive anything, and **requires an empty destination for the new
+cluster's serverName**. The plugin defaults serverName to the cluster name,
+`postgres` — which is the same lineage being recovered from. So the first
+restore attempt died at:
+
+```
+Checking backup destination with barman-cloud-wal-archive  serverName=postgres
+WAL archive check failed for server postgres: Expected empty archive
+options: [--endpoint-url http://truenas... s3://cnpg-equestria/barman/equestria postgres]
+```
+
+It fails closed — the source archive is not corrupted — but the cluster
+never becomes healthy.
+
+**The obvious fix does not work.** Setting
+`backups.pluginConfiguration.parameters.serverName` has no effect: chart
+0.8.1 emits only `barmanObjectName` into `.spec.plugins[]` and silently drops
+the rest of `parameters`. Verified against the rendered Cluster CR:
+
+```console
+kubectl get cluster -n database postgres -o jsonpath='{.spec.plugins}'
+# [{"name":"barman-cloud...","isWALArchiver":true,
+#   "parameters":{"barmanObjectName":"postgres-backups"}}]   <- no serverName
+```
+
+**What works: move the destination instead of the serverName.** Point
+`backups.s3.path` at a fresh path for the restore:
+
+```yaml
+backups:
+  s3:
+    path: "/barman/${CLUSTER_CNAME}-<stamp>"   # fresh, empty -> check passes
+recovery:
+  s3:
+    path: "/barman/${CLUSTER_CNAME}"           # the existing archive, read-only
+```
+
+The chart renders these into two separate ObjectStore CRs
+(`postgres-backups` and `postgres-recovery`), so read and write genuinely
+separate:
+
+```console
+postgres-backups   s3://cnpg-equestria/barman/equestria-20260813
+postgres-recovery  s3://cnpg-equestria/barman/equestria
+```
+
+This is almost certainly what the old `-restore` bucket was working around —
+the same collision, solved by separating read from write. Separating only the
+*write* path is the cheaper half of that trick: no bucket copy needed.
+
+### Result
+
+Second attempt restored cleanly: recovery pod `Completed`, cluster reached
+`3/3 Cluster in healthy state` in ~3 minutes, and every database came back —
+`immich` 626 MB, `windmill` 104 MB, `romm` 59 MB, `freshrss`, `tandoor`,
+`crowdsec`, `coder`, `grafana`, `n8n`, `pulsarr`, `pinepods`, `outline`,
+`vikunja`, `openbao`, and the rest. A fresh backup
+(`backup-20260813224535`) was taken to the new lineage immediately, so
+archiving works on the new path.
+
+## The bootstrap deadlock — NOT resolved, deliberately deferred
+
+Restoring the database did **not** bring the estate back, because of a
+circular dependency that outlives the data loss:
+
+```
+kustomization/database/postgres   wait: true, so it blocks on its own
+                                  ExternalSecrets (postgres-values,
+                                  postgres-backup-config)
+        │                         ...which need ClusterSecretStore/openbao
+        ▼
+ClusterSecretStore/openbao        needs the openbao pods
+        │
+        ▼
+kustomization/kube-system/openbao dependsOn database/postgres  ──┐
+        ▲                                                        │
+        └────────────────────────────────────────────────────────┘
+```
+
+`kube-system/external-secrets-stores` is caught in the same loop — it
+health-checks `ClusterSecretStore/openbao`.
+
+Note what is **not** the problem: OpenBao has everything it materially needs.
+Its Postgres connection URL comes from `ClusterSecretStore/database` (a
+`kubernetes` provider reading the `database` namespace directly, `Valid`
+throughout, and deliberately never backed by OpenBao — see the comment block
+in `kube-system/openbao/ks.yaml`), the `openbao-postgres` Secret is present,
+`tailscale-services` is Ready so `bao-transit` is reachable, and its database
+is restored. It is blocked purely by Flux dependency ordering that is
+circular on itself.
+
+**A live patch is not sufficient.** Removing the circular `dependsOn` with
+`kubectl patch` does break the cycle, but `cluster-apps` reconciles the
+Kustomization back from git within ~a minute — faster than OpenBao can
+deploy — and the deadlock re-forms. Confirmed live.
+
+Options, none taken yet:
+
+- **Break it in git**, not live: a commit that drops `database/postgres` from
+  OpenBao's `dependsOn`. The dependency is arguably wrong anyway — OpenBao
+  needs the *database* reachable, which is `ClusterSecretStore/database` plus
+  the `openbao-postgres` Secret, not the *Kustomization* being Ready. The
+  Kustomization readiness is what drags the ExternalSecrets (and therefore
+  OpenBao itself) into the loop.
+- **Drop `wait: true`** on `database/postgres`, or narrow it to explicit
+  `healthChecks` on the Cluster CR only. Today it waits on everything it
+  applies, including ExternalSecrets that can never sync while OpenBao is
+  down. This is probably the smaller and more correct change.
+- **Suspend `cluster-apps`** for the duration of a manual break, then resume.
+  Effective but heavy-handed, and easy to forget to undo.
+- **Restore OpenBao from the alpha-site break-glass standby** instead
+  (`vault/bootstrap/RUNBOOK.md` Scenario B) and point the store there
+  temporarily. Note the caveat: `ClusterSecretStore/openbao` authenticates
+  via Kubernetes auth (`role: eso-equestria`), so the standby must be able to
+  reach equestria's API server to validate ServiceAccount tokens — verify
+  `kubernetes_host` in the restored standby before committing to this path.
+
+This is the OpenBao-shaped version of the bootstrap catch-22 that
+[03](03-secrets-bootstrap-independence.md) already tracks, made concrete. It
+should be resolved there rather than patched around next time.
+
+## Manual state to unwind once OpenBao is back
+
+Two Secrets in `database` were hand-created during the restore and are
+annotated `driscoll.dev/provenance`. ESO should reclaim both once
+`ClusterSecretStore/openbao` is Ready; verify rather than assume:
+
+- `postgres-backup-s3-creds` — copied from `admin@sgc` (same Minio server,
+  `truenas.driscoll.tech:9000`, same estate-shared credentials).
+- `postgres-values` — hand-rendered with `mode: recovery` and the fresh
+  archive path. **This one matters:** git says `mode: standalone`, so when
+  ESO overwrites it the rendered values revert. That is correct and harmless
+  (CNPG `bootstrap` only applies at cluster creation), but the fresh
+  `backups.s3.path` reverts too — meaning the restored cluster would go back
+  to archiving at `/barman/equestria`, which now collides again. **Land the
+  new path in git before ESO reclaims the Secret**, or the next restore hits
+  the same wall from the other direction.
+
+## Cross-references
+
+- [26-bootstrap-apps-to-pulumi.md](26-bootstrap-apps-to-pulumi.md) — the CRD
+  cascade that destroyed the cluster in the first place
+- [27-migration-churn-failure-modes.md](27-migration-churn-failure-modes.md) —
+  sibling incidents from the same afternoon
+- [03-secrets-bootstrap-independence.md](03-secrets-bootstrap-independence.md) —
+  where the OpenBao bootstrap catch-22 belongs
+- `vault/bootstrap/RUNBOOK.md` — Scenario B (break-glass standby), Scenario D
+  (backup verification)

--- a/docs/cluster-consolidation/README.md
+++ b/docs/cluster-consolidation/README.md
@@ -204,6 +204,7 @@ The v2/v2.1 discovery predates two waves of change; the plans reflect **today**:
 | [25-unseal-key-scope.md](25-unseal-key-scope.md) | *(unfiled)* | A scoped age key for the alpha-site static-unseal file, additive to D5 |
 | [26-bootstrap-apps-to-pulumi.md](26-bootstrap-apps-to-pulumi.md) | *(unfiled)* | Move `scripts/bootstrap-apps.sh` (namespaces, secrets, CRDs, helmfile) into Pulumi; grounded in a live 2026-08-13 incident where a `21`-pattern redirect flip cascade-deleted every Traefik/Gateway API CRD cluster-wide |
 | [27-migration-churn-failure-modes.md](27-migration-churn-failure-modes.md) | *(unfiled)* | Two more 2026-08-13 incidents: `cilium-operator` silently dropped L2-announcement leader election under API-server pressure (cluster-wide external ingress outage, internal traffic unaffected); staging `tsidp` while SGC's copy stayed live crashed Gatus entirely (duplicate monitoring registration) |
+| [28-postgres-restore-and-bootstrap-deadlock.md](28-postgres-restore-and-bootstrap-deadlock.md) | *(unfiled)* | Restoring CNPG from the barman archive after the 2026-08-13 cascade: the archive-collision trap that blocks every same-path restore, and the OpenBao/postgres bootstrap deadlock that survives the restore (documented, deliberately unresolved) |
 
 ## Sequencing
 

--- a/kubernetes/apps/database/postgres/app/resources/values.yaml
+++ b/kubernetes/apps/database/postgres/app/resources/values.yaml
@@ -8,10 +8,10 @@ version:
 # Flip to "recovery" to restore from the barman archive, then back to
 # "standalone" once the restored cluster is promoted.
 #
-# BEFORE FLIPPING, read the serverName warning in the backups block below.
-# Recovering and re-archiving under the same serverName at the same
-# destinationPath is a known CNPG hazard, and this cluster is configured to
-# do exactly that unless you intervene.
+# BEFORE FLIPPING, read the ARCHIVE-COLLISION HAZARD note in the backups
+# block below, and give backups a fresh path. Recovering while archiving to
+# the path being recovered from fails the WAL archive check every time --
+# see docs/cluster-consolidation/28-postgres-restore-and-bootstrap-deadlock.md.
 mode: standalone
 recovery:
   # Was `object_store` pointing at a "-restore" bucket with clusterName
@@ -48,31 +48,42 @@ backups:
   method: plugin
   pluginConfiguration:
     name: barman-cloud.cloudnative-pg.io
-    # ⚠️ SERVERNAME HAZARD, read before any restore.
+    # ⚠️ ARCHIVE-COLLISION HAZARD, read before any restore.
+    #    Confirmed the hard way during the 2026-08-13 restore.
     #
-    # The barman-cloud plugin defaults serverName to the cluster name
-    # ("postgres"), and the recovery block above reads from that same
-    # serverName at this same destinationPath. On a restore, the new cluster
-    # would therefore try to archive INTO the lineage it just recovered FROM.
-    # CNPG's WAL archive check is expected to refuse that (it requires an
-    # empty destination for a new server), so the restore surfaces as a
-    # failing first WAL archive rather than silent corruption -- but it does
-    # block the cluster from reaching a healthy state.
+    # barman-cloud-check-wal-archive runs before the restored cluster may
+    # archive anything, and it REQUIRES AN EMPTY DESTINATION for the new
+    # cluster's serverName. The plugin defaults serverName to the cluster
+    # name ("postgres") -- exactly the lineage the recovery block above
+    # reads from -- so a restore into the same destinationPath always dies
+    # with:
     #
-    # When restoring, set a fresh lineage here so the recovered cluster
-    # archives somewhere new and the source archive stays immutable:
+    #   WAL archive check failed for server postgres: Expected empty archive
     #
-    #   parameters:
-    #     serverName: postgres-<something-new>
+    # It fails closed rather than corrupting the source archive, but the
+    # cluster never reaches a healthy state.
     #
-    # Left unset in steady state: the current lineage is "postgres" and
-    # nothing should change it outside a restore.
+    # DO NOT try to fix this with a serverName override here. The chart
+    # emits only `barmanObjectName` into .spec.plugins[] and silently drops
+    # backups.pluginConfiguration.parameters, so a serverName set here has
+    # no effect -- verified against the rendered Cluster CR.
+    #
+    # What DOES work: move the destination. Give the restored cluster a
+    # fresh archive path (recovery keeps reading the old one, which stays
+    # immutable):
+    #
+    #   backups.s3.path: "/barman/${CLUSTER_CNAME}-<stamp>"
+    #
+    # This is almost certainly why the recovery block used to point at a
+    # separate "-restore" bucket: the same collision, worked around by
+    # separating read from write. Separating the write path is the cheaper
+    # half of that trick -- no bucket copy required.
   endpointURL: "{{ .minio_endpoint }}"
   provider: s3
   s3:
     region: "{{ .minio_region }}"
     bucket: "cnpg-${CLUSTER_CNAME}"
-    path: "/barman/${CLUSTER_CNAME}"
+    path: "/barman/${CLUSTER_CNAME}-20260813"
     accessKey: "{{ .minio_username }}"
     secretKey: "{{ .minio_password }}"
   wal:

--- a/kubernetes/apps/database/postgres/app/resources/values.yaml
+++ b/kubernetes/apps/database/postgres/app/resources/values.yaml
@@ -5,25 +5,42 @@ fullnameOverride: *name
 type: postgresql
 version:
   postgresql: "17.5"
+# Flip to "recovery" to restore from the barman archive, then back to
+# "standalone" once the restored cluster is promoted.
+#
+# BEFORE FLIPPING, read the serverName warning in the backups block below.
+# Recovering and re-archiving under the same serverName at the same
+# destinationPath is a known CNPG hazard, and this cluster is configured to
+# do exactly that unless you intervene.
 mode: standalone
 recovery:
-  method: object_store
-  clusterName: "restore"
+  # Was `object_store` pointing at a "-restore" bucket with clusterName
+  # "restore" -- stale leftover from a one-off restore, and the wrong
+  # mechanism besides. Backups have used the barman-cloud PLUGIN since chart
+  # 0.8.x, so recovery must use `plugin` too; `object_store` speaks the
+  # deprecated in-core barmanObjectStore path and would have looked in a
+  # bucket nothing has ever been written to.
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  # The serverName INSIDE the archive, not a cluster to create. Confirmed
+  # against the live ObjectStore/postgres-backups status, whose
+  # serverRecoveryWindow is keyed "postgres".
+  clusterName: "postgres"
   endpointURL: "{{ .minio_endpoint }}"
   provider: s3
   s3:
     region: "{{ .minio_region }}"
-    # The bucket name below comes from cluster-secrets, where it is
-    # "equestria-db" — so this renders exactly what the 1Password extract
-    # produced. The endpoint above has been TrueNAS Minio for a while; only the
-    # bucket NAME still came from the Backblaze item, which is the mismatch
-    # vault#119 warned about.
+    # Deliberately identical to the backups block below: recovery reads back
+    # exactly what backups write. The chart renders both through the same
+    # helper, so keeping them in sync is what guarantees the restore looks
+    # where the data actually is.
     #
-    # The variable is named in words rather than written out, because Flux
-    # postBuild envsubst expands substitutions inside COMMENTS too: spelling it
-    # normally here would bake the live value into the ConfigMap.
-    bucket: "${BACKBLAZE_DB_BUCKET}-restore"
-    path: "/"
+    # The variables are named in words rather than written out, because Flux
+    # postBuild envsubst expands substitutions inside COMMENTS too: spelling
+    # them normally here would bake the live values into the ConfigMap.
+    bucket: "cnpg-${CLUSTER_CNAME}"
+    path: "/barman/${CLUSTER_CNAME}"
     accessKey: "{{ .minio_username }}"
     secretKey: "{{ .minio_password }}"
 backups:
@@ -31,6 +48,25 @@ backups:
   method: plugin
   pluginConfiguration:
     name: barman-cloud.cloudnative-pg.io
+    # ⚠️ SERVERNAME HAZARD, read before any restore.
+    #
+    # The barman-cloud plugin defaults serverName to the cluster name
+    # ("postgres"), and the recovery block above reads from that same
+    # serverName at this same destinationPath. On a restore, the new cluster
+    # would therefore try to archive INTO the lineage it just recovered FROM.
+    # CNPG's WAL archive check is expected to refuse that (it requires an
+    # empty destination for a new server), so the restore surfaces as a
+    # failing first WAL archive rather than silent corruption -- but it does
+    # block the cluster from reaching a healthy state.
+    #
+    # When restoring, set a fresh lineage here so the recovered cluster
+    # archives somewhere new and the source archive stays immutable:
+    #
+    #   parameters:
+    #     serverName: postgres-<something-new>
+    #
+    # Left unset in steady state: the current lineage is "postgres" and
+    # nothing should change it outside a restore.
   endpointURL: "{{ .minio_endpoint }}"
   provider: s3
   s3:


### PR DESCRIPTION
## Context

The 21:40Z 2026-08-13 `external-secrets` CRD cascade destroyed the `database/postgres` CNPG Cluster CR and its PVCs. **The data was fully recovered** — this PR is the config that made that possible, corrected against what actually happened rather than what the chart docs imply.

## What was wrong

**1. The `recovery:` block was unusable.** It read `method: object_store` against bucket `<db>-restore` path `/` — a bucket nothing has ever written to, via the deprecated in-core `barmanObjectStore` mechanism. Backups have used the barman-cloud **plugin** since chart 0.8.x, and the chart routes the two through entirely different templates. Corrected to `method: plugin`, `clusterName: "postgres"` (the serverName the archive is keyed by), against the real bucket/path.

**2. That alone still failed.** First restore attempt died on:

```
WAL archive check failed for server postgres: Expected empty archive
s3://cnpg-equestria/barman/equestria  postgres
```

`barman-cloud-check-wal-archive` requires an **empty destination** for the new cluster's serverName before it will allow archiving — and the plugin defaults serverName to the cluster name, i.e. the exact lineage being recovered from. It fails closed (source archive is safe) but the cluster never becomes healthy.

**The obvious fix doesn't work:** `backups.pluginConfiguration.parameters.serverName` has no effect — chart 0.8.1 emits only `barmanObjectName` into `.spec.plugins[]` and silently drops the rest. Verified against the rendered Cluster CR.

**What works:** move the *destination*, not the serverName. Recovery reads the old archive; backups write a fresh empty path. The chart renders these into two separate ObjectStores, so read and write genuinely separate:

```
postgres-backups   s3://cnpg-equestria/barman/equestria-20260813
postgres-recovery  s3://cnpg-equestria/barman/equestria
```

This is almost certainly what the old `-restore` bucket was working around — same collision, solved by separating read from write. Separating only the write path is the cheaper half: no bucket copy.

`backups.s3.path` is set to the `-20260813` lineage in git deliberately — that's what the restored cluster is actually archiving to, and leaving git on the old path would have ESO revert the live Secret straight back into the collision.

## Result

Recovery pod `Completed`, cluster `3/3 Cluster in healthy state` in ~3 min, all databases back — `immich` 626 MB, `windmill` 104 MB, `romm` 59 MB, `freshrss`, `tandoor`, `crowdsec`, `coder`, `grafana`, `n8n`, `pulsarr`, `pinepods`, `outline`, `vikunja`, `openbao`, and the rest. Fresh backup taken to the new lineage immediately, so archiving works.

## Piece 28 (new doc)

Covers: confirming restorability in one command (`ObjectStore` `status.serverRecoveryWindow` survives the Cluster CR, and missing `Backup` CRs are *not* a bad sign), the collision trap and its non-obvious non-fix, and the **OpenBao bootstrap deadlock** — `database/postgres`'s Kustomization uses `wait: true` so it blocks on ExternalSecrets that need OpenBao, while `kube-system/openbao` `dependsOn` that Kustomization.

That deadlock is **deliberately left unresolved** per David, and written up with options. Important finding: a `kubectl patch` removing the circular `dependsOn` is *not* sufficient — `cluster-apps` reverts it faster than OpenBao can deploy. Confirmed live.

Also documents the two hand-created Secrets that ESO should reclaim (`postgres-backup-s3-creds`, `postgres-values`), both annotated with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)