### PR TITLE
fix(kube-system): own the snapshot CRDs separately and protect them from deletion

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - ./secrets
   - ./spegel/ks.yaml
   - ./reflector/ks.yaml
+  - ./snapshot-crds/ks.yaml
   - ./snapshot-controller/ks.yaml
   - ./external-secrets
   - ./registry/ks.yaml

--- a/kubernetes/apps/kube-system/snapshot-controller/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/helmrelease.yaml
@@ -47,8 +47,15 @@ spec:
     # Chart v5 enables webhook by default; disable to avoid TLS setup
     webhook:
       enabled: false
-    # Ensure CRDs are installed as part of the chart
-    installCRDs: true
+    # CRDs are owned by ../snapshot-crds, NOT by this chart. Two owners for a
+    # CRD is how they end up deleted: on 2026-08-13 every
+    # snapshot.storage.k8s.io CRD was cascade-removed, and this chart then
+    # could not reinstall itself -- it renders volumeSnapshotClasses below in
+    # the same apply pass, so without the CRD already established it dies with
+    # "no matches for kind VolumeSnapshotClass". Splitting the CRDs into their
+    # own Orphan-protected Kustomization fixes both the ordering and the
+    # ownership.
+    installCRDs: false
     controller:
       replicaCount: 2
       serviceMonitor:

--- a/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
@@ -17,6 +17,10 @@ spec:
       namespace: *namespace
   path: ./kubernetes/apps/kube-system/snapshot-controller
   prune: true
+  # Must not race the CRDs it renders CRs against.
+  dependsOn:
+    - name: snapshot-crds
+      namespace: kube-system
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/apps/kube-system/snapshot-crds/ks.yaml
+++ b/kubernetes/apps/kube-system/snapshot-crds/ks.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app snapshot-crds
+  namespace: &namespace kube-system
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn: []
+  path: ./kubernetes/apps/kube-system/snapshot-crds
+  prune: true
+  # Deleting a CRD deletes every instance of it cluster-wide. On 2026-08-13
+  # exactly that happened to these -- every snapshot.storage.k8s.io CRD went
+  # with a Kustomization churn, which took snapshot-controller, vsc-retention
+  # and the whole VolSync snapshot path with it. Same class as
+  # network/traefik-crds. See
+  # docs/cluster-consolidation/26-bootstrap-apps-to-pulumi.md.
+  deletionPolicy: Orphan
+  wait: false
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/snapshot-crds/kustomization.yaml
+++ b/kubernetes/apps/kube-system/snapshot-crds/kustomization.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # v8.6.0 is the appVersion of the snapshot-controller chart pinned in
+  # ../snapshot-controller/helmrelease.yaml (piraeus chart 5.2.0). Bump the
+  # two together -- a CRD schema older than the controller is how you get
+  # silently-dropped fields.
+  # renovate: datasource=github-releases depName=kubernetes-csi/external-snapshotter
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.6.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+  # renovate: datasource=github-releases depName=kubernetes-csi/external-snapshotter
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.6.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+  # renovate: datasource=github-releases depName=kubernetes-csi/external-snapshotter
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.6.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+  # renovate: datasource=github-releases depName=kubernetes-csi/external-snapshotter
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.6.0/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
+  # renovate: datasource=github-releases depName=kubernetes-csi/external-snapshotter
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.6.0/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+  # renovate: datasource=github-releases depName=kubernetes-csi/external-snapshotter
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.6.0/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
+patches:
+  # Belt and braces on top of this Kustomization's deletionPolicy: Orphan.
+  # deletionPolicy protects these when the KUSTOMIZATION is deleted; this
+  # annotation protects them when a HELM release that also claims them is
+  # uninstalled -- which is the specific way SGC's copies survived (they
+  # carry meta.helm.sh/release-name: csi-driver-nfs plus this annotation).
+  # Deleting a CRD deletes every instance of it cluster-wide, so both
+  # doors get locked.
+  - patch: |-
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        name: not-used
+        annotations:
+          helm.sh/resource-policy: keep
+    target:
+      group: apiextensions.k8s.io
+      kind: CustomResourceDefinition


### PR DESCRIPTION
## What's broken

Every `snapshot.storage.k8s.io` CRD was cascade-deleted on 2026-08-13 — same failure class as the Traefik/Gateway API CRDs in [piece 26](docs/cluster-consolidation/26-bootstrap-apps-to-pulumi.md), but this set **wasn't covered** by the `deletionPolicy: Orphan` sweep in #778.

Deleting a CRD deletes every instance of it cluster-wide, so this took out `VolumeSnapshot`/`VolumeSnapshotClass`/`VolumeSnapshotContent` everywhere — and with them `snapshot-controller`, `vsc-retention`, and the VolSync snapshot path.

**It can't heal itself.** `snapshot-controller` renders `volumeSnapshotClasses` in the same apply pass as its own CRDs, so with the CRD absent it dies with:

```
no matches for kind "VolumeSnapshotClass" in version "snapshot.storage.k8s.io/v1"
```

## The fix

Splits the CRDs into their own `kube-system/snapshot-crds` Kustomization, mirroring the `network/traefik-crds` pattern already proven in this repo:

- **Pinned to external-snapshotter `v8.6.0`** — the `appVersion` of the snapshot-controller chart already in use (piraeus 5.2.0), with `renovate:` annotations so the two stay in step
- **`deletionPolicy: Orphan`** — a Kustomization churn can never take them again
- **`helm.sh/resource-policy: keep`** on every CRD — a *Helm uninstall* can't either. This second door is how SGC's copies survived tonight (they carry the same annotation under `csi-driver-nfs`), and it's the door `deletionPolicy` alone doesn't close
- **`installCRDs: false`** on the chart, so there's exactly one owner — two owners for a CRD is how they get deleted
- **`snapshot-controller` `dependsOn: snapshot-crds`**, so it can never race the CRDs it renders CRs against

## After merge

Flux creates the missing CRDs first, then `snapshot-controller` installs cleanly, and `vsc-retention` unblocks behind it. No out-of-band `kubectl apply` needed — unlike the traefik-crds recovery, there's no deadlock here because `snapshot-crds` has no dependencies.

Validated: `kustomize build kubernetes/apps/kube-system` passes; all 6 CRDs render with the `keep` annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)