### PR TITLE
feat(flux-system): stage the flux-system namespace so the Phase C flip is a no-op

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/helm/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/kubernetes/apps/flux-system/flux-instance/helm/values.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/helm/values.yaml
@@ -1,0 +1,147 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/controlplaneio-fluxcd/charts/refs/heads/main/charts/flux-instance/values.schema.json
+instance:
+  distribution:
+    # renovate: datasource=github-releases depName=controlplaneio-fluxcd/distribution
+    version: 2.9.4
+    registry: "ghcr.io/fluxcd"
+  cluster:
+    networkPolicy: false
+  components:
+    - source-controller
+    - kustomize-controller
+    - helm-controller
+    - notification-controller
+  sync:
+    # >>> THE PHASE C ROOT FLIP HAPPENS ON THE `url` LINE BELOW. <<<
+    #
+    # This block is the actual root of the whole estate: flux-operator turns it
+    # into GitRepository/flux-system, which cluster-meta and cluster-apps
+    # consume. Changing `url` re-points every Kustomization in the cluster at
+    # once.
+    #
+    # It still says equestria-cluster on purpose. Piece 21 Phase B moved the
+    # FILE here without moving the POINTER -- so this repo now *defines* the
+    # root while equestria-cluster still *is* the root. Phase C is the one-line
+    # change to home-operations.git, made here, in this repo.
+    #
+    # DO NOT make that change until:
+    #   1. kubernetes/flux/cluster/ks.yaml carries `prune: false` on BOTH
+    #      cluster-meta and cluster-apps -- and it is live, not merely merged.
+    #      Verify against the cluster, not the PR:
+    #        kubectl get kustomization -n flux-system cluster-apps \
+    #          -o jsonpath='{.spec.prune}'
+    #      Without this, an incomplete tree here does not surface as drift; it
+    #      garbage-collects the cluster.
+    #   2. Every namespace reconciles from GitRepository/home-operations and
+    #      `flux get kustomizations -A` is clean.
+    # `path` stays as-is -- Phase B copied the same relative layout.
+    name: flux-system
+    kind: GitRepository
+    url: "https://github.com/david-driscoll/equestria-cluster.git"
+    ref: "refs/heads/main"
+    path: kubernetes/flux/cluster
+  kustomize:
+    patches:
+    - # Increase the number of workers
+      patch: |
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --concurrent=10
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --requeue-dependency=5s
+      target:
+        kind: Deployment
+        name: (kustomize-controller|helm-controller|source-controller)
+    - # Increase the memory limits
+      patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: all
+        spec:
+          template:
+            spec:
+              containers:
+                - name: manager
+                  resources:
+                    limits:
+                      memory: 1Gi
+      target:
+        kind: Deployment
+        name: (kustomize-controller|helm-controller|source-controller)
+    - # Enable in-memory kustomize builds
+      patch: |
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --concurrent=20
+        - op: replace
+          path: /spec/template/spec/volumes/0
+          value:
+            name: temp
+            emptyDir:
+              medium: Memory
+      target:
+        kind: Deployment
+        name: kustomize-controller
+    - # Enable Helm repositories caching
+      patch: |
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --helm-cache-max-size=10
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --helm-cache-ttl=60m
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --helm-cache-purge-interval=5m
+      target:
+        kind: Deployment
+        name: source-controller
+    - # Flux near OOM detection for Helm
+      patch: |
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --feature-gates=OOMWatch=true
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --oom-watch-memory-threshold=95
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --oom-watch-interval=500ms
+      target:
+        kind: Deployment
+        name: helm-controller
+    - # Disable chart digest tracking
+      patch: |
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --feature-gates=DisableChartDigestTracking=true
+      target:
+        kind: Deployment
+        name: helm-controller
+    - # Controller-level SOPS decryption
+      patch: |
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --sops-age-secret=sops-age
+      target:
+        kind: Deployment
+        name: kustomize-controller
+    - # Watch configmaps and secrets attached to HelmReleases and Kustomizations
+      patch: |-
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --watch-configs-label-selector=owner!=helm
+      target:
+        kind: Deployment
+        name: (helm-controller|kustomize-controller)
+    - # Cancel health checks on new Kustomizations revisions
+      patch: |-
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --feature-gates=CancelHealthCheckOnNewRevision=true
+      target:
+        kind: Deployment
+        name: kustomize-controller

--- a/kubernetes/apps/flux-system/flux-instance/helm/values.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/helm/values.yaml
@@ -13,29 +13,6 @@ instance:
     - helm-controller
     - notification-controller
   sync:
-    # >>> THE PHASE C ROOT FLIP HAPPENS ON THE `url` LINE BELOW. <<<
-    #
-    # This block is the actual root of the whole estate: flux-operator turns it
-    # into GitRepository/flux-system, which cluster-meta and cluster-apps
-    # consume. Changing `url` re-points every Kustomization in the cluster at
-    # once.
-    #
-    # It still says equestria-cluster on purpose. Piece 21 Phase B moved the
-    # FILE here without moving the POINTER -- so this repo now *defines* the
-    # root while equestria-cluster still *is* the root. Phase C is the one-line
-    # change to home-operations.git, made here, in this repo.
-    #
-    # DO NOT make that change until:
-    #   1. kubernetes/flux/cluster/ks.yaml carries `prune: false` on BOTH
-    #      cluster-meta and cluster-apps -- and it is live, not merely merged.
-    #      Verify against the cluster, not the PR:
-    #        kubectl get kustomization -n flux-system cluster-apps \
-    #          -o jsonpath='{.spec.prune}'
-    #      Without this, an incomplete tree here does not surface as drift; it
-    #      garbage-collects the cluster.
-    #   2. Every namespace reconciles from GitRepository/home-operations and
-    #      `flux get kustomizations -A` is clean.
-    # `path` stays as-is -- Phase B copied the same relative layout.
     name: flux-system
     kind: GitRepository
     url: "https://github.com/david-driscoll/equestria-cluster.git"

--- a/kubernetes/apps/flux-system/flux-instance/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/helmrelease.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flux-instance
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.58.0
+    digest: sha256:2df8a79f127d65bcc2a2c906a0f14187f923424b3b3483f0eb8887f36609eb28
+  url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance
+  verify:
+    provider: cosign
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: flux-instance
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: flux-instance
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: flux-operator
+      namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: flux-instance-values

--- a/kubernetes/apps/flux-system/flux-instance/httproute.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/httproute.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: flux-webhook
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "${TUNNEL_DOMAIN}"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+spec:
+  parentRefs:
+    - name: external
+      namespace: network
+  hostnames:
+    - "flux-${CLUSTER_CNAME}-webhook.${ROOT_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /hook/
+      backendRefs:
+        - name: webhook-receiver
+          port: 80

--- a/kubernetes/apps/flux-system/flux-instance/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app flux-instance
+  namespace: &namespace flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: flux-operator
+      namespace: flux-system
+  interval: 1h
+  path: ./kubernetes/apps/flux-system/flux-instance
+  prune: true
+  # See home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  # This is Flux itself -- never let a Kustomization ownership change
+  # cascade-delete the thing that reconciles everything else.
+  deletionPolicy: Orphan
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 10m
+  wait: false
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/flux-system/flux-instance/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/ks.yaml
@@ -23,7 +23,7 @@ spec:
   retryInterval: 2m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   timeout: 10m

--- a/kubernetes/apps/flux-system/flux-instance/kustomization.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./secret.sops.yaml
+  - ./httproute.yaml
+  - ./receiver.yaml
+  - ./policies.yaml
+configMapGenerator:
+  - name: flux-instance-values
+    files:
+      - values.yaml=./helm/values.yaml
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/flux-system/flux-instance/policies.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/policies.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: source-controller-allow-pulumi
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: source-controller
+      app.kubernetes.io/name: source-controller
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: pulumi
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: flux-system
+      ports:
+        - protocol: TCP
+          port: 80

--- a/kubernetes/apps/flux-system/flux-instance/receiver.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/receiver.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/receiver-notification-v1.json
+apiVersion: notification.toolkit.fluxcd.io/v1
+kind: Receiver
+metadata:
+  name: github-webhook
+spec:
+  type: github
+  events: ["ping", "push"]
+  secretRef:
+    name: github-webhook-token-secret
+  resources:
+    - apiVersion: source.toolkit.fluxcd.io/v1
+      kind: GitRepository
+      name: flux-system
+      namespace: flux-system
+    - apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      name: flux-system
+      namespace: flux-system
+    - apiVersion: source.toolkit.fluxcd.io/v1
+      kind: GitRepository
+      name: home-operations
+      namespace: pulumi
+    - apiVersion: source.toolkit.fluxcd.io/v1
+      kind: GitRepository
+      name: vault
+      namespace: flux-system
+    - apiVersion: source.toolkit.fluxcd.io/v1
+      kind: GitRepository
+      name: home-operations
+      namespace: flux-system

--- a/kubernetes/apps/flux-system/flux-instance/secret.sops.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/secret.sops.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-webhook-token-secret
+stringData:
+  token: ENC[AES256_GCM,data:CJtIhCBI3+yvvge2w3HGp6Ncr3DdL47CS/Aq993wCTQ=,iv:6Kz0pf45nJraPW3iYIyq2FGsk4lQvA6S0uabBYFGSvM=,tag:PkTEg9Wre0EG/xZmAEDE0w==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFenl5cGZRdnFsSzJqLy9X
+        ZVc4NmFPVDY5Yk4zQUJVZHl3dUZ6SFF1MG4wCjV3YjVpWmc5RmdYNDROVGhRbGtD
+        YU5OcGRYb0lVNU5vbnl2MWtrUEkrYmMKLS0tIFJsajFBS0dwa3Y0WndzQVozVCtD
+        MUxIbUE2UGZuUTVnb2lYbDF6c2QxUmcKlV10icPEqSfl8akHaGaiLaQ2rb0gEcwg
+        m0jtr1jnP3T1bTIMPzU9IWNuHJGflP7rwo0d3rWNXgEFjoVykYP0gg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMOGJ6MGFSOENDVVhOUlZY
+        eWplcVJmamxxdm9LQjh2UURWWVR4WUtFVlRrCi9qQXN3MEFVL0xvdXh5aVpIZWw5
+        MFo4ME9BMFcyajJZMjdacW5PcURIZE0KLS0tIGpFdkxJL0w2RVB2bVVrMEhCc0xX
+        LzFVK3pSeVpsc1R6UkhtYUc3YjVqcmcKFJ0qwG19F+W+TlvRDZmIPTeYSCgHkY+o
+        /STjFnMDJUrIGKGYG5ZZhf9cxDVtCHKG7t9ntHEGPSPHnOaMF7Nd6Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2025-04-10T04:32:15Z"
+  mac: ENC[AES256_GCM,data:kvMxObio/aky5ZbPEE5701bkEtkjLf+HJRVCaDGJIdF+Er+tUW/goZsQ1lkvmot7oPmBsd7PI4ZgLkt/3Ol4tq0aHOI61I0cMMt9LPs85GnKGXxTGS1Y3cpNXeT3KDOpGbg0rxSOBOmnWooXst40aQASK2+b1b7hpCOjULVcEUk=,iv:cIjMiP2P/fAWwzGnR/PKrE0beBxrxpc1tPJ5uYOuKcM=,tag:KjtZzNSXwsWrwYHRG/fr2w==,type:str]
+  mac_only_encrypted: true
+  version: 3.10.1

--- a/kubernetes/apps/flux-system/flux-operator/definition.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/definition.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: Flux Operator
+  category: ${CLUSTER_TITLE}
+  description: Access to the Flux Operator dashboard
+  url: &url https://flux.${CLUSTER_DOMAIN}
+  icon: https://fluxoperator.dev/favicon.svg
+  access_policy:
+    groups:
+      - admins
+  authentik:
+    proxy:
+      mode: "forward_single"
+      externalHost: *url
+  gatus:
+    - url: *url
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/flux-system/flux-operator/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/helm/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/kubernetes/apps/flux-system/flux-operator/helm/values.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/helm/values.yaml
@@ -1,0 +1,12 @@
+---
+serviceMonitor:
+  create: true
+web:
+  httpRoute:
+    enabled: true
+    parentRefs:
+      - name: internal
+        namespace: network
+        kind: Gateway
+    hostnames:
+      - "flux.${CLUSTER_DOMAIN}"

--- a/kubernetes/apps/flux-system/flux-operator/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/helmrelease.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flux-operator
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.58.0
+    digest: sha256:1ccf038123198fab1923b3fc4977154bd4cc3729f4c7d957dedf09478d9d19d5
+  url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
+  verify:
+    provider: cosign
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: flux-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: flux-operator
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  driftDetection:
+    mode: enabled
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  valuesFrom:
+    - kind: ConfigMap
+      name: flux-operator-values

--- a/kubernetes/apps/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app flux-operator
+  namespace: &namespace flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
+  path: ./kubernetes/apps/flux-system/flux-operator
+  prune: true
+  # See flux-instance/ks.yaml.
+  deletionPolicy: Orphan
+  wait: false
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   postBuild:

--- a/kubernetes/apps/flux-system/flux-operator/kustomization.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./podmonitor.yaml
+  - ./definition.yaml
+configMapGenerator:
+  - name: flux-operator-values
+    files:
+      - values.yaml=./helm/values.yaml
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/flux-system/flux-operator/podmonitor.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/podmonitor.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: flux-system
+  labels:
+    app.kubernetes.io/part-of: flux
+    app.kubernetes.io/component: monitoring
+spec:
+  namespaceSelector:
+    matchNames:
+      - flux-system
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - helm-controller
+          - source-controller
+          - kustomize-controller
+          - notification-controller
+          - image-automation-controller
+          - image-reflector-controller
+          - pulumi-operator-controller-manager
+  podMetricsEndpoints:
+    - port: http-prom

--- a/kubernetes/apps/flux-system/kustomization.yaml
+++ b/kubernetes/apps/flux-system/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+components:
+  - ../../components/alerts
+  - ../../components/common
+resources:
+  - ./flux-instance/ks.yaml
+  - ./flux-operator/ks.yaml
+  - ./repositories/ks.yaml

--- a/kubernetes/apps/flux-system/repositories/home-operations.yaml
+++ b/kubernetes/apps/flux-system/repositories/home-operations.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: home-operations
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://github.com/david-driscoll/home-operations.git
+  ref:
+    branch: main

--- a/kubernetes/apps/flux-system/repositories/ks.yaml
+++ b/kubernetes/apps/flux-system/repositories/ks.yaml
@@ -28,7 +28,7 @@ spec:
   retryInterval: 2m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   timeout: 10m

--- a/kubernetes/apps/flux-system/repositories/ks.yaml
+++ b/kubernetes/apps/flux-system/repositories/ks.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app repositories
+  namespace: &namespace flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: flux-instance
+      namespace: flux-system
+  interval: 1h
+  path: ./kubernetes/apps/flux-system/repositories
+  prune: true
+  # PERMANENT, unlike the blanket Orphan the piece 21 sweep put on ordinary
+  # namespaces (which is stripped as each one lands here). This Kustomization
+  # owns GitRepository/home-operations -- the source every single -ref
+  # redirect in equestria-cluster reads from, and the source this very
+  # Kustomization reads from. Cascade-deleting it does not break one app; it
+  # severs the tree from the repo that defines it, with no path back through
+  # GitOps. Same reasoning as flux-instance/ks.yaml and flux-operator/ks.yaml.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: home-operations
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 10m
+  wait: false
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/flux-system/repositories/kustomization.yaml
+++ b/kubernetes/apps/flux-system/repositories/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./vault.yaml
+  - ./home-operations.yaml

--- a/kubernetes/apps/flux-system/repositories/vault.yaml
+++ b/kubernetes/apps/flux-system/repositories/vault.yaml
@@ -1,0 +1,46 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: vault
+spec:
+  interval: 1h
+  url: ssh://git@github.com/david-driscoll/vault
+  ref:
+    branch: main
+  secretRef:
+    name: vault-ssh-credentials
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: vault-ssh-credentials
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  refreshPolicy: Periodic
+  refreshInterval: 1m
+  target:
+    name: vault-ssh-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        identity: "{{ .private_key }}"
+        known_hosts: "{{ .known_hosts }}"
+  dataFrom:
+    - extract:
+        # was: GitHub david-driscoll/vault Deploy Key
+        key: shared/github-david-driscoll-vault-deploy-key
+      rewrite:
+        - regexp:
+            source: "[\\W]"
+            target: _


### PR DESCRIPTION
Stages `kubernetes/apps/flux-system/**` here so the Phase C root flip applies **zero diff** to Flux's own Kustomizations.

**This PR is inert.** Nothing points at this path until the flip. It supersedes the earlier redirect approach — see "Why not a `-ref` redirect" below.

## The design

The three child Kustomizations (`flux-instance`, `flux-operator`, `repositories`) keep `sourceRef: flux-system` — the *self* GitRepository, which is what the live objects already say. Post-flip that resolves to this repo, so the flip updates nothing. It's also where piece 21's Phase C step 5 cleanup was headed anyway.

`flux-instance/helm/values.yaml` is byte-identical to equestria's. **A comment in that file is actively unsafe:**

```yaml
# flux-instance/kustomization.yaml
configMapGenerator:
  - name: flux-instance-values        # <- no disableNameSuffixHash
    files: [values.yaml=./helm/values.yaml]
configurations: [./helm/kustomizeconfig.yaml]   # rewrites spec/valuesFrom/name
```

The file is embedded verbatim into a **content-hashed** ConfigMap. Any byte change — including a comment — renames the ConfigMap, which changes the HelmRelease's `valuesFrom`, which triggers a Helm upgrade of the chart that manages Flux itself. An earlier revision of this PR added a comment block there; it's removed, and that guidance lives in the docs instead.

Comments in the three `ks.yaml` files are kept — kustomize strips comments, so they cost nothing in the render.

## Proof the flip is a no-op

```bash
kustomize build --load-restrictor LoadRestrictionsNone <equestria>/kubernetes/apps/flux-system
kustomize build --load-restrictor LoadRestrictionsNone kubernetes/apps/flux-system
```

With #803's `components/common` applied, the **only** remaining delta is the `decryption` + `substituteFrom` blocks this repo injects at *build* time (via `components/common`'s `kind: Kustomization` patch). equestria gets the identical fields injected at *apply* time by `cluster-apps`'s own patch.

Confirmed against the live objects — they already carry exactly that:

```
spec.decryption   {"provider":"sops","secretRef":{"name":"sops-age"}}
spec.postBuild    substituteFrom: [cluster-secrets, cluster-versions, shared-secrets]
```

Both paths converge on the same applied object. **At the flip these three Kustomizations are re-applied with a spec identical to what is already live.**

## Why not a `-ref` redirect (supersedes equestria-cluster#3170)

The `-ref` pattern exists to move a namespace's source *ahead of* the root flip. For `flux-system` that buys nothing — the flip moves it for free — while costing a prune event on Flux's own Kustomizations at the one moment when recovery requires out-of-band `kubectl`.

It also **destroys the rollback path**: #3170 deletes equestria's `flux-instance/`, `flux-operator/` and `repositories/` directories, so reverting `instance.sync.url` would land on a tree that no longer defines Flux. Leaving equestria's tree intact means the flip is revertible with one commit.

`deletionPolicy: Orphan` would have made #3170 survivable — all 16 other `-ref` redirects prove the mechanism. But "survivable" is a worse property than "never happens".

**equestria-cluster#3170 should be closed, not merged.**

## Sequence

1. #803 — Flux root + `versions.env` (`cluster-versions` must exist before the flip)
2. This PR — inert staging
3. Phase C — flip `instance.sync.url` in **equestria's** `values.yaml` (still the live one), with `prune: false` verified live first

🤖 Generated with [Claude Code](https://claude.com/claude-code)