### PR TITLE
feat(equestria): add home (repo consolidation piece 21, 3/5)

### DIFF
--- a/kubernetes/apps/equestria/home/collabora/definition.yaml
+++ b/kubernetes/apps/equestria/home/collabora/definition.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: Collabora Online
+  category: Applications
+  description: Collabora Online is a powerful online office suite that supports all major document, spreadsheet, and presentation file formats, enabling collaborative editing and real-time communication.
+  url: &url https://collabora.${ROOT_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/collabora-online.svg
+  access_policy:
+    groups:
+      - family
+      - friends
+  authentik:
+    proxy:
+      mode: "forward_single"
+      externalHost: *url
+  gatus:
+    - group: "Applications"
+      url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/equestria/home/collabora/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/collabora/helmrelease.yaml
@@ -1,0 +1,72 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app collabora
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  driftDetection:
+    mode: enabled
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: true
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        pod:
+          securityContext:
+            runAsNonRoot: false
+            # fsGroupChangePolicy: OnRootMismatch
+        containers:
+          *app :
+            image:
+              repository: docker.io/collabora/code
+              tag: 26.04.3.1.1@sha256:6b70f91f0b6e9c76f75f162f58ef0a12cf9415d78e14713d33c0318ddc4a2cc0
+              pullPolicy: IfNotPresent
+            env:
+              extra_params: --o:ssl.termination=true --o:ssl.enable=false
+
+    service:
+      app:
+        controller: *app
+        type: ClusterIP
+        ports:
+          http:
+            port: &port 9980
+
+    route:
+      internal:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "${APP}.${ROOT_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port

--- a/kubernetes/apps/equestria/home/collabora/ks.yaml
+++ b/kubernetes/apps/equestria/home/collabora/ks.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app collabora
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/equestria/home/collabora
+  prune: true
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  dependsOn: []
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components: []
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/equestria/home/collabora/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/collabora/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./definition.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/equestria/home/dynacat/ks.yaml
+++ b/kubernetes/apps/equestria/home/dynacat/ks.yaml
@@ -1,0 +1,65 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app dynacat
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+    - name: external-secrets
+      namespace: kube-system
+  path: ./dashboard
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../kubernetes/components/failover/fast-node-eviction
+    - ../kubernetes/components/tailscale
+    # NOTE: these paths resolve inside the home-operations repo, not this one --
+    # sourceRef above is GitRepository/home-operations. If this app ever needs a
+    # bootstrap or disaster-recovery restore, add
+    # `../kubernetes/components/volsync-restore` here, wait for
+    # `kubectl -n equestria get replicationdestination dynacat-dst` to report a
+    # lastSyncTime, then REMOVE it again. Leaving it in permanently is what
+    # caused the 2026-07 Longhorn incident (vault#120): the restore-once trigger
+    # had already fired, the nightly volsync-system/restore-cleanup CronJob
+    # reaped the RD at 03:30, and Flux recreated it on the next reconcile --
+    # re-running a full restic restore and re-provisioning a 5Gi
+    # longhorn-snapshot + 8Gi longhorn-cache PVC pair, every single day.
+    - ../kubernetes/components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_CAPACITY: 5Gi
+      # Both movers read this one variable, but the defaults are asymmetric:
+      # 2Gi in the ReplicationSource and 8Gi in the ReplicationDestination. The
+      # ReplicationSource has run fine on 2Gi for 83 days against this exact
+      # restic repository (which is tiny -- a full restore completes in 4s), so
+      # pinning 2Gi changes nothing today and stops a future volsync-restore
+      # from silently provisioning an 8Gi longhorn-cache volume to restore a 5Gi
+      # source. Same pin as crowdsec-ui (#2987) and tsiam (sgc#1739).
+      VOLSYNC_CACHE_CAPACITY: 2Gi
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"
+    substituteFrom:
+    - kind: Secret
+      name: github-token

--- a/kubernetes/apps/equestria/home/freshrss/definition.yaml
+++ b/kubernetes/apps/equestria/home/freshrss/definition.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: FreshRSS
+  category: Applications
+  description: Free and open source RSS feed aggregator
+  url: &url https://${APP}.${ROOT_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/freshrss.svg
+  access_policy:
+    groups:
+      - friends
+      - family
+  authentik:
+    oauth2:
+      clientType: confidential
+      allowedRedirectUris:
+        - url: https://${APP}.${ROOT_DOMAIN}:443/i/oidc/
+        - url: https://${APP}.${TAILSCALE_DOMAIN}:443/i/oidc/
+      propertyMappings:
+        - email
+        - openid
+        - profile
+  gatus:
+    - group: "Applications"
+      url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 401"

--- a/kubernetes/apps/equestria/home/freshrss/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/freshrss/externalsecret.yaml
@@ -1,0 +1,81 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-env
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-env
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        TZ: "${TIMEZONE}"
+        CRON_MIN: "1,31"
+        # OIDC Configuration
+        OIDC_ENABLED: "1"
+        OIDC_PROVIDER_METADATA_URL: "{{ .oidc_openid_configuration_url }}"
+        OIDC_REMOTE_USER_CLAIM: "preferred_username"
+        OIDC_SCOPES: "openid email profile"
+        OIDC_X_FORWARDED_HEADERS: "X-Forwarded-Host X-Forwarded-Port X-Forwarded-Proto"
+        # Database Configuration
+        DB_TYPE: "pgsql"
+        DB_HOST: "{{ .postgres_hostname }}"
+        DB_PORT: "{{ .postgres_port }}"
+        DB_NAME: "{{ .postgres_database }}"
+        DB_USER: "{{ .postgres_username }}"
+        DB_PASSWORD: "{{ .postgres_password }}"
+        # HTTP Configuration
+        HTTP_HOST: "0.0.0.0"
+        HTTP_PORT: "80"
+        # OIDC Credentials
+        OIDC_CLIENT_ID: "{{ .oidc_client_id }}"
+        OIDC_CLIENT_SECRET: "{{ .oidc_client_secret }}"
+        OIDC_CLIENT_CRYPTO_KEY: "{{ .crypto_password }}"
+  dataFrom:
+    - extract:
+        # was: FreshRSS Crypto Key
+        key: shared/freshrss-crypto-key
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "crypto_$1"
+    - extract:
+        key: '${APP}-postgres'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: database
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "postgres_$1"
+    - extract:
+        key: '${APP}-oidc-credentials'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: cluster
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "oidc_$1"

--- a/kubernetes/apps/equestria/home/freshrss/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/freshrss/helmrelease.yaml
@@ -1,0 +1,134 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app freshrss
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  driftDetection:
+    mode: enabled
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: true
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        pod:
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+            fsGroup: 0
+            fsGroupChangePolicy: OnRootMismatch
+
+        containers:
+          *app :
+            image:
+              repository: freshrss/freshrss
+              tag: 1.29.1@sha256:ab6b363102ccdbc39f6a62db926f567c61a5289bf25ba460f1c34423d8cc1a4d
+            env:
+              TZ: "${TIMEZONE}"
+            envFrom:
+              - secretRef:
+                  name: ${APP}-env
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1024Mi
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 80
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+
+    defaultPodOptions:
+      securityContext:
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+        seccompProfile:
+          type: RuntimeDefault
+
+    persistence:
+      data:
+        existingClaim: ${APP}
+        globalMounts:
+          - path: /var/www/FreshRSS/data
+      extensions:
+        type: emptyDir
+        globalMounts:
+          - path: /var/www/FreshRSS/extensions
+
+    service:
+      app:
+        controller: *app
+        type: ClusterIP
+        ports:
+          http:
+            port: *port
+            targetPort: *port
+
+    route:
+      internal:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "${APP}.${ROOT_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: *app
+                port: *port
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: local-user

--- a/kubernetes/apps/equestria/home/freshrss/ks.yaml
+++ b/kubernetes/apps/equestria/home/freshrss/ks.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app freshrss
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+    - name: postgres
+      namespace: database
+    - name: external-secrets
+      namespace: kube-system
+  path: ./kubernetes/apps/equestria/home/freshrss
+  prune: true
+  force: false
+  wait: true
+  interval: 1h
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../../components/failover/fast-node-eviction
+    - ../../../../components/postgres
+    - ../../../../components/tailscale
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_CAPACITY: 2Gi
+      VOLSYNC_ACCESSMODES: ReadWriteOnce

--- a/kubernetes/apps/equestria/home/freshrss/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/freshrss/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# kustomization.yaml
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./definition.yaml

--- a/kubernetes/apps/equestria/home/immich/definition.yaml
+++ b/kubernetes/apps/equestria/home/immich/definition.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: Immich
+  category: Applications
+  description: Immich is an image and video backup solution
+  url: &url https://photos.${ROOT_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/immich.svg
+  access_policy:
+    groups:
+      - family
+      - friends
+  authentik:
+    oauth2:
+      clientType: confidential
+      allowedRedirectUris:
+        - url: "https://immich.${ROOT_DOMAIN}/auth/login"
+        - url: "https://immich.${ROOT_DOMAIN}/user-settings"
+        - url: "https://photos.${ROOT_DOMAIN}/auth/login"
+        - url: "https://photos.${ROOT_DOMAIN}/user-settings"
+        - url: "https://immich.${TAILSCALE_DOMAIN}/auth/login"
+        - url: "https://immich.${TAILSCALE_DOMAIN}/user-settings"
+        - url: "https://photos.${TAILSCALE_DOMAIN}/auth/login"
+        - url: "https://photos.${TAILSCALE_DOMAIN}/user-settings"
+        - url: app.immich:///oauth-callback
+          matching_mode: strict
+      propertyMappings:
+        - email
+        - openid
+        - profile
+        - immich_role
+      includeClaimsInIdToken: true
+      subMode: user_email
+  gatus:
+    - group: "Applications"
+      url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/equestria/home/immich/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/immich/externalsecret.yaml
@@ -1,0 +1,113 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-config
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  # Every dataFrom below carries an explicit sourceRef, so this default store
+  # was never consulted — it named onepassword-connect purely by inheritance
+  # from the template it was copied from. Pointing it at the store actually in
+  # use removes a phantom 1Password dependency that Phase 11 would otherwise
+  # have to chase down.
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: cluster
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-config
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      templateFrom:
+      - target: Data
+        configMap:
+          name: ${APP}-config
+          items:
+          - key: config.json
+            templateAs: Values
+  dataFrom:
+    - extract:
+        key: '${APP}-oidc-credentials'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: cluster
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "oidc_$1"
+
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-env
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  # Every dataFrom below carries an explicit sourceRef, so this default store
+  # was never consulted — it named onepassword-connect purely by inheritance
+  # from the template it was copied from. Pointing it at the store actually in
+  # use removes a phantom 1Password dependency that Phase 11 would otherwise
+  # have to chase down.
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-env
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        TZ: "${TIMEZONE}"
+        IMMICH_CONFIG_FILE: "/etc/immich/config.json"
+        REDIS_DBINDEX: "0"
+        REDIS_HOSTNAME: valkey.database.svc.cluster.local
+        REDIS_PORT: "6379"
+        DB_USERNAME: "{{ .postgres_username }}"
+        DB_PASSWORD: "{{ .postgres_password }}"
+        DB_DATABASE_NAME: "{{ .postgres_database }}"
+        DB_PORT: "{{ .postgres_port }}"
+        DB_HOSTNAME: "{{ .postgres_hostname }}"
+        IMMICH_WEB_URL: http://${APP}.${NAMESPACE}:3000
+        # IMMICH_SERVER_URL: http://${APP}.${NAMESPACE}:3001
+        PUBLIC_IMMICH_SERVER_URL: https://photos.${ROOT_DOMAIN}
+        IMMICH_MACHINE_LEARNING_URL: http://${APP}-machine-learning.${NAMESPACE}:3003
+
+        # DISABLE_REVERSE_GEOCODING: "true"
+        # ENABLE_MAPBOX: "false"
+  dataFrom:
+    - extract:
+        key: '${APP}-postgres'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: database
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "postgres_$1"

--- a/kubernetes/apps/equestria/home/immich/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/immich/helmrelease.yaml
@@ -1,0 +1,181 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app immich
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  driftDetection:
+    mode: enabled
+  timeout: 20m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: true
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            supplementalGroups: [0, 1, 44, 109, 303, 568, 10000]
+        containers:
+          *app :
+            image:
+              repository: ghcr.io/immich-app/immich-server
+              tag: v3.1.0@sha256:b434cb9287eea1471c9974845914d4dd328c9c2d652e446ed4930f99944f0ceb
+            envFrom:
+              - secretRef:
+                  name: ${APP}-env
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 568
+              runAsGroup: 568
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 2
+                memory: 2Gi
+          machine-learning:
+            image:
+              repository: ghcr.io/immich-app/immich-machine-learning
+              tag: v3.1.0@sha256:5a0839dc5303cd7215bcd2180a26aed3af41675aefb3e75e5157e9f10ad16e6e
+            envFrom:
+              - secretRef:
+                  name: ${APP}-env
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 568
+              runAsGroup: 568
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+                amd.com/gpu: 1
+              limits:
+                cpu: 1
+                memory: 2Gi
+                amd.com/gpu: 1
+
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups: [44, 109, 303, 568, 10000]
+        seccompProfile: { type: RuntimeDefault }
+
+    persistence:
+      data:
+        existingClaim: spike-data-immich
+      mc-cache:
+        existingClaim: *app
+        advancedMounts:
+          *app :
+            *app :
+              - path: /uploads
+                subPath: uploads
+            machine-learning:
+              - path: /cache
+                subPath: cache
+              - path: /.cache
+                subPath: dotCache
+      tmpfs:
+        type: emptyDir
+        advancedMounts:
+          *app :
+            *app :
+              - path: /usr/src/app/.reverse-geocoding-dump
+                subPath: geocoding
+              - path: /usr/src/app/.transformers_cache
+                subPath: transformers
+      matplotlib:
+        type: emptyDir
+        globalMounts:
+          - path: /.config/matplotlib
+      config:
+        type: secret
+        name: ${APP}-config
+        defaultMode: 493
+        globalMounts:
+          - path: /etc/immich/config.json
+            subPath: config.json
+
+    service:
+      immich-machine-learning:
+        controller: *app
+        type: ClusterIP
+        ports:
+          http:
+            port: 3003
+      *app :
+        controller: *app
+        type: ClusterIP
+        ports:
+          http:
+            port: &port 2283
+
+    route:
+      internal:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "${APP}.${ROOT_DOMAIN}"
+          - "photos.${ROOT_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - matches:
+              - headers:
+                  - name: X-Api-Key
+                    value: ".*"
+                    type: RegularExpression
+            backendRefs:
+              - identifier: *app
+                port: *port
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: local-user
+          - backendRefs:
+              - identifier: *app
+                port: *port
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: local-user

--- a/kubernetes/apps/equestria/home/immich/ks.yaml
+++ b/kubernetes/apps/equestria/home/immich/ks.yaml
@@ -1,0 +1,46 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app immich
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/equestria/home/immich
+  prune: true
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+    - name: postgres
+      namespace: database
+    - name: valkey
+      namespace: database
+    - name: external-secrets
+      namespace: kube-system
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../../components/failover/fast-node-eviction
+    - ../../../../components/postgres
+    - ../../../../components/tailscale
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_ACCESSMODES: ReadWriteMany
+      TAILSCALE_HOST: photos

--- a/kubernetes/apps/equestria/home/immich/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/immich/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./definition.yaml
+  - ./nfs.yaml
+configMapGenerator:
+- name: ${APP}-config
+  files:
+  - config.json=./resources/config.json
+  options:
+    disableNameSuffixHash: true

--- a/kubernetes/apps/equestria/home/immich/nfs.yaml
+++ b/kubernetes/apps/equestria/home/immich/nfs.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master-standalone-strict/persistentvolume-v1.json
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: spike-data-immich
+  labels:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  mountOptions:
+    - nfsvers=4.2
+    - hard
+    - intr
+    - nconnect=8
+    - noatime
+  capacity:
+    storage: 2Ti
+  storageClassName: nfs-csi
+  csi:
+    driver: nfs.csi.k8s.io
+    volumeHandle: spike-data-immich-volume-id
+    volumeAttributes:
+      server: "${SPIKE_IP}"
+      share: /mnt/stash/data/immich
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: spike-data-immich
+  labels:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  storageClassName: nfs-csi
+  volumeName: spike-data-immich
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Ti

--- a/kubernetes/apps/equestria/home/immich/resources/config.json
+++ b/kubernetes/apps/equestria/home/immich/resources/config.json
@@ -1,0 +1,157 @@
+{
+  "backup": {
+    "database": {
+      "enabled": true,
+      "cronExpression": "0 02 * * *",
+      "keepLastAmount": 14
+    }
+  },
+  "job": {
+    "backgroundTask": {
+      "concurrency": 5
+    },
+    "smartSearch": {
+      "concurrency": 2
+    },
+    "metadataExtraction": {
+      "concurrency": 5
+    },
+    "faceDetection": {
+      "concurrency": 2
+    },
+    "search": {
+      "concurrency": 5
+    },
+    "sidecar": {
+      "concurrency": 5
+    },
+    "library": {
+      "concurrency": 5
+    },
+    "migration": {
+      "concurrency": 5
+    },
+    "thumbnailGeneration": {
+      "concurrency": 3
+    },
+    "videoConversion": {
+      "concurrency": 1
+    },
+    "notifications": {
+      "concurrency": 5
+    }
+  },
+  "logging": {
+    "enabled": true,
+    "level": "log"
+  },
+  "machineLearning": {
+    "enabled": true,
+    "urls": ["http://immich-machine-learning:3003"],
+    "clip": {
+      "enabled": true,
+      "modelName": "ViT-B-32__openai"
+    },
+    "duplicateDetection": {
+      "enabled": true,
+      "maxDistance": 0.01
+    },
+    "facialRecognition": {
+      "enabled": true,
+      "modelName": "buffalo_l",
+      "minScore": 0.7,
+      "maxDistance": 0.5,
+      "minFaces": 3
+    }
+  },
+  "map": {
+    "enabled": true,
+    "lightStyle": "https://tiles.immich.cloud/v1/style/light.json",
+    "darkStyle": "https://tiles.immich.cloud/v1/style/dark.json"
+  },
+  "reverseGeocoding": {
+    "enabled": false
+  },
+  "metadata": {
+    "faces": {
+      "import": false
+    }
+  },
+  "oauth": {
+    "autoLaunch": true,
+    "autoRegister": true,
+    "buttonText": "Login with Authentik",
+    "clientId": "{{ .oidc_client_id }}",
+    "clientSecret": "{{ .oidc_client_secret }}",
+    "defaultStorageQuota": null,
+    "enabled": true,
+    "issuerUrl": "{{ .oidc_issuer }}",
+    "mobileOverrideEnabled": false,
+    "mobileRedirectUri": "",
+    "scope": "openid email profile immich_role",
+    "signingAlgorithm": "RS256",
+    "profileSigningAlgorithm": "none",
+    "storageLabelClaim": "preferred_username",
+    "storageQuotaClaim": "immich_quota"
+  },
+  "passwordLogin": {
+    "enabled": false
+  },
+  "storageTemplate": {
+    "enabled": false
+  },
+  "image": {
+    "thumbnail": {
+      "format": "webp",
+      "size": 250,
+      "quality": 80
+    },
+    "preview": {
+      "format": "jpeg",
+      "size": 1440,
+      "quality": 80
+    },
+    "colorspace": "p3",
+    "extractEmbedded": false
+  },
+  "newVersionCheck": {
+    "enabled": true
+  },
+  "trash": {
+    "enabled": true,
+    "days": 30
+  },
+  "theme": {
+    "customCss": ""
+  },
+  "library": {
+    "scan": {
+      "enabled": true,
+      "cronExpression": "0 0 * * *"
+    },
+    "watch": {
+      "enabled": true
+    }
+  },
+  "server": {
+    "externalDomain": "https://photos.${ROOT_DOMAIN}",
+    "loginPageMessage": ""
+  },
+  "notifications": {
+    "smtp": {
+      "enabled": false,
+      "from": "",
+      "replyTo": "",
+      "transport": {
+        "ignoreCert": false,
+        "host": "",
+        "port": 587,
+        "username": "",
+        "password": ""
+      }
+    }
+  },
+  "user": {
+    "deleteDelay": 7
+  }
+}

--- a/kubernetes/apps/equestria/home/karakeep/definition.yaml
+++ b/kubernetes/apps/equestria/home/karakeep/definition.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: "Karakeep"
+  category: Applications
+  description: "Bookmark everything app with AI tagging and crawling"
+  url: &url https://${APP}.${ROOT_DOMAIN}
+  icon: https://raw.githubusercontent.com/karakeep-app/karakeep/main/screenshots/logo.png
+  access_policy:
+    groups:
+      - family
+  authentik:
+    oauth2:
+      clientType: confidential
+      allowedRedirectUris:
+        - url: https://${APP}.${ROOT_DOMAIN}/api/auth/callback/custom
+        - url: https://${APP}.${TAILSCALE_DOMAIN}/api/auth/callback/custom
+      propertyMappings:
+        - email
+        - openid
+        - profile
+      includeClaimsInIdToken: true
+      subMode: user_email
+  gatus:
+    - group: "Applications"
+      url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/equestria/home/karakeep/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/karakeep/externalsecret.yaml
@@ -1,0 +1,79 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-env
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-env
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        TZ: "${TIMEZONE}"
+        DATA_DIR: "/data"
+        MEILI_ADDR: "http://meilisearch:7700"
+        # The MASTER key of the meilisearch this points at, not karakeep's own
+        # secret. Meilisearch enforces auth now, so sending anything else is a
+        # 403 on every search. NEXTAUTH_SECRET below is karakeep's own and is
+        # correctly unrelated.
+        MEILI_MASTER_KEY: "{{ .meili_password }}"
+        NEXTAUTH_URL: "https://${APP}.${ROOT_DOMAIN}"
+        NEXTAUTH_SECRET: "{{ .karakeep_password }}"
+        DISABLE_PASSWORD_AUTH: "true"
+        DISABLE_SIGNUPS: "true"
+        OAUTH_AUTO_REDIRECT: "true"
+        OAUTH_PROVIDER_NAME: "${CLUSTER_TITLE}"
+        # OIDC fields come from the cluster store below, populated by the
+        # applications Pulumi stack.
+        OAUTH_WELLKNOWN_URL: "{{ .oidc_openid_configuration_url }}"
+        OAUTH_CLIENT_ID: "{{ .oidc_client_id }}"
+        OAUTH_CLIENT_SECRET: "{{ .oidc_client_secret }}"
+  dataFrom:
+    - extract:
+        # was: 'Karakeep Secret Key'
+        key: shared/karakeep-secret-key
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "karakeep_$1"
+    - extract:
+        # Meilisearch's master key, so karakeep authenticates with the same
+        # value the server was started with.
+        key: shared/meilisearch-secret-key
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "meili_$1"
+    - extract:
+        key: '${APP}-oidc-credentials'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: cluster
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "oidc_$1"

--- a/kubernetes/apps/equestria/home/karakeep/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/karakeep/helmrelease.yaml
@@ -1,0 +1,143 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app karakeep
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  driftDetection:
+    mode: enabled
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: true
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    fullnameOverride: *app
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        initContainers:
+          fix-run-perms:
+            image:
+              repository: busybox
+              tag: 1.38.0@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616
+              pullPolicy: IfNotPresent
+            command:
+              - /bin/sh
+              - -c
+            args:
+              - chown -R 1001:1001 /run || true
+            securityContext:
+              runAsUser: 0
+              allowPrivilegeEscalation: true
+        containers:
+          *app :
+            image:
+              repository: ghcr.io/karakeep-app/karakeep
+              tag: 0.33.2@sha256:b069e4307dec06ea06d16989c6861c30a1ff208568be44ed5fb5d422cd3e950c
+              pullPolicy: IfNotPresent
+            envFrom:
+              - secretRef:
+                  name: ${APP}-env
+            env:
+              TZ: "${TIMEZONE}"
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 3000
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 2
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+              runAsNonRoot: true
+              runAsUser: 1001
+              runAsGroup: 1001
+    defaultPodOptions:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+    persistence:
+      data:
+        existingClaim: ${APP}
+        advancedMounts:
+          *app :
+            *app :
+            - path: /data
+              subPath: karakeep
+            meilisearch:
+              - path: /meili_data
+                subPath: meilisearch
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /run
+    service:
+      *app :
+        controller: *app
+        type: ClusterIP
+        ports:
+          http:
+            port: *port
+            targetPort: *port
+
+    route:
+      internal:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "${APP}.${ROOT_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: *app
+                port: *port
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: local-user

--- a/kubernetes/apps/equestria/home/karakeep/ks.yaml
+++ b/kubernetes/apps/equestria/home/karakeep/ks.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app karakeep
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: meilisearch
+      namespace: equestria
+  path: ./kubernetes/apps/equestria/home/karakeep
+  prune: true
+  force: false
+  wait: true
+  interval: 1h
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../../components/failover/fast-node-eviction
+    - ../../../../components/tailscale
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_ACCESSMODES: ReadWriteOnce

--- a/kubernetes/apps/equestria/home/karakeep/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/karakeep/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./definition.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/equestria/home/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./immich/ks.yaml
+  - ./n8n/ks.yaml
+  - ./dynacat/ks.yaml
+  - ./obsidian-sync/ks.yaml
+  - ./super-productivity/ks.yaml
+  - ./windmill/ks.yaml
+  - ./rustdesk/ks.yaml
+  - ./tandoor/ks.yaml
+  - ./freshrss/ks.yaml
+  - ./searxng/ks.yaml
+  # - ./karakeep/ks.yaml
+  - ./meilisearch/ks.yaml
+  - ./tududi/ks.yaml
+  # - ./outline/ks.yaml
+  # - ./collabora/ks.yaml

--- a/kubernetes/apps/equestria/home/meilisearch/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/meilisearch/externalsecret.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-env
+  namespace: equestria
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-env
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        TZ: "${TIMEZONE}"
+        MEILI_NO_ANALYTICS: "true"
+        MEILI_MASTER_KEY: "{{ .meili_password }}"
+  dataFrom:
+    - extract:
+        # was: MeiliSearch Secret Key
+        key: shared/meilisearch-secret-key
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "meili_$1"

--- a/kubernetes/apps/equestria/home/meilisearch/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/meilisearch/helmrelease.yaml
@@ -1,0 +1,73 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: meilisearch
+spec:
+  interval: 1h
+  url: https://meilisearch.github.io/meilisearch-kubernetes
+---
+# HelmRelease for standalone MeiliSearch (broken out from karakeep)
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: meilisearch
+spec:
+  chart:
+    spec:
+      chart: meilisearch
+      version: 0.38.0
+      sourceRef:
+        kind: HelmRepository
+        name: meilisearch
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    auth:
+      existingMasterKeySecret: meilisearch-env
+    fullnameOverride: meilisearch
+    envFrom:
+      - secretRef:
+          name: meilisearch-env
+    # NOTE: this chart's key is `environment:` (rendered into the
+    # meilisearch-environment ConfigMap and consumed via envFrom), NOT `env:`.
+    # The previous `env:` block was silently ignored by the chart — see vault#102.
+    environment:
+      MEILI_NO_ANALYTICS: "true"
+      # One-way on-startup DB migration 1.47.0 -> 1.51.0. See vault#102.
+      MEILI_UPGRADE_DB: "true"
+      # Production now that meilisearch-env resolves a real MEILI_MASTER_KEY
+      # (42 bytes, from secrets/shared/meilisearch-secret-key in OpenBao).
+      # It was pinned to "development" only because that key rendered empty and
+      # production refuses to boot without >=16 bytes.
+      #
+      # This is the change that makes Meilisearch ENFORCE auth. Until now it has
+      # been answering /keys with no credentials at all, because the pod has
+      # been running since before the key existed — the StatefulSet carries no
+      # reloader annotation, so the Secret gaining a value never restarted it.
+      # Editing this map changes the chart's checksum/config annotation, which
+      # rolls the pod and picks up the key and this setting together.
+      MEILI_ENV: "production"
+
+    persistence:
+      enabled: true
+      storageClass: longhorn
+
+    serviceMonitor:
+      enabled: true
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi

--- a/kubernetes/apps/equestria/home/meilisearch/ks.yaml
+++ b/kubernetes/apps/equestria/home/meilisearch/ks.yaml
@@ -1,0 +1,35 @@
+---
+# ks.yaml - Flux Kustomization for meilisearch
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app meilisearch
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/equestria/home/meilisearch
+  prune: true
+  wait: true
+  interval: 1h
+  timeout: 10m
+  dependsOn:
+    - name: external-secrets
+      namespace: kube-system
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../../components/failover/fast-node-eviction
+    - ../../../../components/tailscale
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/equestria/home/meilisearch/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/meilisearch/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/equestria/home/n8n/definition.yaml
+++ b/kubernetes/apps/equestria/home/n8n/definition.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: N8N
+  category: Applications
+  description: Workflow Automation Tool
+  url: &url https://${APP}.${ROOT_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/n8n.svg
+  access_policy:
+    groups:
+      - friends
+      - family
+  authentik:
+    proxy:
+      mode: "forward_single"
+      externalHost: *url
+  gatus:
+    - group: "Applications"
+      url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/equestria/home/n8n/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/n8n/externalsecret.yaml
@@ -1,0 +1,57 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-env
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-env
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        DB_TYPE: postgresdb
+        DB_POSTGRESDB_PORT: "{{ .postgres_port }}"
+        DB_POSTGRESDB_DATABASE: "{{ .postgres_database }}"
+        DB_POSTGRESDB_HOST: "{{ .postgres_hostname }}"
+        DB_POSTGRESDB_USER: "{{ .postgres_username }}"
+        DB_POSTGRESDB_PASSWORD: "{{ .postgres_password }}"
+        N8N_ENCRYPTION_KEY: "{{ .n8n_password }}"
+        N8N_LICENSE_ACTIVATION_KEY: "{{ .n8n_license_key }}"
+  dataFrom:
+    - extract:
+        # was: N8N
+        key: shared/n8n
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "n8n_$1"
+    - extract:
+        key: '${APP}-postgres'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: database
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "postgres_$1"

--- a/kubernetes/apps/equestria/home/n8n/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/n8n/helmrelease.yaml
@@ -1,0 +1,200 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app n8n
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  driftDetection:
+    mode: enabled
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: true
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        pod:
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 1000
+            runAsGroup: 568
+        initContainers:
+          fix-permissions:
+            image:
+              repository: busybox
+              tag: 1.38.0@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616
+            command:
+              - /bin/sh
+              - -c
+              - |
+                chown -R 1000:1000 /config
+            securityContext:
+              runAsUser: 0
+              runAsGroup: 0
+              capabilities:
+                add:
+                  - CHOWN
+                  - FOWNER
+        containers:
+          *app :
+            image:
+              repository: ghcr.io/n8n-io/n8n
+              tag: 2.35.2@sha256:76ceaf6a44e0448788f690ef8719fedefe5d260771165f288fdeb5d05bc3b3a6
+            env:
+              N8N_PORT: &port 8080
+              N8N_HOST: &host "n8n.${ROOT_DOMAIN}"
+              WEBHOOK_URL: "https://n8n.${ROOT_DOMAIN}"
+              N8N_USER_FOLDER: /config
+              N8N_RUNNERS_ENABLED: true
+              N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS: false
+              GENERIC_TIMEZONE: "${TIMEZONE}"
+              TZ: "${TIMEZONE}"
+
+              # User management
+              EXTERNAL_HOOK_FILES: /hooks/hooks.js
+              N8N_FORWARD_AUTH_HEADER: X-Authentik-Email
+              N8N_BLOCK_ENV_ACCESS_IN_NODE: false
+
+              # App Configuration
+              N8N_PERSONALIZATION_ENABLED: true
+              N8N_VERSION_NOTIFICATIONS_ENABLED: false
+              N8N_HIRING_BANNER_ENABLED: false
+              N8N_USER_MANAGEMENT_DISABLED: true
+              N8N_TEMPLATES_ENABLED: true
+              N8N_PROXY_HOPS: "1"
+
+              # Logging
+              N8N_LOG_LEVEL: debug
+              N8N_LOG_OUTPUT: console
+              N8N_DIAGONISTICS_ENABLED: true
+              N8N_METRICS: true
+              # NODE_FUNCTION_ALLOW_EXTERNAL: databricks/sql
+              NODE_FUNCTION_ALLOW_BUILTIN: crypto,fs
+              NODE_OPTIONS: "--max-old-space-size=768"
+            envFrom:
+              - secretRef:
+                  name: ${APP}-env
+            resources:
+              requests:
+                cpu: 50m
+                memory: 512Mi
+              limits:
+                memory: 1Gi
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *port
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+              readiness:
+                <<: *probes
+                spec:
+                  httpGet:
+                    path: /healthz/readiness
+                    port: *port
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    defaultPodOptions:
+      securityContext:
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: false
+        runAsUser: 1000
+        runAsGroup: 568
+        seccompProfile: { type: RuntimeDefault }
+
+    persistence:
+
+      config:
+        existingClaim: ${APP}
+        globalMounts:
+          - path: /home/node/
+            subPath: home
+          - path: /config
+      cache:
+        type: emptyDir
+        globalMounts:
+          - path: /config/.cache
+      hook-files:
+        type: configMap
+        name: n8n-hooks
+        defaultMode: 493
+        globalMounts:
+          - path: /hooks/hooks.js
+            subPath: hooks.js
+            readOnly: true
+
+      media:
+        existingClaim: truenas-media
+        globalMounts:
+          - path: /media
+            readOnly: true
+
+    service:
+      app:
+        controller: *app
+        type: ClusterIP
+        ports:
+          http:
+            port: *port
+
+    route:
+      internal:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "${APP}.${ROOT_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: authenticated-user

--- a/kubernetes/apps/equestria/home/n8n/ks.yaml
+++ b/kubernetes/apps/equestria/home/n8n/ks.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app n8n
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/equestria/home/n8n
+  prune: true
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+    - name: postgres
+      namespace: database
+    - name: valkey
+      namespace: database
+    - name: external-secrets
+      namespace: kube-system
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../../components/failover/fast-node-eviction
+    - ../../../../components/postgres
+    - ../../../../components/tailscale
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_ACCESSMODES: ReadWriteMany
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"

--- a/kubernetes/apps/equestria/home/n8n/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/n8n/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./definition.yaml
+configMapGenerator:
+  - name: n8n-hooks
+    files:
+      - ./resources/hooks.js
+    options:
+      annotations:
+        kustomize.toolkit.fluxcd.io/substitute: disabled
+      disableNameSuffixHash: true

--- a/kubernetes/apps/equestria/home/n8n/resources/hooks.js
+++ b/kubernetes/apps/equestria/home/n8n/resources/hooks.js
@@ -1,0 +1,193 @@
+module.exports = {
+  n8n: {
+    ready: [
+      async function ({ app }, config) {
+        const { dirname, resolve } = require("path");
+        const { randomBytes } = require("crypto");
+        const { hash } = require("bcryptjs");
+        const { issueCookie } = require(resolve(
+          dirname(require.resolve("n8n")),
+          "auth/jwt"
+        ));
+
+        // Trust the proxy for correct X-Forwarded-* handling and rate limiting
+        app.set("trust proxy", 1);
+
+        const ignoreAuth =
+          /^\/(assets|healthz|webhook|rest\/oauth2-credential|health)/;
+        const cookieName = "n8n-auth";
+
+        const UserRepo = this.dbCollections.User;
+        const RoleRepo = this.dbCollections.Role;
+
+        const { stack } = app.router;
+        const idx = stack.findIndex((l) => l?.name === "cookieParser");
+
+        // Derive the Layer class from an existing router-stack entry (every
+        // entry is a Layer instance). This is version-independent and avoids
+        // requiring the internal "router/lib/layer" module path, which is not
+        // resolvable from /hooks and was removed in the router version bundled
+        // with newer n8n images (>= 2.30.x).
+        const Layer = (stack[idx] ?? stack[0]).constructor;
+
+        const layer = new Layer(
+          "/",
+          { strict: false, end: false },
+          async (req, res, next) => {
+            try {
+              // Skip if URL matches ignore list
+              if (ignoreAuth.test(req.url)) return next();
+
+              // Skip until instance owner setup is complete
+              if (!config.get("userManagement.isInstanceOwnerSetUp", false))
+                return next();
+
+              // Skip if auth cookie already present
+              if (req.cookies?.[cookieName]) return next();
+
+              // X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid,X-authentik-jwt,X-authentik-meta-jwks,X-authentik-meta-outpost,X-authentik-meta-provider,X-authentik-meta-app,X-authentik-meta-version
+              // Read email and optional names from headers/JWT
+              const emailHeader = req.headers["x-authentik-email"];
+              const authHeader = req.headers["x-authentik-jwt"] || "";
+              let firstName = req.headers["x-authentik-name"] || "";
+              let lastName = "";
+
+              // Try to extract given/family names from JWT payload
+              if (authHeader) {
+                try {
+                  const token = String(authHeader).replace(/^Bearer\s+/i, "");
+                  const parts = token.split(".");
+                  if (parts.length === 3) {
+                    const payload = JSON.parse(
+                      Buffer.from(parts[1], "base64").toString()
+                    );
+                    firstName = payload.given_name || payload.firstName || "";
+                    lastName = payload.family_name || payload.lastName || "";
+                    this.logger?.debug(
+                      `Extracted from JWT: firstName="${firstName}", lastName="${lastName}"`
+                    );
+                  }
+                } catch (e) {
+                  this.logger?.debug(`Failed to decode JWT: ${e.message}`);
+                }
+              }
+
+              const userEmail = Array.isArray(emailHeader)
+                ? emailHeader[0]
+                : String(emailHeader).trim();
+              const userFirstName = Array.isArray(firstName)
+                ? firstName[0]
+                : String(firstName).trim();
+              const userLastName = Array.isArray(lastName)
+                ? lastName[0]
+                : String(lastName).trim();
+
+              this.logger?.info(
+                `SSO auto-login attempt for email: ${userEmail}`
+              );
+
+              // 1) Try to fetch the user including the 'role' relation (needed by n8n 1.112.6)
+              let user = await UserRepo.findOne({
+                where: { email: userEmail },
+                relations: ["role"],
+              });
+
+              // 2) If not found — create the user (with 'global:member' role) and a project
+              if (!user) {
+                const hashed = await hash(randomBytes(16).toString("hex"), 10);
+
+                const userData = {
+                  email: userEmail,
+                  role: "global:member", // string-based role is valid for createUserWithProject
+                  password: hashed,
+                  firstName: firstName,
+                  lastName: lastName,
+                };
+
+                const created = await UserRepo.createUserWithProject(userData);
+                user = created.user;
+
+                this.logger?.info(
+                  `Created new user: ${userEmail} (${userFirstName} ${userLastName}) via SSO`
+                );
+              } else {
+                // 3) Update first/last name if they changed upstream
+                let changed = false;
+                if (userFirstName && user.firstName !== userFirstName) {
+                  user.firstName = userFirstName;
+                  changed = true;
+                }
+                if (userLastName && user.lastName !== userLastName) {
+                  user.lastName = userLastName;
+                  changed = true;
+                }
+                if (changed) {
+                  await UserRepo.save(user);
+                  this.logger?.info(
+                    `Updated user: ${userEmail} (${userFirstName} ${userLastName}) via SSO`
+                  );
+                } else {
+                  this.logger?.info(
+                    `Existing user logged in: ${userEmail} via SSO`
+                  );
+                }
+              }
+
+              // 4) Ensure 'user.role' exists (critical in 1.112.6, which dereferences role.slug)
+              if (!user.role) {
+                // Try to load by roleId
+                if (user.roleId && RoleRepo) {
+                  user.role = await RoleRepo.findOneBy({ id: user.roleId });
+                } else {
+                  // As a last resort, reload the user with relations
+                  const reloaded = await UserRepo.findOne({
+                    where: { id: user.id },
+                    relations: ["role"],
+                  });
+                  if (reloaded) user = reloaded;
+                }
+              }
+
+              if (!user.role || !user.role.slug) {
+                // Without a valid role cookie issuance will crash on 1.112.6
+                this.logger?.error(
+                  `User ${userEmail} has no valid role; cannot issue cookie.`
+                );
+                res.statusCode = 401;
+                res.end(
+                  `User ${userEmail} has no valid role. Ask admin to assign a role.`
+                );
+                return;
+              }
+
+              // 5) Issue n8n auth cookie (alt: this.auth.issueCookie(res, user, project))
+              issueCookie(res, user);
+
+              // 6) Attach context for downstream middleware/routes
+              req.user = user;
+              req.userId = user.id;
+
+              return next();
+            } catch (error) {
+              this.logger?.error(`SSO middleware error: ${error.message}`);
+              return next(error);
+            }
+          }
+        );
+
+        // Insert our middleware right after cookieParser
+        stack.splice(idx + 1, 0, layer);
+        this.logger?.info("SSO middleware initialized successfully");
+
+        // Logout endpoint: clear n8n cookie and redirect to your IdP logout
+        app.get("/logout", (req, res) => {
+          this.logger?.info("User logout initiated");
+          res.clearCookie(cookieName, { path: "/" });
+          res.redirect(
+            "/oauth2/sign_out?rd=http://localhost:8080/realms/demo/protocol/openid-connect/logout"
+          );
+        });
+      },
+    ],
+  },
+};

--- a/kubernetes/apps/equestria/home/obsidian-sync/definition.yaml
+++ b/kubernetes/apps/equestria/home/obsidian-sync/definition.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: obsidian-sync
+spec:
+  name: Obsidian Sync
+  icon: https://obsidian.md/favicon.ico
+  url: &url https://obsidian-sync.${ROOT_DOMAIN}/_utils
+  description: Self-hosted Obsidian LiveSync server using CouchDB
+  category: Applications
+  access_policy:
+    groups:
+      - family
+      - friends
+
+  authentik:
+    proxy:
+      mode: "forward_single"
+      externalHost: *url
+
+  gatus:
+    - name: Obsidian Sync
+      url: https://obsidian-sync.${ROOT_DOMAIN}/_up
+      interval: 1m
+      conditions:
+        - "[STATUS] == 200"
+        - "[RESPONSE_TIME] < 1000"

--- a/kubernetes/apps/equestria/home/obsidian-sync/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/obsidian-sync/externalsecret.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}
+spec:
+  refreshInterval: 1h
+  # PHASE 6 PILOT — first ExternalSecret moved from 1Password to OpenBao.
+  #
+  # Chosen deliberately: one standalone app, one key, nothing else depends on
+  # this Secret, and a failure shows up as CouchDB rejecting auth rather than as
+  # anything cluster-wide.
+  #
+  # The `key` below is now a path INSIDE the `secrets` mount — the store pins
+  # `path: secrets`, so it is not repeated here. Field names are unchanged
+  # (`username`, `password`), which is why the template needs no edit: Phase 4
+  # migrated the item field-for-field.
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: obsidian-sync-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        couchdb-user: "{{ .username }}"
+        couchdb-password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        # was: Obsidian Sync   (1Password item title in vault Eris)
+        key: shared/obsidian-sync

--- a/kubernetes/apps/equestria/home/obsidian-sync/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/obsidian-sync/helmrelease.yaml
@@ -1,0 +1,146 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app obsidian-sync
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  driftDetection:
+    mode: enabled
+  timeout: 20m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: true
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 5984
+        runAsGroup: 5984
+        fsGroup: 5984
+        fsGroupChangePolicy: OnRootMismatch
+
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        containers:
+          app:
+            image:
+              repository: couchdb
+              tag: 3.5.2@sha256:b80216f643e99d31df318c740dbc556ac08b56444030ed1d5e6d7b0d4e625213
+
+            env:
+              TZ: ${TIMEZONE}
+              COUCHDB_USER:
+                valueFrom:
+                  secretKeyRef:
+                    name: obsidian-sync-secret
+                    key: couchdb-user
+              COUCHDB_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: obsidian-sync-secret
+                    key: couchdb-password
+
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 3
+                  periodSeconds: 5
+
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+    service:
+      *app :
+        controller: *app
+        ports:
+          http:
+            port: &port 5984
+
+    configMaps:
+      *app :
+        data:
+          cors.ini: |
+            [httpd]
+            enable_cors = true
+
+            [cors]
+            # SECURITY: Restrict origins to your specific domains in production
+            # For Obsidian apps, use: origins = https://app.obsidian.md, app://obsidian.md
+            # For development/testing only, you can use: origins = *
+            origins = *
+            credentials = true
+            methods = GET, PUT, POST, HEAD, DELETE
+            headers = accept, authorization, content-type, origin, referer
+            max_age = 3600
+
+    persistence:
+      data:
+        enabled: true
+        existingClaim: *app
+        globalMounts:
+          - path: /opt/couchdb/data
+
+      config:
+        enabled: true
+        type: configMap
+        name: *app
+        globalMounts:
+          - path: /opt/couchdb/etc/local.d/cors.ini
+            subPath: cors.ini
+            readOnly: true
+
+    route:
+      internal:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "${APP}.${ROOT_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - backendRefs:
+              - identifier: *app
+                port: *port
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: local-api
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: ${APP}-cors

--- a/kubernetes/apps/equestria/home/obsidian-sync/ks.yaml
+++ b/kubernetes/apps/equestria/home/obsidian-sync/ks.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app obsidian-sync
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+    - name: external-secrets
+      namespace: kube-system
+  path: ./kubernetes/apps/equestria/home/obsidian-sync
+  prune: true
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../../components/failover/fast-node-eviction
+    - ../../../../components/tailscale
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_CAPACITY: 8Gi
+      VOLSYNC_PUID: "5984"
+      VOLSYNC_PGID: "5984"

--- a/kubernetes/apps/equestria/home/obsidian-sync/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/obsidian-sync/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./middleware.yaml
+  - ./post-install-hook.yaml
+  - ./definition.yaml

--- a/kubernetes/apps/equestria/home/obsidian-sync/middleware.yaml
+++ b/kubernetes/apps/equestria/home/obsidian-sync/middleware.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/traefik.io/middleware_v1alpha1.json
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: ${APP}-cors
+spec:
+  headers:
+    accessControlAllowCredentials: true
+    # Explicitly list required headers for security
+    accessControlAllowHeaders:
+      - "Authorization"
+      - "Content-Type"
+      - "Accept"
+      - "Origin"
+      - "X-Requested-With"
+      - "X-Auth-Token"
+    accessControlAllowMethods:
+      - GET
+      - POST
+      - PUT
+      - DELETE
+      - HEAD
+      - OPTIONS
+    # SECURITY: Pre-configured with Obsidian-specific origins
+    # Obsidian desktop app uses app://obsidian.md
+    # Obsidian web uses https://app.obsidian.md
+    accessControlAllowOriginList:
+      - "https://app.obsidian.md"
+      - "app://obsidian.md"
+      - "capacitor://localhost"
+      - "http://localhost"
+    accessControlMaxAge: 100
+    addVaryHeader: true

--- a/kubernetes/apps/equestria/home/obsidian-sync/post-install-hook.yaml
+++ b/kubernetes/apps/equestria/home/obsidian-sync/post-install-hook.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: obsidian-sync-init
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: init
+          image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              echo "Waiting for CouchDB to be ready..."
+              until curl -f -s http://obsidian-sync:5984/_up; do
+                echo "CouchDB not ready yet, waiting..."
+                sleep 5
+              done
+
+              echo "CouchDB is ready!"
+              echo "Creating initial databases..."
+
+              # Use environment variables with curl to avoid exposing credentials in process list
+              curl -X PUT -u "$${COUCHDB_USER}:$${COUCHDB_PASSWORD}" http://obsidian-sync:5984/_users || true
+              curl -X PUT -u "$${COUCHDB_USER}:$${COUCHDB_PASSWORD}" http://obsidian-sync:5984/_replicator || true
+              curl -X PUT -u "$${COUCHDB_USER}:$${COUCHDB_PASSWORD}" http://obsidian-sync:5984/_global_changes || true
+
+              echo "Initial setup complete!"
+          env:
+            - name: COUCHDB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: obsidian-sync-secret
+                  key: couchdb-user
+            - name: COUCHDB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: obsidian-sync-secret
+                  key: couchdb-password

--- a/kubernetes/apps/equestria/home/outline/definition.yaml
+++ b/kubernetes/apps/equestria/home/outline/definition.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: "Outline"
+  category: Applications
+  description: "Outline — collaborative knowledge base"
+  url: &url https://${APP}.${ROOT_DOMAIN}
+  icon: https://raw.githubusercontent.com/outline/outline/main/public/logos/outline-logo-light.png
+  access_policy:
+    groups:
+      - family
+  authentik:
+    oauth2:
+      clientType: confidential
+      allowedRedirectUris:
+        - url: "https://${APP}.${ROOT_DOMAIN}/auth/oidc.callback"
+        - url: "https://${APP}.${TAILSCALE_DOMAIN}/auth/oidc.callback"
+      propertyMappings:
+        - email
+        - openid
+        - profile
+      includeClaimsInIdToken: true
+      subMode: user_email
+  gatus:
+    - group: "Applications"
+      url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/equestria/home/outline/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/outline/externalsecret.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-values
+  namespace: equestria
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-values
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      templateFrom:
+      - target: Data
+        configMap:
+          name: ${APP}-values
+          items:
+            - key: values.yaml
+              templateAs: Values
+  dataFrom:
+    - extract:
+        key: 'Outline Secret Key'
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "outline_$1"
+
+    - extract:
+        key: '${APP}-postgres'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: database
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "postgres_$1"
+
+    - extract:
+        key: '${APP}-oidc-credentials'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: cluster
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "oidc_$1"

--- a/kubernetes/apps/equestria/home/outline/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/outline/helmrelease.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: community-charts
+spec:
+  interval: 1h
+  url: https://community-charts.github.io/helm-charts
+---
+# HelmRelease for standalone MeiliSearch (broken out from karakeep)
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: outline
+spec:
+  chart:
+    spec:
+      chart: outline
+      version: 0.9.3
+      sourceRef:
+        kind: HelmRepository
+        name: community-charts
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      strategy: rollback
+  valuesFrom:
+    - kind: Secret
+      name: ${APP}-values
+      valuesKey: values.yaml

--- a/kubernetes/apps/equestria/home/outline/ks.yaml
+++ b/kubernetes/apps/equestria/home/outline/ks.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app outline
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn: []
+  path: ./kubernetes/apps/equestria/home/outline
+  prune: true
+  force: false
+  wait: true
+  interval: 1h
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../../components/failover/fast-node-eviction
+    - ../../../../components/postgres
+    - ../../../../components/tailscale
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_ACCESSMODES: ReadWriteOnce

--- a/kubernetes/apps/equestria/home/outline/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/outline/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./definition.yaml
+  - ./externalsecret.yaml
+configMapGenerator:
+  - name: ${APP}-values
+    files:
+      - values.yaml=./resources/values.yaml
+    options:
+      disableNameSuffixHash: true

--- a/kubernetes/apps/equestria/home/outline/resources/values.yaml
+++ b/kubernetes/apps/equestria/home/outline/resources/values.yaml
@@ -1,0 +1,227 @@
+# Default values for outline.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+image:
+  repository: outlinewiki/outline
+  # -- This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: "1.9.2@sha256:32d76719c378931dd65d93945930ca380d8376a0337d98a991fcc12b266f33cf"
+# -- This is for setting up the secret key. It will be auto generated if not set and external secret is not set.
+secretKey: "{{ .outline_password }}"
+
+# -- This is for setting up the utils secret. It will be auto generated if not set and external secret is not set.
+utilsSecret: "{{ .outline_password }}"
+
+# -- This is for setting up the file storage. More information about file storage can be found here: https://docs.getoutline.com/s/hosting/doc/file-storage-N4M0T6Ypu7
+fileStorage:
+  local:
+    rootDir: /var/lib/outline/data
+    persistence:
+      enabled: true
+      existingClaim: "${APP}"
+
+# -- This is for setting up the auth.
+auth:
+  oidc:
+    enabled: true
+    # -- This is for setting up the oidc client id.
+    clientId: "{{ .oidc_client_id }}"
+    # -- This is for setting up the oidc client secret.
+    clientSecret: "{{ .oidc_client_secret }}"
+    # -- This is for setting up the oidc auth uri.
+    authUri: "{{ .oidc_authorization_url }}"
+    # -- This is for setting up the oidc token uri.
+    tokenUri: "{{ .oidc_token_url }}"
+    # -- This is for setting up the oidc user info uri.
+    userInfoUri: "{{ .oidc_userinfo_url }}"
+    # -- This is for setting up the oidc logout uri. This is optional.
+    logoutUri: "{{ .oidc_logout_url }}"
+    # -- This is for setting up the oidc username claim.
+    usernameClaim: preferred_username
+    # -- This is for setting up the oidc display name.
+    displayName: "${CLUSTER_TITLE}"
+    # -- This is for setting up the oidc scopes.
+    scopes:
+      - openid
+      - profile
+      - email
+# -- This is for setting up the integrations. More information about integrations can be found here: https://docs.getoutline.com/s/hosting/doc/integrations-Oav5MXNDJk
+integrations:
+
+  # -- This is for setting up the iframely. More information about iframely can be found here: https://docs.getoutline.com/s/hosting/doc/iframely-HwLF1EZ9mo
+  iframely:
+    # -- This is for setting up the iframely enabled.
+    enabled: false
+    # -- This is for setting up the iframely url.
+    url: ""
+    # -- This is for setting up the iframely api key.
+    apiKey: ""
+    # -- This is for setting up the iframely existing secret. If it's set, apiKey will be ignored.
+    existingSecret:
+      # -- This is for setting up the iframely existing secret name.
+      name: ""
+      # -- This is for setting up the iframely secret key.
+      apiKeyKey: "api-key"
+
+  # -- This is for setting up the openai. More information about openai can be found here: https://docs.getoutline.com/s/hosting/doc/openai-iiTYCN9Nct
+  openAI:
+    # -- This is for setting up the openai enabled.
+    enabled: false
+    # -- This is for setting up the openai url.
+    url: ""
+    # -- This is for setting up the openai api key.
+    apiKey: ""
+    # -- This is for setting up the openai vector database url.
+    vectorDatabaseUrl: ""
+    # -- This is for setting up the openai existing secret. If it's set, apiKey will be ignored.
+    existingSecret:
+      # -- This is for setting up the openai existing secret name.
+      name: ""
+      # -- This is for setting up the openai secret key.
+      apiKeyKey: "api-key"
+
+  # -- This is for setting up the pdf export. More information about pdf export can be found here: https://docs.getoutline.com/s/hosting/doc/pdf-export-7Dn1hCyUo5
+  pdfExport:
+    # -- This is for setting up the pdf export enabled.
+    enabled: false
+    # -- This is for setting up the pdf export gotenberg url.
+    gotenbergUrl: ""
+
+  # -- This is for setting up the sentry. More information about sentry can be found here: https://docs.getoutline.com/s/hosting/doc/sentry-jxcFttcDl5
+  sentry:
+    # -- This is for setting up the sentry enabled.
+    enabled: false
+    # -- This is for setting up the sentry dsn.
+    dsn: ""
+    # -- This is for setting up the sentry tunnel.
+    tunnel: ""
+
+  # -- This is for setting up the slack. More information about slack can be found here: https://docs.getoutline.com/s/hosting/doc/slack-G2mc8DOJHk
+  slack:
+    # -- This is for setting up the slack enabled.
+    enabled: false
+    # -- This is for setting up the slack verification token.
+    verificationToken: ""
+    # -- This is for setting up the slack app id.
+    appId: ""
+    # -- This is for setting up the slack message actions.
+    messageActions: true
+    # -- This is for setting up the slack existing secret. If it's set, verificationToken will be ignored.
+    existingSecret:
+      # -- This is for setting up the slack existing secret name.
+      name: ""
+      # -- This is for setting up the slack secret key.
+      verificationTokenKey: "verification-token"
+
+  # -- This is for setting up the dropbox.
+  dropbox:
+    # -- This is for setting up the dropbox enabled.
+    enabled: false
+    # -- This is for setting up the dropbox app key.
+    appKey: ""
+    # -- This is for setting up the dropbox existing secret. If it's set, appKey will be ignored.
+    existingSecret:
+      # -- This is for setting up the dropbox existing secret name.
+      name: ""
+      # -- This is for setting up the dropbox secret key.
+      appKeyKey: "app-key"
+
+  # -- This is for setting up the linear. More information about linear can be found here: https://docs.getoutline.com/s/hosting/doc/linear-g8N2riMweL
+  linear:
+    # -- This is for setting up the linear enabled.
+    enabled: false
+    # -- This is for setting up the linear client id.
+    clientId: ""
+    # -- This is for setting up the linear client secret.
+    clientSecret: ""
+    # -- This is for setting up the linear existing secret. If it's set, clientSecret will be ignored.
+    existingSecret:
+      # -- This is for setting up the linear existing secret name.
+      name: ""
+      # -- This is for setting up the linear secret key.
+      clientSecretKey: "client-secret"
+
+  # -- This is for setting up the notion. More information about notion can be found here: https://docs.getoutline.com/s/hosting/doc/notion-2v6g7WY3l3
+  notion:
+    # -- This is for setting up the notion enabled.
+    enabled: false
+    # -- This is for setting up the notion client id.
+    clientId: ""
+    # -- This is for setting up the notion client secret.
+    clientSecret: ""
+    # -- This is for setting up the notion existing secret. If it's set, clientSecret will be ignored.
+    existingSecret:
+      # -- This is for setting up the notion existing secret name.
+      name: ""
+      # -- This is for setting up the notion secret key.
+      clientSecretKey: "client-secret"
+
+# -- This is for setting up the smtp. More information about smtp can be found here: https://docs.getoutline.com/s/hosting/doc/smtp-cqCJyZGMIB
+smtp:
+  # -- This is for setting up the smtp host.
+  host: ""
+  # -- This is for setting up the smtp port.
+  port: 587
+  # -- This is for setting up the smtp username.
+  username: ""
+  # -- This is for setting up the smtp password.
+  password: ""
+  # -- This is for setting up the smtp from email.
+  fromEmail: ""
+  # -- This is for setting up the smtp reply email.
+  replyEmail: ""
+  # -- This is for setting up the smtp tls ciphers.
+  tlsCiphers: ""
+  # -- This is for setting up the smtp secure.
+  secure: true
+  # -- This is for setting up the smtp existing secret. If it's set, password will be ignored.
+  existingSecret:
+    # -- This is for setting up the smtp existing secret name.
+    name: ""
+    # -- This is for setting up the smtp username key.
+    usernameKey: "username"
+    # -- This is for setting up the smtp secret key.
+    passwordKey: "password"
+
+# -- This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  # -- This is for setting up the ingress enabled.
+  enabled: false
+  # -- This is for setting up the ingress class name.
+  className: ""
+  # -- This is for setting up the ingress annotations.
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # -- This is for setting up the ingress hosts.
+  hosts:
+    - host: outline.mydomain.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  # -- This is for setting up the ingress tls.
+  tls: []
+  #  - secretName: outline-tls
+  #    hosts:
+  #      - outline.mydomain.com
+
+# -- External Redis parameters
+externalRedis:
+  # -- External Redis server host
+  host: "valkey.datavalkey.database.svc.cluster.local"
+  # -- External Redis server port
+  port: 6379
+
+# -- External PostgreSQL parameters
+externalPostgresql:
+  # -- External PostgreSQL server host
+  host: "{{ .postgresql_hostname }}"
+  # -- External PostgreSQL username
+  username: "{{ .postgresql_username }}"
+  # -- External PostgreSQL password
+  password: "{{ .postgresql_password }}"
+  # -- External PostgreSQL server port
+  port: 5432
+  # -- The name of the external PostgreSQL database. For more information: https://docs.getoutline.com/s/hosting/doc/docker-7pfeLP5a8t
+  database: "${APP}"

--- a/kubernetes/apps/equestria/home/rustdesk/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/rustdesk/helmrelease.yaml
@@ -1,0 +1,104 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/app-template-4.1.1/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app rustdesk
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: true
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      *app :
+        replicas: 1
+        type: statefulset
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        containers:
+          *app :
+            image:
+              repository: rustdesk/rustdesk-server
+              tag: "1.1.10-3@sha256:d9d3b36554819d855950788c197ff0abd6cba3838d1ce3a0782fce59fd412337"
+            command: ["hbbs", "-r ${RUSTDESK_IP}:21117"]
+            env:
+              TZ: ${TIMEZONE}
+              RELAY: "${RUSTDESK_IP}:21117"
+              ENCRYPTED_ONLY: "1"
+              DB_URL: /db/db_v2.sqlite3
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 256Mi
+
+          relay:
+            image:
+              repository: rustdesk/rustdesk-server
+              tag: "1.1.10-3@sha256:d9d3b36554819d855950788c197ff0abd6cba3838d1ce3a0782fce59fd412337"
+            command: ["hbbr"]
+
+    persistence:
+      db:
+        existingClaim: *app
+        globalMounts:
+          - path: /db
+            subPath: hbbs
+          - path: /root
+            subPath: root
+
+    probes:
+      startup:
+        enabled: false
+      liveness:
+        enabled: false
+      readiness:
+        enabled: false
+
+    service:
+      *app :
+        controller: *app
+        type: LoadBalancer
+        annotations:
+          io.cilium/lb-ipam-ips: "${RUSTDESK_IP}"
+          external-dns.alpha.kubernetes.io/hostname: ${APP}.${ROOT_DOMAIN}
+          gatus.home-operations.com/enabled: "false"
+          gatus.home-operations.com/endpoint: |-
+            group: services
+        ports:
+          web:
+            port: 21114
+          nat:
+            port: 21115
+          rustdesk-3:
+            port: &port 21116
+          rustdesk-4:
+            port: *port
+            protocol: UDP
+          rustdesk-5-relay:
+            port: 21117
+          rustdesk-6:
+            port: 21118
+          rustdesk-7-relay:
+            port: 21119

--- a/kubernetes/apps/equestria/home/rustdesk/ks.yaml
+++ b/kubernetes/apps/equestria/home/rustdesk/ks.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rustdesk
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/equestria/home/rustdesk
+  prune: true
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_ACCESSMODES: ReadWriteMany
+      VOLSYNC_CAPACITY: 2Gi

--- a/kubernetes/apps/equestria/home/rustdesk/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/rustdesk/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/equestria/home/searxng/definition.yaml
+++ b/kubernetes/apps/equestria/home/searxng/definition.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: searxng
+spec:
+  name: SearXNG
+  category: Applications
+  description: "Private, decentralized metasearch engine"
+  url: &url https://searxng.${ROOT_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/selfhst/icons/svg/searxng.svg
+  access_policy:
+    groups:
+      - family
+  authentik:
+    proxy:
+      mode: "forward_single"
+      externalHost: *url
+  gatus:
+    - group: "Applications"
+      url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/equestria/home/searxng/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/searxng/externalsecret.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-env
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-env
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        TZ: "${TIMEZONE}"
+        SEARXNG_SECRET: "{{ .searxng_password }}"
+  dataFrom:
+    - extract:
+        # was: SearXNG Secret Key
+        key: shared/searxng-secret-key
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: searxng_$1

--- a/kubernetes/apps/equestria/home/searxng/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/searxng/helmrelease.yaml
@@ -1,0 +1,134 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app searxng
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  driftDetection:
+    mode: enabled
+  timeout: 15m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 5
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 5
+      strategy: rollback
+  rollback:
+    force: true
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    fullnameOverride: *app
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+        containers:
+          *app :
+            image:
+              repository: searxng/searxng
+              tag: 2026.3.25-541c6c3cb@sha256:0ae88cc7056eddde1f02df272f39f6fb2884640ed7af428c5b0a6b9c3d5bb918
+              pullPolicy: IfNotPresent
+            envFrom:
+              - secretRef:
+                  name: ${APP}-env
+            env:
+              TZ: "${TIMEZONE}"
+              SEARX_SETTINGS_PATH: /etc/searxng/settings.yml
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &port 8080
+                  initialDelaySeconds: 30
+                  periodSeconds: 20
+                  timeoutSeconds: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *port
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
+    persistence:
+      data:
+        existingClaim: ${APP}
+        globalMounts:
+          - path: /var/cache/searxng/
+      config:
+        type: configMap
+        name: ${APP}-settings
+        defaultMode: 493
+        globalMounts:
+          - path: /etc/searxng/
+            readOnly: true
+
+    service:
+      *app :
+        controller: *app
+        type: ClusterIP
+        ports:
+          http:
+            port: *port
+
+    route:
+      internal:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "${APP}.${ROOT_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - backendRefs:
+              - identifier: *app
+                port: *port
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: local-user

--- a/kubernetes/apps/equestria/home/searxng/ks.yaml
+++ b/kubernetes/apps/equestria/home/searxng/ks.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app searxng
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: external-secrets
+      namespace: kube-system
+    - name: volsync
+      namespace: volsync-system
+  path: ./kubernetes/apps/equestria/home/searxng
+  prune: true
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../../components/failover/fast-node-eviction
+    - ../../../../components/tailscale
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_CAPACITY: 5Gi

--- a/kubernetes/apps/equestria/home/searxng/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/searxng/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./definition.yaml
+  - ./externalsecret.yaml
+configMapGenerator:
+- name: ${APP}-settings
+  files:
+    - resources/settings.yml
+  options:
+    disableNameSuffixHash: true

--- a/kubernetes/apps/equestria/home/searxng/resources/settings.yml
+++ b/kubernetes/apps/equestria/home/searxng/resources/settings.yml
@@ -1,0 +1,58 @@
+use_default_settings: true
+
+engines:
+  - name: bitbucket
+    disabled: false
+  - name: gitlab
+    disabled: false
+  - name: gitea
+    disabled: false
+  - name: goodreads
+    disabled: false
+  - name: hackernews
+    disabled: false
+  - name: reddit
+    disabled: false
+  - name: crossref
+    disabled: false
+  - name: free software directory
+    disabled: false
+
+# Minimal SearXNG settings.yml
+# Replace or extend with a production-ready configuration from https://docs.searxng.org/
+server:
+  bind_address: 0.0.0.0
+  port: 8080
+
+# Example placeholders
+search:
+  timeout: 10
+  image_proxy: true
+  base_url: https://searxng.${ROOT_DOMAIN}
+valkey:
+  host: valkey://valkey.database.svc.cluster.local:6379/8
+plugins:
+
+  searx.plugins.calculator.SXNGPlugin:
+    active: true
+
+  searx.plugins.infinite_scroll.SXNGPlugin:
+    active: true
+
+  searx.plugins.hash_plugin.SXNGPlugin:
+    active: true
+
+  searx.plugins.self_info.SXNGPlugin:
+    active: true
+
+  searx.plugins.tracker_url_remover.SXNGPlugin:
+    active: true
+
+  searx.plugins.unit_converter.SXNGPlugin:
+    active: true
+
+  searx.plugins.ahmia_filter.SXNGPlugin:
+    active: true
+
+  searx.plugins.hostnames.SXNGPlugin:
+    active: true

--- a/kubernetes/apps/equestria/home/super-productivity/definition.yaml
+++ b/kubernetes/apps/equestria/home/super-productivity/definition.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: "Super Productivity"
+  category: Applications
+  description: "Advanced todo list app with timeboxing, time tracking, and integrations for Jira, GitHub, GitLab and more"
+  url: &url https://${APP}.${ROOT_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/super-productivity.png
+  access_policy:
+    groups:
+      - family
+  authentik:
+    proxy:
+      mode: "forward_single"
+      externalHost: *url
+  gatus:
+    - group: "Applications"
+      url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/equestria/home/super-productivity/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/super-productivity/helmrelease.yaml
@@ -1,0 +1,112 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/app-template-4.1.1/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app super-productivity
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  driftDetection:
+    mode: enabled
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: true
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      *app :
+        replicas: 1
+        pod:
+          securityContext:
+            runAsNonRoot: false
+
+        containers:
+          *app :
+            image:
+              repository: johannesjo/super-productivity
+              tag: v18.19.0@sha256:ae91fe9ac19561e0f3669d15a2c4c71d7a75c43a29eb44ddc010ae50d1f63c82
+              pullPolicy: IfNotPresent
+            env:
+              TZ: "${TIMEZONE}"
+            securityContext:
+              runAsNonRoot: false
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop: ["ALL"]
+                add: ["NET_BIND_SERVICE", "CHOWN", "SETUID", "SETGID"]
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 80
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  failureThreshold: 3
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+
+    service:
+      app:
+        controller: *app
+        type: ClusterIP
+        ports:
+          http:
+            port: *port
+
+    route:
+      internal:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "${APP}.${ROOT_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: authenticated-user

--- a/kubernetes/apps/equestria/home/super-productivity/ks.yaml
+++ b/kubernetes/apps/equestria/home/super-productivity/ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app super-productivity
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/equestria/home/super-productivity
+  prune: true
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../../components/failover/fast-node-eviction
+    - ../../../../components/tailscale
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/equestria/home/super-productivity/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/super-productivity/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./definition.yaml

--- a/kubernetes/apps/equestria/home/tandoor/definition.yaml
+++ b/kubernetes/apps/equestria/home/tandoor/definition.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: Tandoor Recipes
+  category: Applications
+  description: Recipe management application
+  url: &url https://${APP}.${ROOT_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/tandoor-recipes.svg
+  access_policy:
+    groups:
+      - friends
+      - family
+  authentik:
+    proxy:
+      mode: "forward_single"
+      externalHost: *url
+      propertyMappings:
+        - remote_user
+  gatus:
+    - group: "Applications"
+      url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/equestria/home/tandoor/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/tandoor/externalsecret.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-env
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-env
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        ALLOWED_HOSTS: recipes.${ROOT_DOMAIN}
+        COMMENT_PREF_DEFAULT: "1"
+        DEBUG: "0"
+        DEFAULT_FROM_EMAIL: recipes@${ROOT_DOMAIN}
+        # EMAIL_HOST: smtp-relay.networking.svc.cluster.local
+        # EMAIL_PORT: 2525
+        ENABLE_PDF_EXPORT: "1"
+        ENABLE_SIGNUP: "0"
+        FRACTION_PREF_DEFAULT: "0"
+        GUNICORN_MEDIA: "0"
+        SHOPPING_MIN_AUTOSYNC_INTERVAL: "5"
+        SOCIAL_PROVIDERS: allauth.socialaccount.providers.openid_connect
+        TZ: "${TIMEZONE}"
+        SECRET_KEY: "{{ .secret_password }}"
+        DB_ENGINE: django.db.backends.postgresql
+        POSTGRES_HOST: "{{ .postgres_hostname }}"
+        POSTGRES_PORT: "{{ .postgres_port }}"
+        POSTGRES_DB: "{{ .postgres_database }}"
+        POSTGRES_USER: "{{ .postgres_username }}"
+        POSTGRES_PASSWORD: "{{ .postgres_password }}"
+        REMOTE_USER_AUTH: "1"
+  dataFrom:
+    - extract:
+        # was: Tandoor Secret Key
+        key: shared/tandoor-secret-key
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "secret_$1"
+    - extract:
+        key: '${APP}-postgres'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: database
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "postgres_$1"

--- a/kubernetes/apps/equestria/home/tandoor/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/tandoor/helmrelease.yaml
@@ -1,0 +1,129 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app tandoor
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  driftDetection:
+    mode: enabled
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: true
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        pod:
+          securityContext:
+            runAsNonRoot: false
+
+        containers:
+          *app :
+            image:
+              repository: ghcr.io/tandoorrecipes/recipes
+              tag: 2.6.13@sha256:f6c58afdea7a721d079ebd6ee5483f2c9da77dd1e709e16d60a82c218e80a451
+            env:
+              DEBUG: "0"
+              ALLOWED_HOSTS: "*"
+              GUNICORN_MEDIA: "0"
+              TANDOOR_PORT: &port 8888
+            envFrom:
+              - secretRef:
+                  name: ${APP}-env
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1024Mi
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: false
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+
+    persistence:
+      data:
+        existingClaim: *app
+        globalMounts:
+          - path: /opt/recipes/mediafiles
+            subPath: mediafiles
+          - path: /opt/recipes/staticfiles
+            subPath: staticfiles
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /opt/recipes/cookbook/static/django_js_reverse
+            subPath: django_js_reverse
+          - path: /tmp
+            subPath: tmp
+
+    service:
+      *app :
+        controller: *app
+        type: ClusterIP
+        ports:
+          http:
+            port: *port
+
+    route:
+      internal:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "${APP}.${ROOT_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - backendRefs:
+              - identifier: *app
+                port: *port
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: authenticated-user

--- a/kubernetes/apps/equestria/home/tandoor/ks.yaml
+++ b/kubernetes/apps/equestria/home/tandoor/ks.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tandoor
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+    - name: postgres
+      namespace: database
+    - name: external-secrets
+      namespace: kube-system
+  path: ./kubernetes/apps/equestria/home/tandoor
+  prune: true
+  force: false
+  wait: true
+  interval: 1h
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../../components/failover/fast-node-eviction
+    - ../../../../components/postgres
+    - ../../../../components/tailscale
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_ACCESSMODES: ReadWriteMany

--- a/kubernetes/apps/equestria/home/tandoor/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/tandoor/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# kustomization.yaml
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./definition.yaml

--- a/kubernetes/apps/equestria/home/tududi/definition.yaml
+++ b/kubernetes/apps/equestria/home/tududi/definition.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: "Tududi"
+  category: Applications
+  description: "Personal task management with CalDAV sync and OIDC SSO"
+  url: &url https://${APP}.${ROOT_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/tududi-dark.png
+  access_policy:
+    groups:
+      - family
+  authentik:
+    oauth2:
+      clientType: confidential
+      allowedRedirectUris:
+        - url: https://${APP}.${ROOT_DOMAIN}/api/oidc/callback/authentik
+        - url: https://${APP}.${TAILSCALE_DOMAIN}/api/oidc/callback/authentik
+      propertyMappings:
+        - email
+        - openid
+        - profile
+      includeClaimsInIdToken: true
+      subMode: user_email
+  gatus:
+    - group: "Applications"
+      url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/equestria/home/tududi/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/tududi/externalsecret.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-env
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-env
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        TUDUDI_SESSION_SECRET: "{{ .tududi_session_secret }}"
+        ENCRYPTION_KEY: "{{ .tududi_encryption_key }}"
+        OIDC_CLIENT_ID: "{{ .oidc_client_id }}"
+        OIDC_CLIENT_SECRET: "{{ .oidc_client_secret }}"
+        # Authentik issuer URL — openid-client's Issuer.discover() accepts both
+        # the issuer base URL and the full /.well-known/openid-configuration URL
+        OIDC_ISSUER_URL: "{{ .oidc_openid_configuration_url }}"
+  dataFrom:
+    - extract:
+        # was: Tududi
+        key: shared/tududi
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "tududi_$1"
+    - extract:
+        key: '${APP}-oidc-credentials'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: cluster
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "oidc_$1"

--- a/kubernetes/apps/equestria/home/tududi/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/tududi/helmrelease.yaml
@@ -1,0 +1,148 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app tududi
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  driftDetection:
+    mode: enabled
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: true
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    fullnameOverride: *app
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: Recreate
+        containers:
+          *app :
+            image:
+              repository: docker.io/chrisvel/tududi
+              tag: 1.3.1@sha256:8b57eaba3e97ea17ae6a26b061d28d1c46707ca1a46a767b8f5d55edca412b20
+              pullPolicy: IfNotPresent
+            envFrom:
+              - secretRef:
+                  name: ${APP}-env
+            env:
+              TZ: "${TIMEZONE}"
+              NODE_ENV: production
+              PORT: &port 3002
+              HOST: "0.0.0.0"
+              # Reverse proxy
+              TUDUDI_TRUST_PROXY: "true"
+              TUDUDI_ALLOWED_ORIGINS: "https://${APP}.${ROOT_DOMAIN}"
+              # OIDC/SSO — credentials injected via ExternalSecret
+              OIDC_ENABLED: "true"
+              OIDC_PROVIDER_NAME: "Authentik"
+              OIDC_PROVIDER_SLUG: "authentik"
+              OIDC_SCOPE: "openid profile email"
+              OIDC_AUTO_PROVISION: "true"
+              # BASE_URL constructs the OIDC redirect URI: ${BASE_URL}/api/oidc/callback/authentik
+              BASE_URL: "https://${APP}.${ROOT_DOMAIN}"
+              # CalDAV — clients connect to https://${APP}.${ROOT_DOMAIN}/caldav/
+              CALDAV_ENABLED: "true"
+              FF_ENABLE_CALDAV: "true"
+              # Database stored at /app/backend/db/production.sqlite3
+              DB_FILE: "db/production.sqlite3"
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: *port
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 4
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 30
+            securityContext:
+              readOnlyRootFilesystem: false
+    defaultPodOptions:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+
+    persistence:
+      data:
+        existingClaim: ${APP}
+        advancedMounts:
+          *app :
+            *app :
+              - path: /app/backend/db
+                subPath: db
+              - path: /app/backend/uploads
+                subPath: uploads
+
+    service:
+      *app :
+        controller: *app
+        type: ClusterIP
+        ports:
+          http:
+            port: *port
+
+    route:
+      internal:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "${APP}.${ROOT_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: *app
+                port: *port
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: local-user

--- a/kubernetes/apps/equestria/home/tududi/ks.yaml
+++ b/kubernetes/apps/equestria/home/tududi/ks.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tududi
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/equestria/home/tududi
+  prune: true
+  force: false
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+    - name: external-secrets
+      namespace: kube-system
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../../components/failover/fast-node-eviction
+    - ../../../../components/tailscale
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_ACCESSMODES: ReadWriteOnce

--- a/kubernetes/apps/equestria/home/tududi/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/tududi/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./definition.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/equestria/home/windmill/definition.yaml
+++ b/kubernetes/apps/equestria/home/windmill/definition.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: Windmill
+  category: Applications
+  description: Workflow Automation Platform
+  url: &url https://${APP}.${ROOT_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/windmill.svg
+  access_policy:
+    groups:
+      - friends
+      - family
+  authentik:
+    oauth2:
+      clientType: confidential
+      allowedRedirectUris:
+        - url: "https://${APP}.${ROOT_DOMAIN}/user/login_callback/authentik"
+        - url: "https://${APP}.${TAILSCALE_DOMAIN}/user/login_callback/authentik"
+      propertyMappings:
+        - email
+        - openid
+        - profile
+      includeClaimsInIdToken: true
+      subMode: user_email
+
+  gatus:
+    - group: "Applications"
+      url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/equestria/home/windmill/externalsecret.yaml
+++ b/kubernetes/apps/equestria/home/windmill/externalsecret.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-pguser-secret
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: database
+  refreshPolicy: Periodic
+  refreshInterval: 4m
+  target:
+    name: ${APP}-pguser-secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        uri: "{{ .postgres_uri }}"
+  dataFrom:
+    - extract:
+        key: '${APP}-postgres'
+      sourceRef:
+        storeRef:
+          kind: ClusterSecretStore
+          name: database
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _
+        - regexp:
+            source: "(.*)"
+            target: "postgres_$1"

--- a/kubernetes/apps/equestria/home/windmill/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/windmill/helmrelease.yaml
@@ -1,0 +1,83 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: windmill
+spec:
+  interval: 1h
+  url: https://windmill-labs.github.io/windmill-helm-charts/
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app windmill
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: windmill
+      version: 4.0.238
+      sourceRef:
+        kind: HelmRepository
+        name: windmill
+  maxHistory: 2
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    windmill:
+      baseDomain: ${APP}.${ROOT_DOMAIN}
+      baseProtocol: https
+      appReplicas: 2
+      lspReplicas: 1
+      multiplayerReplicas: 0
+      app:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        volumes: &volumes
+          - name: media
+            persistentVolumeClaim:
+              claimName: truenas-media
+        volumeMounts: &volumeMounts
+          - name: media
+            mountPath: /media
+      workerGroups:
+        - name: default
+          replicas: 3
+          volumes: *volumes
+          volumeMounts: *volumeMounts
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 2Gi
+        - name: native
+          replicas: 1
+          volumes: *volumes
+          volumeMounts: *volumeMounts
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+    ingress:
+      enabled: false
+    postgresql:
+      enabled: false
+    minio:
+      enabled: false
+  valuesFrom:
+    - kind: Secret
+      name: ${APP}-pguser-secret
+      valuesKey: uri
+      targetPath: windmill.databaseUrl

--- a/kubernetes/apps/equestria/home/windmill/httproute.yaml
+++ b/kubernetes/apps/equestria/home/windmill/httproute.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ${APP}
+  annotations:
+    reloader.stakater.com/auto: "true"
+    external-dns.alpha.kubernetes.io/target: "${INTERNAL_DOMAIN}"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+      kind: Gateway
+  hostnames:
+    - "${APP}.${ROOT_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: windmill-app
+          port: 8000
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: local-user

--- a/kubernetes/apps/equestria/home/windmill/ks.yaml
+++ b/kubernetes/apps/equestria/home/windmill/ks.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app windmill
+  namespace: &namespace equestria
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/equestria/home/windmill
+  prune: true
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  dependsOn:
+    - name: postgres
+      namespace: database
+    - name: external-secrets
+      namespace: kube-system
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  components:
+    - ../../../../components/failover/fast-node-eviction
+    - ../../../../components/postgres
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/equestria/home/windmill/kustomization.yaml
+++ b/kubernetes/apps/equestria/home/windmill/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./definition.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/equestria/kustomization.yaml
+++ b/kubernetes/apps/equestria/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./dns
   - ./downloads
   - ./games
+  - ./home
   - ./idp
   - ./shared
   - ./utils


### PR DESCRIPTION
## 3 of 5 — equestria namespace migration

Stacked on #797 (2/5); retargets to `main` as the stack lands.

The **`home`** group — 15 apps: collabora, dynacat, freshrss, immich, karakeep, meilisearch, n8n, obsidian-sync, outline, rustdesk, searxng, super-productivity, tandoor, tududi, windmill.

Note `dynacat` already sources from `home-operations` today (it reads `./dashboard` at the repo root, migrated ahead of this piece) — its `ks.yaml` is carried across unchanged apart from the usual two edits.

Same two per-file changes, diff-audited: `sourceRef` → `home-operations`, migration-only `deletionPolicy: Orphan` stripped. `books` stays commented out.

Build validated; 26 Kustomizations enabled at this point in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)