### PR TITLE
fix(traefik): un-gate both dashboards from authentik (break-glass)

### DIFF
--- a/docker/_common/traefik/compose.yaml
+++ b/docker/_common/traefik/compose.yaml
@@ -13,7 +13,13 @@ services:
       traefik.enable: true
       # Dashboard configuration
       traefik.http.routers.dashboard.rule: Host(`internal.${CLUSTER_DOMAIN}`)
-      traefik.http.routers.dashboard.middlewares: authentik-outpost@docker
+      # BREAK-GLASS: network-gated, NOT authentik-gated. This dashboard is on
+      # EVERY Dockge host (_common), including the one that will host authentik
+      # itself -- gating it behind authentik makes it unreachable exactly when it
+      # is needed. See docs/cluster-consolidation/07-authentik-to-alpha-site.md
+      # section 3.3. The authentik-outpost middleware below stays defined: other
+      # stacks on this host still reference it.
+      traefik.http.routers.dashboard.middlewares: internal-network@file
       traefik.http.routers.dashboard.entrypoints: websecure
       traefik.http.routers.dashboard.service: api@internal
       traefik.http.routers.dashboard.tls.certresolver: le

--- a/docker/_common/traefik/definition.yaml
+++ b/docker/_common/traefik/definition.yaml
@@ -13,10 +13,10 @@ spec:
   access_policy:
     groups:
       - admins
-  authentik:
-    proxy:
-      mode: "forward_single"
-      externalHost: *url
+  # No `authentik:` block by design -- see compose.yaml's dashboard router. The
+  # other _common stacks (backrest, neo4j, prometheus) still declare proxy
+  # providers, so each host keeps a non-empty proxyProviders list and its
+  # Outpost resource survives (components/DockgeLxc.ts:748).
   gatus:
     - url: *url
       method: GET

--- a/docker/_common/traefik/dynamic/middlewares.yaml
+++ b/docker/_common/traefik/dynamic/middlewares.yaml
@@ -3,6 +3,17 @@ http:
     compress:
       compress:
         minResponseBodyBytes: 1024
+    # The Dockge-side equivalent of the cluster's network/internal-network
+    # Middleware. Same intent, same ranges minus the two Kubernetes-only ones
+    # (CLUSTER_NETWORK/SERVICE_NETWORK), which have no meaning on a Docker host.
+    # This exists so the dashboard has a network-only gate to use instead of the
+    # authentik forwardAuth one -- see compose.yaml's dashboard router.
+    internal-network:
+      ipAllowList:
+        sourceRange:
+          - 10.0.0.0/8
+          - 192.168.0.0/16
+          - 100.64.0.0/10
     errors:
       errors:
         status:

--- a/kubernetes/apps/network/traefik/definition.yaml
+++ b/kubernetes/apps/network/traefik/definition.yaml
@@ -13,10 +13,9 @@ spec:
   access_policy:
     groups:
       - admins
-  authentik:
-    proxy:
-      mode: "forward_single"
-      externalHost: *url
+  # No `authentik:` block by design -- the dashboard is deliberately not behind a
+  # proxy provider (see values.yaml's middleware comment). Leaving one here would
+  # keep minting a forward_single provider that nothing routes through.
   gatus:
     - url: *url
       method: GET

--- a/kubernetes/apps/network/traefik/values.yaml
+++ b/kubernetes/apps/network/traefik/values.yaml
@@ -172,7 +172,13 @@ ingressRoute:
       - "traefik"
       - "websecure"
     middlewares:
-      - name: authenticated-user
+      # BREAK-GLASS: network-gated, NOT authentik-gated. `authenticated-user`
+      # chains error-pages -> outpost -> internal-network; `local-user` is the
+      # same chain without the outpost hop. The Traefik dashboard is one of the
+      # tools used to diagnose an authentik outage, so it must not depend on
+      # authentik being up. See docs/cluster-consolidation/07-authentik-to-alpha-site.md
+      # section 3.3 -- a hard prerequisite of moving authentik off-cluster.
+      - name: local-user
         namespace: network
     tls:
       secretName: "le-production-tls"


### PR DESCRIPTION
First of three PRs implementing [`docs/cluster-consolidation/07-authentik-to-alpha-site.md`](https://github.com/david-driscoll/home-operations/blob/main/docs/cluster-consolidation/07-authentik-to-alpha-site.md) (piece G′, vault#84 decision D4). This one is §3.3 — a stated **hard prerequisite** of moving authentik off-cluster, and independently correct regardless of whether that move happens.

## Problem

The Traefik dashboard is one of the tools you reach for to diagnose an authentik outage. Both instances currently route *through* authentik to get to it — the exact inversion of break-glass.

## Changes

**Kubernetes** (`kubernetes/apps/network/traefik/`)
- The dashboard IngressRoute chained `authenticated-user` (`error-pages` → `outpost` → `internal-network`). It now chains `local-user` — the same chain without the `outpost` hop. The network gate is unchanged; only the authentik dependency is removed.

**Dockge** (`docker/_common/traefik/`) — the more important of the two, because `_common` deploys to *every* Dockge host, including the one that will host authentik itself.
- Its dashboard router pointed at the `authentik-outpost@docker` forwardAuth middleware, and there was no network-only middleware to switch to. Adds `internal-network` to the stack's dynamic config: the Dockge equivalent of the cluster's `network/internal-network` Middleware, same ranges minus the two Kubernetes-only ones (`CLUSTER_NETWORK`/`SERVICE_NETWORK`), which have no meaning on a Docker host.

**Both** `definition.yaml` files drop their `authentik.proxy` block — a `forward_single` provider that nothing routes through is drift.

## What this trades

`access_policy: groups: [admins]` stays in both files. It binds to the authentik **Application**, not the provider (`components/authentik.ts:497-513`), so the dashboard keeps its catalog tile — it is simply **no longer authentik-enforced**. From here the dashboard is gated by source network only. That is the deliberate trade §3.3 asks for: an admin tool that stays reachable when identity is down.

## Blast radius checked

- The `authentik-outpost` middleware *definition* is left in place — other stacks on these hosts still reference it.
- Removing traefik's proxy provider does **not** empty any host's `proxyProviders` list: `backrest`, `neo4j` and `prometheus` all still declare one, so `createOutpost`'s early return (`components/DockgeLxc.ts:748`) is not hit and each host's `Outpost` resource survives.
- `*url` anchors in both `definition.yaml` files are still consumed by their `gatus` blocks.

## Verification

- [x] All five touched YAML files parse
- [ ] `pulumi preview` on `stacks/applications` shows only the two proxy-provider deletions — **please confirm before merge**, this touches live routing on both clusters and every Dockge host
- [ ] Dashboard reachable at `internal.${CLUSTER_DOMAIN}` from an allowed source range after apply; rejected from outside it

🤖 Generated with [Claude Code](https://claude.com/claude-code)