### PR TITLE
feat(postgres): heartbeat the dockge Postgres dumps so a stale backup is loud

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -662,6 +662,14 @@ export class DockgeLxc extends ComponentResource {
 
     const replacements = [
       replaceVariable(/\$\{host\}/g, output(this.args.host.shortName ?? this.args.host.name)),
+      // The dockge instance's STABLE identity — the ComponentResource name
+      // ("celestia-dockge"), which is also the `name` field written to
+      // `hosts/dockge/<slug>` and therefore what `getDockgeInstances()` hands
+      // stacks/backups as `detail.name`. `${host}` is NOT a substitute: it is
+      // `shortName ?? name`, so on alpha-site it renders "as". Anything that
+      // has to line up with a cross-stack consumer of the dockge inventory
+      // must use this one.
+      replaceVariable(/\$\{DOCKGE_NAME\}/g, this.name),
       replaceVariable(/\$\{searchDomain\}/g, this.args.globals.searchDomain),
       replaceVariable(/\$\{ROOT_DOMAIN\}/g, this.args.globals.searchDomain),
       replaceVariable(/\$\{TIMEZONE\}/g, "America/New_York"),

--- a/docker/_common/postgres/.env
+++ b/docker/_common/postgres/.env
@@ -23,6 +23,25 @@ TIMEZONE=${TIMEZONE}
 POSTGRES_DUMP_INTERVAL_SECONDS=86400
 POSTGRES_DUMP_KEEP_DAYS=14
 
+# --- dump reporting --------------------------------------------------------
+# backup.sh pushes the result of every cycle to a Gatus external endpoint, so
+# that dumps which stop being produced -- or a postgres that is unreachable --
+# surface as a failed check instead of as a warning in a container log. The
+# endpoint is registered per dockge host in stacks/backups/index.ts; Gatus uses
+# the token as both the URL path segment and the bearer, and expires the
+# heartbeat if no push arrives, which also covers the container being stopped.
+#
+# The token must equal toGatusKey("Dockge Postgres Dumps", <dockge name>) from
+# that stack. DOCKGE_NAME -- written without its sigils here, because a comment
+# is substituted exactly like a value is -- is the token that yields the SAME
+# identity the backups stack reads out of hosts/dockge (`detail.name`, e.g.
+# "celestia-dockge"). Do not switch it to the host token, which is the SHORT
+# name and renders "as" on alpha-site. The "dockge-postgres-dumps_" prefix
+# restates toGatusKey's group half; it is stable because the group title is a
+# constant in that stack, and both sides carry a pointer to the other.
+POSTGRES_DUMP_UPTIME_URL=$UPTIME_API_URL
+POSTGRES_DUMP_UPTIME_TOKEN=dockge-postgres-dumps_${DOCKGE_NAME}
+
 # --- application databases -------------------------------------------------
 # Declared per host, NOT here. Any variable named PGAPP_<NAME>_PASSWORD makes
 # provision.sh create a login role <name> and a database <name> owned by it.

--- a/docker/_common/postgres/backup.sh
+++ b/docker/_common/postgres/backup.sh
@@ -10,20 +10,66 @@
 # backup source — each one a consistent snapshot taken inside a single
 # transaction, written to a path that IS in backup scope.
 #
+# WHY IT REPORTS. restic snapshotting a dumps directory succeeds whether the
+# directory holds last night's dumps or a fortnight-old set, so the backrest
+# plan's own success hook cannot tell you the dumps stopped being produced.
+# Everything below therefore ends each cycle by pushing the result to a Gatus
+# external endpoint whose heartbeat expires if no push arrives — the same
+# dead-man's-switch shape BackupPlanDirector gives every backrest plan, and the
+# closest docker-side equivalent of a failed Kubernetes CronJob. A cycle that
+# dumps nothing, or that cannot reach the server at all, now reports failure
+# instead of printing a warning into a log nobody reads.
+#
 # NOTE FOR EDITORS: this file is run through the Pulumi variable substitution
 # in components/DockgeLxc.ts. Do not introduce shell variables named host,
-# hostname, ipAddress, searchDomain, APP, STACK_NAME, CLUSTER_*, TIMEZONE, or
-# UPTIME_API_URL — those tokens are rewritten in transit.
+# hostname, ipAddress, searchDomain, APP, STACK_NAME, CLUSTER_*, DOCKGE_NAME,
+# TIMEZONE, or UPTIME_API_URL — those tokens are rewritten in transit.
 set -eu
 
 interval="${POSTGRES_DUMP_INTERVAL_SECONDS:-86400}"
 keep_days="${POSTGRES_DUMP_KEEP_DAYS:-14}"
 out_dir=/dumps
 
+# Last-cycle result, as `<epoch> <ok|failed>`. Read by the container
+# healthcheck in compose.yaml, and readable straight off the host when
+# something looks wrong. It lives in /dumps deliberately: the retention sweep
+# below only matches *.dump/*.sql/*.tmp, so it is never swept, and being inside
+# the backed-up directory means a restored snapshot carries the evidence of
+# when its dumps were actually taken.
+status_file="${out_dir}/.last-run"
+
+# Push target. Both are set in .env, from the DOCKGE_NAME and UPTIME_API_URL
+# substitutions -- named without their sigils here on purpose, because a
+# comment is rewritten in transit exactly like code is (see the editor note
+# above). If either is empty the reporting is skipped and the loop still dumps.
+# Gatus uses the endpoint token as both the path segment and the bearer.
+uptime_url="${POSTGRES_DUMP_UPTIME_URL:-}"
+uptime_token="${POSTGRES_DUMP_UPTIME_TOKEN:-}"
+
 echo "[backup] every ${interval}s, keeping ${keep_days} days, into ${out_dir}"
+if [ -n "$uptime_url" ] && [ -n "$uptime_token" ]; then
+  echo "[backup] reporting to ${uptime_url} as ${uptime_token}"
+else
+  echo "[backup] WARN: POSTGRES_DUMP_UPTIME_URL/TOKEN unset — no failure reporting" >&2
+fi
+
+# The postgres:18-alpine image has no curl; busybox wget does have --header and
+# --post-data, and ssl_client + ca-certificates for the TLS leg. Verified
+# against the pinned digest. A push that fails is only a warning: losing the
+# report is not a reason to lose the dumps, and a missing push already reads as
+# failure at the Gatus end once the heartbeat expires.
+report() {
+  [ -n "$uptime_url" ] && [ -n "$uptime_token" ] || return 0
+  wget -q -T 15 -O /dev/null \
+    --header="Authorization: Bearer ${uptime_token}" \
+    --post-data="" \
+    "${uptime_url}/api/v1/endpoints/${uptime_token}/external?success=$1" \
+    || echo "[backup] WARN: could not report success=$1 to uptime" >&2
+}
 
 while true; do
   stamp=$(date +%Y%m%dT%H%M%S)
+  failures=0
 
   # Roles and their passwords live outside any single database, so a per-database
   # dump alone is not restorable on a fresh cluster. --globals-only captures them.
@@ -31,30 +77,57 @@ while true; do
     mv "${out_dir}/globals-${stamp}.sql.tmp" "${out_dir}/globals-${stamp}.sql"
   else
     rm -f "${out_dir}/globals-${stamp}.sql.tmp"
-    echo "[backup] WARN: globals dump failed" >&2
+    echo "[backup] ERROR: globals dump failed" >&2
+    failures=$((failures + 1))
   fi
 
   # Template databases and the maintenance database carry nothing worth keeping.
-  for db_name in $(psql -tA -d postgres \
-      -c "SELECT datname FROM pg_database WHERE datistemplate = false AND datname <> 'postgres'"); do
-    # -Fc is the custom format: compressed, and restorable selectively with
-    # pg_restore rather than only as a whole-file replay.
-    if pg_dump -Fc -d "$db_name" -f "${out_dir}/${db_name}-${stamp}.dump.tmp"; then
-      # Rename only after a clean exit, so a dump interrupted mid-write is never
-      # mistaken for a good one by the retention sweep or by a restore.
-      mv "${out_dir}/${db_name}-${stamp}.dump.tmp" "${out_dir}/${db_name}-${stamp}.dump"
-      echo "[backup] dumped ${db_name}"
-    else
-      rm -f "${out_dir}/${db_name}-${stamp}.dump.tmp"
-      echo "[backup] WARN: dump of ${db_name} failed" >&2
-    fi
-  done
+  #
+  # The list is captured into a variable rather than inlined as `for db in
+  # $(psql ...)`: `set -e` does not check the exit status of a command
+  # substitution in a `for` list, so a server that is down or refusing
+  # connections used to yield an empty list, iterate zero times, and complete
+  # the cycle as a success. That was the single worst failure mode here —
+  # a total outage looked exactly like a host with no application databases.
+  if db_list=$(psql -tA -d postgres \
+      -c "SELECT datname FROM pg_database WHERE datistemplate = false AND datname <> 'postgres'"); then
+    for db_name in $db_list; do
+      # -Fc is the custom format: compressed, and restorable selectively with
+      # pg_restore rather than only as a whole-file replay.
+      if pg_dump -Fc -d "$db_name" -f "${out_dir}/${db_name}-${stamp}.dump.tmp"; then
+        # Rename only after a clean exit, so a dump interrupted mid-write is never
+        # mistaken for a good one by the retention sweep or by a restore.
+        mv "${out_dir}/${db_name}-${stamp}.dump.tmp" "${out_dir}/${db_name}-${stamp}.dump"
+        echo "[backup] dumped ${db_name}"
+      else
+        rm -f "${out_dir}/${db_name}-${stamp}.dump.tmp"
+        echo "[backup] ERROR: dump of ${db_name} failed" >&2
+        failures=$((failures + 1))
+      fi
+    done
+  else
+    echo "[backup] ERROR: could not list databases — server unreachable?" >&2
+    failures=$((failures + 1))
+  fi
 
   # Retention. Restic keeps its own history of these files, so this only bounds
   # what sits on the host between snapshots.
   find "$out_dir" -maxdepth 1 -type f \( -name '*.dump' -o -name '*.sql' \) \
     -mtime "+${keep_days}" -delete 2>/dev/null || true
   find "$out_dir" -maxdepth 1 -type f -name '*.tmp' -mtime +1 -delete 2>/dev/null || true
+
+  # A host with no application databases is a SUCCESS, not an empty failure:
+  # the globals dump still ran, and luna/skystar/alpha-site legitimately
+  # declare no PGAPP_* consumers today.
+  if [ "$failures" -eq 0 ]; then
+    printf '%s ok %s\n' "$(date +%s)" "$stamp" >"$status_file"
+    echo "[backup] cycle ${stamp} ok"
+    report true
+  else
+    printf '%s failed %s\n' "$(date +%s)" "$stamp" >"$status_file"
+    echo "[backup] cycle ${stamp} FAILED — ${failures} error(s)" >&2
+    report false
+  fi
 
   sleep "$interval"
 done

--- a/docker/_common/postgres/compose.yaml
+++ b/docker/_common/postgres/compose.yaml
@@ -167,6 +167,33 @@ services:
       - ./backup.sh:/backup.sh:ro
       - /opt/stacks-data/postgres/dumps:/dumps
     entrypoint: ["/bin/sh", "/backup.sh"]
+    # A stalled or failing dump loop is otherwise indistinguishable from a
+    # healthy one: the container stays up either way, and restic goes on
+    # snapshotting whatever is already in /dumps. backup.sh writes
+    # "<epoch> ok|failed" to /dumps/.last-run at the end of every cycle; this
+    # turns that into container health, so `docker ps` and Arcane show it
+    # without anyone reading logs. The paging signal is the Gatus heartbeat
+    # (POSTGRES_DUMP_UPTIME_TOKEN in .env), not this.
+    #
+    # Deliberately NOT autoheal-labelled, like the server above: restarting the
+    # loop cannot fix an unreachable database or a full disk, and a restart
+    # resets the very state this reads.
+    #
+    # `$$` is compose's escape for a literal `$`. The image has no bash, and
+    # every construct here is POSIX sh -- verified against the pinned digest.
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          set -- $$(cat /dumps/.last-run 2>/dev/null);
+          [ "$${2:-}" = ok ] || exit 1;
+          [ $$(( $$(date +%s) - $${1:-0} )) -lt $$(( $${POSTGRES_DUMP_INTERVAL_SECONDS:-86400} + 10800 )) ]
+      interval: 5m
+      timeout: 10s
+      retries: 2
+      # A cold start dumps every database on the node before it can write the
+      # first result, so nothing is judged until that has had room to finish.
+      start_period: 30m
     restart: unless-stopped
     dns:
       - 100.100.100.100

--- a/stacks/backups/index.ts
+++ b/stacks/backups/index.ts
@@ -1,6 +1,15 @@
 import { BackupPlanOrchestrator } from "@components/BackupPlanOrchestrator.ts";
 import { GlobalResources } from "@components/globals.ts";
+import { addUptimeGatus, toGatusKey } from "@components/helpers.ts";
+import type { ExternalEndpoint } from "@openapi/application-definition.js";
 import * as pulumi from "@pulumi/pulumi";
+
+// Gatus group for the per-node Postgres dumps produced by
+// docker/_common/postgres. `docker/_common/postgres/.env` restates
+// toGatusKey(this, <dockge name>) to build POSTGRES_DUMP_UPTIME_TOKEN, so this
+// string and `detail.name` below are load-bearing on both sides -- changing
+// either orphans every push and every endpoint goes permanently red.
+const DOCKGE_POSTGRES_DUMP_GROUP = "Dockge Postgres Dumps";
 
 const globals = new GlobalResources({}, {});
 const dockgeDetails = globals.store.getDockgeInstances();
@@ -56,6 +65,44 @@ const dockgeInstances = dockgeDetails.apply(details => {
       }),
     );
   });
+});
+
+// The dockge plans above snapshot /postgres/dumps, but restic cannot tell a
+// fresh dump from a fortnight-old one -- it copies whatever is on disk and
+// reports success either way. So a node whose postgres-backup loop has been
+// failing, or whose postgres is unreachable, keeps producing green backups of
+// increasingly stale dumps. These heartbeats close that hole: backup.sh pushes
+// the result of each cycle here, and Gatus pages when no push arrives inside
+// 25h -- which also covers the container being stopped or never started. It is
+// the docker-side equivalent of a failed CronJob in
+// kubernetes/apps/database/postgres/backups.
+addUptimeGatus("dockge-postgres-dumps", globals, {
+  endpoints: [],
+  "external-endpoints": dockgeDetails.apply(details =>
+    details.map(
+      detail =>
+        ({
+          enabled: true,
+          name: detail.name,
+          token: toGatusKey(DOCKGE_POSTGRES_DUMP_GROUP, detail.name),
+          group: DOCKGE_POSTGRES_DUMP_GROUP,
+          // Dumps run every POSTGRES_DUMP_INTERVAL_SECONDS (24h) with the
+          // clock starting at container start, so the window has to absorb a
+          // restart's worth of drift plus the dump itself. Same 25h the
+          // backrest plans use.
+          heartbeat: { interval: "25h" },
+          alerts: [
+            {
+              type: "pushover",
+              enabled: true,
+              "success-threshold": 1,
+              "failure-threshold": 1,
+              "minimum-reminder-interval": "24h",
+            },
+          ],
+        }) as ExternalEndpoint,
+    ),
+  ),
 });
 
 backupPlanOrchestrator.addBackupPlan(


### PR DESCRIPTION
## What this is

Every dockge host now runs a Postgres server (`docker/_common/postgres`), and the ask was to make sure those databases are backed up the way `kubernetes/apps/database/postgres/backups/cronjob.yaml` covers the cluster ones.

**They already were.** Tracing the chain end to end: `backup.sh` writes to `/opt/stacks-data/postgres/dumps` → [rclone-sftp](../blob/main/docker/_common/rclone-sftp/compose.yaml) serves that as `/data/stacks/` → the celestia backrest pre-sync pulls `/stacks/` excluding only `/postgres/pgdata` → restic snapshot, per host. The stack is deployed on all four hosts (celestia, luna, skystar, alpha-site each have a `postgres/.env-local` and no `.ignore`).

What was missing is the other half of what the CronJob gives you: **a way to know it worked.**

## The gap

restic cannot tell a fresh dump from a fortnight-old one — it snapshots whatever is on disk and reports success either way. So a node whose dump loop had been failing would keep producing green backups of increasingly stale dumps, indefinitely.

`backup.sh` made that worse in two ways:

- every failure was a `WARN` into a log nobody reads, then `sleep`;
- databases were listed as `for db in $(psql ...)`, and `set -e` does not check a command substitution in a `for` list — so an unreachable server iterated **zero** databases and completed the cycle as a **success**. A total outage looked exactly like a host with no application databases.

## The change

- **[`backup.sh`](../blob/claude/docker-postgres-dump-heartbeat/docker/_common/postgres/backup.sh)** — counts failures per cycle, makes "could not list databases" a hard error, records `<epoch> ok|failed` in `/dumps/.last-run`, and pushes each result to a Gatus external endpoint.
- **[`stacks/backups/index.ts`](../blob/claude/docker-postgres-dump-heartbeat/stacks/backups/index.ts)** — registers one external endpoint per dockge host, `heartbeat: 25h` + pushover, the same dead-man's-switch shape `BackupPlanDirector` already gives every backrest plan. This also covers the container being stopped or never started, which nothing did before.
- **[`compose.yaml`](../blob/claude/docker-postgres-dump-heartbeat/docker/_common/postgres/compose.yaml)** — healthcheck over `.last-run`.
- **[`DockgeLxc.ts`](../blob/claude/docker-postgres-dump-heartbeat/components/DockgeLxc.ts)** — new `${DOCKGE_NAME}` substitution. The token has to match on both sides; `${host}` is `shortName ?? name` and renders `as` on alpha-site, whereas `DOCKGE_NAME` is the ComponentResource name that is also written to `hosts/dockge` and handed back as `detail.name`.

The healthcheck is deliberately **not** the paging signal — see the caveat below. It is also not `autoheal`-labelled: restarting the loop cannot fix an unreachable database, and a restart resets the very state it reads.

## Verification

Ran the new script against a real `postgres:18-alpine` at the pinned digest, with a mock uptime endpoint:

| scenario | result |
| --- | --- |
| two databases present | both dumped, `success=true` pushed, healthcheck exit 0 |
| server stopped mid-flight | `ERROR: could not list databases`, `success=false` pushed, healthcheck exit 1, container still running |
| app databases dropped (luna/skystar/alpha-site today) | reports `ok` on globals alone — correct, not an empty failure |
| recovery | next cycle back to `ok`, healthcheck exit 0 |

Also confirmed against the pinned image that it has no `curl` (the push uses busybox `wget --header --post-data` over `ssl_client`), that compose unescapes `$$` to exactly the command tested, and that the rendered `.env` token is byte-identical to `toGatusKey("Dockge Postgres Dumps", <dockge name>)` for all four hosts. `tsc` and `biome` clean on the changed files.

## Deploy order

Run `stacks/backups` first so the endpoints exist before the hosts start pushing, then `home` / `ocracoke` / `gulf-of-mexico`. A push to an unregistered endpoint is only a warning, so the reverse order is survivable — just noisier.

⚠️ `pulumi preview` on `home`/`ocracoke`/`gulf-of-mexico` invents phantom `StandardDns`/`TailnetKey` deletes; judge from `pulumi stack history`, not the preview.

## Known limitation, not fixed here

`DockerContainerUnhealthy` in [`docker/_common/prometheus/config/rules/alerts.yml`](../blob/main/docker/_common/prometheus/config/rules/alerts.yml) alerts on `container_health_status`, which nothing on those hosts exports — cAdvisor does not emit Docker healthcheck state, and the string appears nowhere else in the repo. **That rule can never fire.** It is why the Gatus heartbeat, not the healthcheck, is the paging signal here. Fixing it properly means adding an exporter that reads health off the socket proxy; worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
