### PR TITLE
feat(dockge): support the embedded authentik outpost, per host

### DIFF
--- a/components/DockgeLxc.ts
+++ b/components/DockgeLxc.ts
@@ -47,6 +47,44 @@ export interface DockgeLxcArgs {
   legacyTun?: boolean;
   sftpKey: Input<SshKeyDefinition>;
   monitor: TailscaleMonitor;
+  /**
+   * Docker service name that Traefik's `authentik-outpost` forwardAuth middleware
+   * dials, substituted into `docker/_common/traefik/compose.yaml` as
+   * `${AUTHENTIK_FORWARDAUTH_HOST}`.
+   *
+   * Defaults to `authentik_proxy` — the service in `docker/_common/authentik-outpost`,
+   * which is what every host that runs the sidecar needs. A host running authentik
+   * *locally* has no sidecar (see `useEmbeddedOutpost`) and must point this at the
+   * authentik server container instead.
+   *
+   * This is an arg rather than a `deployStacks({ variables })` entry deliberately: the
+   * variables channel has no defaulting, so a host added later that forgot the entry
+   * would render a literal `${AUTHENTIK_FORWARDAUTH_HOST}` into a Traefik label and
+   * fail that host's forwardAuth closed. Resolves open question 8 in
+   * docs/cluster-consolidation/07-authentik-to-alpha-site.md.
+   */
+  authentikForwardAuthHost?: Input<string>;
+  /**
+   * Use the authentik server's built-in *embedded* outpost for this host's proxy
+   * providers instead of standing up a per-host `Outpost` and a sidecar container.
+   *
+   * Only correct on a host that runs authentik itself — otherwise the embedded outpost
+   * has no route to the host's services. Exactly one host in the estate qualifies
+   * (alpha-site, once piece 07 lands); see that document's section 2.5 for why, and
+   * for the `.ignore` that suppresses the sidecar stack alongside this flag.
+   *
+   * When set, `createOutpost` skips the API token mint and the `.env-token` SSH write
+   * entirely — the embedded outpost needs neither, which is also what removes the
+   * bootstrap loop described in section 2.4.
+   */
+  useEmbeddedOutpost?: boolean;
+  /**
+   * Name of the embedded outpost to look up when `useEmbeddedOutpost` is set.
+   * authentik's built-in is conventionally "authentik Embedded Outpost", but that
+   * string is a server-side default rather than anything this repo controls — hence
+   * the override. Verify against the live server before relying on the default.
+   */
+  embeddedOutpostName?: Input<string>;
 }
 export interface ExternalServiceOpts {
   name: Input<string>;
@@ -698,6 +736,10 @@ export class DockgeLxc extends ComponentResource {
         output(this.cluster.icon).apply(icon => icon ?? ""),
       ),
       replaceVariable(/\$\{CLUSTER_AUTHENTIK_DOMAIN\}/g, this.args.host.remote ? interpolate`authentik.${this.args.globals.tailscaleDomain}` : this.cluster.authentikDomain),
+      // Defaulted, NOT sourced from args.variables — see DockgeLxcArgs. Every host
+      // that runs the authentik-outpost sidecar wants the sidecar's service name;
+      // only a host running authentik locally overrides it.
+      replaceVariable(/\$\{AUTHENTIK_FORWARDAUTH_HOST\}/g, output(this.args.authentikForwardAuthHost ?? "authentik_proxy")),
       replaceVariable(/\$UPTIME_API_URL/g, interpolate`https://uptime.${this.args.globals.searchDomain}`),
       ...Object.entries(args.variables ?? {}).map(([key, value]) => replaceVariable(new RegExp(`\\$\\{${key}\\}`, "g"), value)),
       // The secret-reference resolver runs last, after every ${VAR}
@@ -747,6 +789,41 @@ export class DockgeLxc extends ComponentResource {
 
     if (proxyProviders.length === 0) {
       return;
+    }
+
+    // A host that runs authentik itself uses that server's embedded outpost rather
+    // than a per-host Outpost fronted by a sidecar container. Two things fall away
+    // with it: the sidecar (suppressed by an .ignore on the host's authentik-outpost
+    // directory) and this method's live API round-trip — the embedded outpost needs
+    // no token, so nothing here has to reach a running authentik to succeed. That is
+    // what keeps the deploy from depending on the very server it is deploying.
+    // docs/cluster-consolidation/07-authentik-to-alpha-site.md section 2.5.
+    if (this.args.useEmbeddedOutpost) {
+      const embeddedName = output(this.args.embeddedOutpostName ?? "authentik Embedded Outpost");
+      // getOutpost returns an optional id, and a name that matches nothing comes back
+      // as a successful lookup with no id rather than an error — which would otherwise
+      // surface much later as an attachment against an empty outpost. Fail loudly here
+      // instead, and say which knob fixes it.
+      const embeddedId = all([authentik.getOutpostOutput({ name: embeddedName }, { parent: applicationManager.outpostsComponent }), embeddedName]).apply(([result, name]) => {
+        if (!result.id) {
+          throw new Error(`No authentik outpost named "${name}" — set embeddedOutpostName on the ` + `${this.args.host.name} DockgeLxc to whatever the live server calls its embedded outpost.`);
+        }
+        return result.id;
+      });
+      return proxyProviders.map(
+        (provider, index) =>
+          new authentik.OutpostProviderAttachment(
+            `${this.args.host.name}-embedded-outpost-${index}`,
+            {
+              outpost: embeddedId,
+              protocolProvider: provider.id.apply(parseFloat),
+            },
+            {
+              parent: applicationManager.outpostsComponent,
+              dependsOn: [provider],
+            },
+          ),
+      );
     }
 
     const outpost = new authentik.Outpost(

--- a/docker/_common/traefik/compose.yaml
+++ b/docker/_common/traefik/compose.yaml
@@ -22,8 +22,17 @@ services:
       traefik.http.routers.dashboard-tailscale.entrypoints: tailscale
       traefik.http.routers.dashboard-tailscale.service: api@internal
 
-      # The middleware
-      traefik.http.middlewares.authentik-outpost.forwardauth.address: http://authentik_proxy:9000/outpost.goauthentik.io/auth/traefik
+      # The middleware.
+      #
+      # ${AUTHENTIK_FORWARDAUTH_HOST} defaults to `authentik_proxy` — the service in
+      # docker/_common/authentik-outpost, i.e. the sidecar every host runs. A host
+      # that runs authentik ITSELF has no sidecar and points this at the authentik
+      # server container instead, because the embedded outpost serves this same
+      # /outpost.goauthentik.io path. Set per host via DockgeLxc's
+      # authentikForwardAuthHost arg, which defaults rather than requiring every host
+      # to remember it. See docs/cluster-consolidation/07-authentik-to-alpha-site.md
+      # section 2.5.
+      traefik.http.middlewares.authentik-outpost.forwardauth.address: http://${AUTHENTIK_FORWARDAUTH_HOST}:9000/outpost.goauthentik.io/auth/traefik
       traefik.http.middlewares.authentik-outpost.forwardauth.trustForwardHeader: true
       traefik.http.middlewares.authentik-outpost.forwardauth.authResponseHeaders: X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid,X-authentik-jwt,X-authentik-meta-jwks,X-authentik-meta-outpost,X-authentik-meta-provider,X-authentik-meta-app,X-authentik-meta-version
 


### PR DESCRIPTION
Second of three PRs implementing [`docs/cluster-consolidation/07-authentik-to-alpha-site.md`](https://github.com/david-driscoll/home-operations/blob/main/docs/cluster-consolidation/07-authentik-to-alpha-site.md) §2.5. Depends on nothing; **inert until a host opts in** — no host does in this PR.

Independent of #806, though both touch `docker/_common/traefik/compose.yaml` (different lines, ~10 apart — should merge cleanly in either order).

## Why

A Dockge host normally reaches authentik through the `authentik-outpost` sidecar, which dials *out* to a remote server. On the one host that will run authentik **locally**, that sidecar is a second copy of the proxy sitting beside the server that already contains one, holding a token minted over the network to reach a service on localhost. §2.5 drops it there in favour of authentik's embedded outpost.

## Changes

**`authentikForwardAuthHost`** substitutes `${AUTHENTIK_FORWARDAUTH_HOST}` into `_common/traefik`'s forwardAuth middleware, which until now hardcoded `authentik_proxy` — the sidecar's service name. A host running authentik locally must dial the server container instead; the embedded outpost serves the identical `/outpost.goauthentik.io` path, so **only the address moves**, not the middleware chain.

It's a `DockgeLxc` arg with a default rather than a `deployStacks({ variables })` entry deliberately: the variables channel has no defaulting, so a host added later that forgot the entry would render a literal `${AUTHENTIK_FORWARDAUTH_HOST}` into a Traefik label and fail that host's forwardAuth **closed**. This is the plan's open question 8, resolved.

**`useEmbeddedOutpost`** makes `createOutpost` attach the host's proxy providers to the server's built-in outpost (`getOutpost` + `OutpostProviderAttachment`, both already present in `sdks/authentik`) instead of constructing a per-host `Outpost`. The token mint and the `.env-token` SSH write fall away with it — the embedded outpost needs neither, which is what stops a deploy run from depending on the very authentik it is deploying (plan §2.4's bootstrap loop).

**`embeddedOutpostName`** defaults to `"authentik Embedded Outpost"`. That string is a server-side default, not something this repo controls, and `getOutpost` answers an unmatched name with a *successful lookup carrying no id* rather than an error — so the lookup throws with the name and the knob that fixes it, instead of silently attaching providers to nothing. Plan open question 6 says to verify it live; this override is how.

## Inertness

- No host sets `useEmbeddedOutpost` or `embeddedOutpostName` → `createOutpost` takes the existing branch unchanged.
- No host sets `authentikForwardAuthHost` → `${AUTHENTIK_FORWARDAUTH_HOST}` renders `authentik_proxy`, so every host's Traefik label is **byte-identical** to today.

## Context worth knowing for the follow-up

After #806 lands, `backrest` is the only remaining in-repo consumer of the `authentik-outpost@docker` middleware — and `docker/alpha-site/backrest/.ignore` means alpha-site's backrest is hand-created in Dockge, outside this repo. Because the middleware *definition* lives in the generator-managed `_common/traefik` stack, repointing the address there fixes that hand-created stack too. Worth knowing before the cutover PR flips alpha-site.

## Verification

- [x] `npx tsc --noEmit` clean (one pre-existing `TS6307` about `dynamic/` not being in `tsconfig.json`'s `include`, present on clean `main` too)
- [x] `npx biome check` clean
- [ ] `pulumi preview` on `stacks/home` shows **no diff** — please confirm the inertness claim before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)