### PR TITLE
fix(vsc-retention): escape shell variables so Flux envsubst stops eating them

### DIFF
--- a/kubernetes/apps/kube-system/vsc-retention/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/vsc-retention/helmrelease.yaml
@@ -103,9 +103,9 @@ spec:
                 # -- that needs a finalizer strip, which is a human decision, not something
                 # this job does unattended. The growth alert (VolumeSnapshotContentsGrowing)
                 # is what catches that class of stall.
-                RETENTION_DAYS="${RETENTION_DAYS:-7}"
-                CUTOFF_EPOCH=$(date -u -d "-${RETENTION_DAYS} days" +%s)
-                echo "Reclaiming orphaned VolumeSnapshotContents older than ${RETENTION_DAYS} days (cutoff epoch ${CUTOFF_EPOCH})"
+                RETENTION_DAYS="$${RETENTION_DAYS:-7}"
+                CUTOFF_EPOCH=$(date -u -d "-$${RETENTION_DAYS} days" +%s)
+                echo "Reclaiming orphaned VolumeSnapshotContents older than $${RETENTION_DAYS} days (cutoff epoch $${CUTOFF_EPOCH})"
 
                 live_vscs=$(kubectl get volumesnapshots.snapshot.storage.k8s.io -A \
                   -o custom-columns='VSC:.status.boundVolumeSnapshotContentName' --no-headers 2>/dev/null \


### PR DESCRIPTION
## What's broken

`vsc-retention` has **never reconciled** since it was added in `8020d659c`:

```
post build failed for 'HelmRelease.v2.../vsc-retention': envsubst error:
variable substitution failed: variable not set (strict mode): "RETENTION_DAYS"
```

The inline cleanup script references `${RETENTION_DAYS}` and `${CUTOFF_EPOCH}` as **shell** variables — but Flux's postBuild envsubst runs over the manifest first and tries to resolve them as *Flux* substitutions. Neither is defined in `cluster-secrets`, so strict mode fails the entire build.

This is why `vsc-retention` showed up in tonight's not-ready list despite having nothing to do with the incident — it was already broken, and pre-dates it.

## Fix

Escaped all four braced references with `$$`, matching the convention already used in `longhorn/values.yaml` and `network/crowdsec/values.yaml`.

`RETENTION_DAYS` is still supplied for real by the container env (line 79), so the `:-7` fallback remains a genuine fallback rather than the only source of the value.

Validated with `kustomize build kubernetes/apps/kube-system`; no unescaped braced refs remain in the script body.

## Follow-up worth considering

`openbao-replica` avoids this whole class of problem by keeping its script in a **mounted file** rather than inline in the HelmRelease. That's the more robust shape if this script grows — inline shell inside a Flux-substituted manifest will keep hitting this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)