### PR TITLE
feat(stargate-command): port the namespace so the Phase C flip is a no-op

### DIFF
--- a/kubernetes/apps/stargate-command/chrony/chrony.conf
+++ b/kubernetes/apps/stargate-command/chrony/chrony.conf
@@ -1,0 +1,27 @@
+# Cloudflare time servers
+server time.cloudflare.com iburst
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Specify file containing keys for NTP authentication.
+keyfile /etc/chrony.keys
+
+# Save NTS keys and cookies.
+ntsdumpdir /var/lib/chrony
+
+# Insert/delete leap seconds by slewing instead of stepping.
+#leapsecmode slew
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+leapsectz right/UTC
+
+# Specify directory for log files.
+logdir /var/log/chrony

--- a/kubernetes/apps/stargate-command/chrony/helmrelease.yaml
+++ b/kubernetes/apps/stargate-command/chrony/helmrelease.yaml
@@ -1,0 +1,94 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app chrony
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  dependsOn: []
+  values:
+    controllers:
+      *app :
+        type: statefulset
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        pod:
+          priorityClassName: system-cluster-critical
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: *app
+                    app.kubernetes.io/component: *app
+        containers:
+          app:
+            image:
+              repository: docker.io/library/rockylinux
+              tag: 9@sha256:d7be1c094cc5845ee815d4632fe377514ee6ebcf8efaed6892889657e5ddaaa6
+            args:
+              - "/bin/bash"
+              - "-c"
+              - "dnf install -y chrony iputils dnsutils && chronyd -n -d"
+            resources:
+              requests:
+                cpu: 23m
+                memory: 50M
+            securityContext:
+              privileged: true
+
+    service:
+      *app :
+        controller: *app
+        type: LoadBalancer
+        annotations:
+          io.cilium/lb-ipam-ips: "${CHRONY_VIP}"
+        externalIPs:
+          - "${CHRONY_VIP}"
+        externalTrafficPolicy: Cluster
+        ports:
+          ntp-port:
+            port: &ntp-port 123
+            protocol: UDP
+          other:
+            port: 31880
+            protocol: TCP
+
+    persistence:
+      config:
+        type: configMap
+        name: chrony-configmap
+        defaultMode: 493
+        globalMounts:
+          - path: /etc/chrony.conf
+            subPath: chrony.conf
+            readOnly: true
+      data:
+        type: emptyDir
+        globalMounts:
+          - path: /var/lib/chrony

--- a/kubernetes/apps/stargate-command/chrony/ks.yaml
+++ b/kubernetes/apps/stargate-command/chrony/ks.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app chrony
+  namespace: &namespace stargate-command
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: sgc-secrets
+      namespace: *namespace
+  path: ./kubernetes/apps/stargate-command/chrony
+  prune: true
+  # Kept deliberately, NOT migration-sweep scaffolding. This namespace runs the
+  # live home-automation stack (Home Assistant, Mosquitto, Matter, chrony) and
+  # its fate is decided in piece 22, not here. Until then a Kustomization
+  # ownership change must never be able to cascade-delete it.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/stargate-command/chrony/kustomization.yaml
+++ b/kubernetes/apps/stargate-command/chrony/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: chrony-configmap
+    files:
+      - chrony.conf=./chrony.conf
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/stargate-command/home-assistant/definition.yaml
+++ b/kubernetes/apps/stargate-command/home-assistant/definition.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: home-assistant
+spec:
+  name: Home Assistant
+  category: Applications
+  description: Home automation and things that make the house angry.
+  url: https://home.${ROOT_DOMAIN}/auth/oidc/welcome
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/home-assistant.svg
+  access_policy:
+    groups:
+      - friends
+      - family
+  authentik:
+    oauth2:
+      clientType: confidential
+      allowedRedirectUris:
+      - url: "https://home.${ROOT_DOMAIN}/auth/oidc/callback"
+      - url: "https://home.${TAILSCALE_DOMAIN}/auth/oidc/callback"
+      - url: "https://${APP}.${ROOT_DOMAIN}/auth/oidc/callback"
+      propertyMappings:
+        - email
+        - openid
+        - profile
+      includeClaimsInIdToken: true
+      subMode: user_email
+  gatus:
+    - url: https://home.${ROOT_DOMAIN}
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/stargate-command/home-assistant/externalsecret.yaml
+++ b/kubernetes/apps/stargate-command/home-assistant/externalsecret.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-assistant-ssh
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        id_rsa: "{{ .privatekey }}"
+        id_rsa.pub: "{{ .publickey }}"
+        authorized_keys: "{{ .publickey }}"
+        ssh: "{{ .privatekey }}"
+        # NOT `.known_hosts`. OpenBao stores this field as "known hosts" —
+        # with a SPACE — and the Vault provider returns key names verbatim.
+        # This template only ever worked because the ESO 1Password provider
+        # silently sanitised spaces to underscores in `extract` keys; on
+        # OpenBao `{{ .known_hosts }}` renders nothing and, under
+        # missingkey=error, fails the WHOLE ExternalSecret.
+        #
+        # `.knownhosts` comes from the explicit `data:` mapping below, which
+        # names the property itself and so is provider-independent. Same for
+        # .privatekey / .publickey above — that is why they were never at risk.
+        known_hosts: "{{ .knownhosts }}"
+  dataFrom:
+    - extract:
+        key: shared/eris-ssh-key
+  data:
+    - secretKey: publickey
+      remoteRef:
+        key: &ssh-key shared/eris-ssh-key
+        property: public key
+    - secretKey: privatekey
+      remoteRef:
+        key: *ssh-key
+        property: private key
+    - secretKey: knownhosts
+      remoteRef:
+        key: *ssh-key
+        property: known hosts

--- a/kubernetes/apps/stargate-command/home-assistant/helmrelease.yaml
+++ b/kubernetes/apps/stargate-command/home-assistant/helmrelease.yaml
@@ -1,0 +1,226 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app home-assistant
+
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  driftDetection:
+    mode: enabled
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    fullnameOverride: *app
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 30
+          priorityClassName: system-cluster-critical
+        initContainers:
+          fix-permissions:
+            image:
+              repository: alpine
+              tag: 3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+              pullPolicy: IfNotPresent
+            command:
+              - sh
+              - -c
+              - |
+                echo "Resetting permissions on /config to 0777";
+                if [ -d /config ]; then
+                  chmod -R 0777 /config || true
+                else
+                  echo "/config not found";
+                fi
+            securityContext:
+              runAsUser: 0
+              runAsGroup: 0
+              runAsNonRoot: false
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 64Mi
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/home-assistant
+              tag: 2026.8.1@sha256:e1f54eb0306d7ded8b3cdee70c21178413cd175aa3e526452af0e086a39ecc51
+              pullPolicy: IfNotPresent
+            env:
+              HASS_HTTP_TRUSTED_PROXY_1: "${CLUSTER_NETWORK}"
+              HASS_HTTP_TRUSTED_PROXY_2: "${SERVICE_NETWORK}"
+              HASS_EXTERNAL_URL: "https://home.${ROOT_DOMAIN}"
+              TZ: "${TIMEZONE}"
+            resources:
+              requests:
+                memory: 1Gi
+                cpu: 200m
+              limits:
+                # cpu: 2
+                memory: 2Gi
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &app-port 8123
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *app-port
+                  initialDelaySeconds: 0
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *app-port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+
+          code:
+            image:
+              repository: ghcr.io/coder/code-server
+              tag: 4.132.0@sha256:b88ed46a6ace76a0294a17a24f39aa88032ed0a3692c3d8ab5433b47ab57ccbf
+            env:
+              TZ: ${TIMEZONE}
+              HOME: /home/coder
+              USER: coder
+              GIT_SSH_COMMAND: ssh -i /home/coder/.ssh/id_rsa -o IdentitiesOnly=yes
+            args:
+              - --auth
+              - none
+              - --user-data-dir
+              - /config/.vscode
+              - --extensions-dir
+              - /config/.vscode
+              - --port
+              - "8888"
+              - /config
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 1Gi
+
+    defaultPodOptions:
+      # required for mDNS and other host network features
+      hostNetwork: true
+      securityContext:
+        fsGroup: 568
+        fsGroupChangePolicy: "OnRootMismatch"
+        runAsGroup: 568
+        runAsNonRoot: true
+        runAsUser: 568
+        seccompProfile:
+          type: RuntimeDefault
+      shareProcessNamespace: true
+
+    service:
+      app:
+        controller: *app
+        type: ClusterIP
+        ports:
+          http:
+            port: *app-port
+      code:
+        controller: *app
+        type: ClusterIP
+        ports:
+          http:
+            port: &code-port 8888
+
+    route:
+      internal:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "home.${ROOT_DOMAIN}"
+          - "${APP}.${ROOT_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *app-port
+
+      code-internal:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - "${APP}-code.${ROOT_DOMAIN}"
+        kind: HTTPRoute
+        rules:
+          - backendRefs:
+              - identifier: code
+                port: *code-port
+
+    persistence:
+      config:
+        existingClaim: ${APP}
+      deploy-key:
+        type: secret
+        name: home-assistant-ssh
+        defaultMode: 256
+        globalMounts:
+          - path: /home/coder/.ssh/
+            readOnly: true
+      config-cache:
+        type: emptyDir
+        globalMounts:
+          - path: /config/.venv
+      config-logs:
+        type: emptyDir
+        globalMounts:
+          - path: /config/logs
+      config-tts:
+        type: emptyDir
+        globalMounts:
+          - path: /config/tts
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/stargate-command/home-assistant/ks.yaml
+++ b/kubernetes/apps/stargate-command/home-assistant/ks.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app home-assistant
+  namespace: &namespace stargate-command
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/stargate-command/home-assistant
+  prune: true
+  # Kept deliberately, NOT migration-sweep scaffolding. This namespace runs the
+  # live home-automation stack (Home Assistant, Mosquitto, Matter, chrony) and
+  # its fate is decided in piece 22, not here. Until then a Kustomization
+  # ownership change must never be able to cascade-delete it.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+    - name: sgc-secrets
+      namespace: *namespace
+    - name: mosquitto
+      namespace: *namespace
+    - name: external-secrets
+      namespace: kube-system
+    - name: tailscale-operator
+      namespace: tailscale-system
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  components:
+    - ../../../components/failover/fast-node-eviction
+    - ../../../components/volsync
+    - ../../../components/tailscale
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_CAPACITY: 40Gi
+      TAILSCALE_SERVICE: home-assistant-app
+      TAILSCALE_HOST: home

--- a/kubernetes/apps/stargate-command/home-assistant/kustomization.yaml
+++ b/kubernetes/apps/stargate-command/home-assistant/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./definition.yaml

--- a/kubernetes/apps/stargate-command/home-assistant/scripts/check_and_clone.sh
+++ b/kubernetes/apps/stargate-command/home-assistant/scripts/check_and_clone.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Check if the /config/.git directory exists
+if [ ! -d "/config/.git" ]; then
+    echo "Git directory not found. Cloning repository..."
+    git clone --bare "${HOME_ASSISTANT_SSH_URL}" /config/.git
+else
+    echo "Git directory exists. Hydrating master branch..."
+    git --git-dir=/config/.git --work-tree=/config checkout master
+fi

--- a/kubernetes/apps/stargate-command/kustomization.yaml
+++ b/kubernetes/apps/stargate-command/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: stargate-command
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+components:
+  - ../../components/alerts
+  - ../../components/common
+  - ../../components/repos/app-template
+resources:
+  - ./chrony/ks.yaml
+  - ./matter/ks.yaml
+  - ./mosquitto/ks.yaml
+  - ./secrets/ks.yaml
+  - ./home-assistant/ks.yaml

--- a/kubernetes/apps/stargate-command/matter/helmrelease.yaml
+++ b/kubernetes/apps/stargate-command/matter/helmrelease.yaml
@@ -1,0 +1,105 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app matter
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 15m
+  driftDetection:
+    mode: enabled
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          hostNetwork: true
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-assistant-libs/python-matter-server
+              tag: 8.1.0@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a
+              pullPolicy: IfNotPresent
+
+            env:
+              TZ: "${TIMEZONE}"
+              MATTER_SERVER__INSTANCE_NAME: ${APP}
+              MATTER_SERVER__PORT: &wsPort 5580
+              MATTER_SERVER__APPLICATION_URL: &host matter.sgc.${ROOT_DOMAIN}
+              MATTER_SERVER__LOG_LEVEL: debug
+
+            resources:
+              requests:
+                cpu: 50m
+                memory: "256Mi"
+              limits:
+                # cpu: 100m
+                memory: "2Gi"
+
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 0 # Must be run as root user
+        runAsGroup: 0
+        runAsNonRoot: false # Must be run as root user
+        fsGroup: 0
+        fsGroupChangePolicy: "OnRootMismatch"
+        supplementalGroups:
+          - 34
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+
+    service:
+      *app :
+        controller: *app
+        type: LoadBalancer
+        # annotations:
+        #   io.cilium/lb-ipam-ips: "${AUTOMATION_VIP}"
+        externalIPs:
+          - "${AUTOMATION_VIP}"
+        ports:
+          ws:
+            protocol: TCP
+            port: *wsPort
+            primary: true
+        externalTrafficPolicy: Cluster
+
+    route:
+      internal:
+        parentRefs:
+          - name: internal
+            namespace: network
+            kind: Gateway
+        hostnames:
+          - *host
+        kind: HTTPRoute
+        rules:
+          - backendRefs:
+              - identifier: *app
+                port: *wsPort
+
+    persistence:
+      data:
+        existingClaim: ${APP}

--- a/kubernetes/apps/stargate-command/matter/ks.yaml
+++ b/kubernetes/apps/stargate-command/matter/ks.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app matter
+  namespace: &namespace stargate-command
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/stargate-command/matter
+  prune: true
+  # Kept deliberately, NOT migration-sweep scaffolding. This namespace runs the
+  # live home-automation stack (Home Assistant, Mosquitto, Matter, chrony) and
+  # its fate is decided in piece 22, not here. Until then a Kustomization
+  # ownership change must never be able to cascade-delete it.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+    - name: sgc-secrets
+      namespace: *namespace
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  components:
+    - ../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      VOLSYNC_CAPACITY: 4Gi

--- a/kubernetes/apps/stargate-command/matter/kustomization.yaml
+++ b/kubernetes/apps/stargate-command/matter/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/stargate-command/mosquitto/definition.yaml
+++ b/kubernetes/apps/stargate-command/mosquitto/definition.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: ${APP}
+spec:
+  name: Mosquitto
+  category: Infrastructure
+  description: Mosquitto MQTT broker
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/mosquitto.svg
+  access_policy:
+    groups:
+      - admins
+  # authentik:
+  #   proxy:
+  #     mode: "forward_single"
+  #     externalHost: *url

--- a/kubernetes/apps/stargate-command/mosquitto/helmrelease.yaml
+++ b/kubernetes/apps/stargate-command/mosquitto/helmrelease.yaml
@@ -1,0 +1,148 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app mosquitto
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      *app :
+        type: statefulset
+        replicas: 2
+        podDisruptionBudget:
+          maxUnavailable: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          init-config:
+            image:
+              repository: public.ecr.aws/docker/library/eclipse-mosquitto
+              tag: 2.0.22@sha256:212f89e1eaeb2c322d6441b64396e3346026674db8fa9c27beac293405c32b3c
+              pullPolicy: IfNotPresent
+            command: ["/bin/sh", "-c"]
+            args: |-
+              cp /config/mosquitto_pwd /mosquitto/external_config/mosquitto_pwd
+              chmod 0700 /mosquitto/external_config/mosquitto_pwd
+              mosquitto_passwd -U /mosquitto/external_config/mosquitto_pwd
+        containers:
+          app:
+            command:
+              - sh
+              - -c
+              - exec mosquitto -c "/config/$(hostname).conf"
+            image:
+              repository: public.ecr.aws/docker/library/eclipse-mosquitto
+              tag: "2.0.22@sha256:212f89e1eaeb2c322d6441b64396e3346026674db8fa9c27beac293405c32b3c"
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            resources:
+              limits:
+                # cpu: 100m
+                memory: 200Mi
+              requests:
+                cpu: 10m
+                memory: 8Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+        pod:
+          priorityClassName: system-cluster-critical
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: *app
+                    app.kubernetes.io/component: *app
+        statefulset:
+          volumeClaimTemplates:
+          - name: data
+            storageClass: longhorn
+            accessMode: ReadWriteOnce
+            size: 4Gi
+            globalMounts:
+            - path: /mosquitto/data
+              subPath: data
+          persistentVolumeClaimRetentionPolicy:
+            whenDeleted: Delete
+            whenScaled: Delete
+
+    defaultPodOptions:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: "DoNotSchedule"
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: *app
+
+      securityContext:
+        fsGroup: 568
+        fsGroupChangePolicy: "OnRootMismatch"
+        runAsGroup: 568
+        runAsNonRoot: true
+        runAsUser: 568
+        seccompProfile:
+          type: RuntimeDefault
+      shareProcessNamespace: true
+
+    authentication:
+      passwordEntries: ""
+    persistence:
+      config:
+        type: secret
+        name: mosquitto-secret
+        defaultMode: 493
+      external-config:
+        type: emptyDir
+        globalMounts:
+          - path: /mosquitto/external_config
+    service:
+      app:
+        controller: *app
+        type: LoadBalancer
+        annotations:
+          reloader.stakater.com/auto: "true"
+          io.cilium/lb-ipam-ips: "${AUTOMATION_VIP}"
+          external-dns.alpha.kubernetes.io/hostname: ${AUTOMATION_DOMAIN}
+          external-dns.alpha.kubernetes.io/target: "${AUTOMATION_VIP}"
+          tailscale.com/expose: "true"
+          tailscale.com/hostname: "${AUTOMATION_CNAME}"
+          tailscale.com/tags: "tag:observability"
+        ports:
+          mqtt:
+            protocol: TCP
+            port: &mqtt-port 1883
+          wsmqtt:
+            protocol: TCP
+            port: &wsmqtt-port 9090

--- a/kubernetes/apps/stargate-command/mosquitto/ks.yaml
+++ b/kubernetes/apps/stargate-command/mosquitto/ks.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mosquitto
+  namespace: &namespace stargate-command
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/stargate-command/mosquitto
+  prune: true
+  # Kept deliberately, NOT migration-sweep scaffolding. This namespace runs the
+  # live home-automation stack (Home Assistant, Mosquitto, Matter, chrony) and
+  # its fate is decided in piece 22, not here. Until then a Kustomization
+  # ownership change must never be able to cascade-delete it.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  dependsOn:
+    - name: sgc-secrets
+      namespace: *namespace
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/stargate-command/mosquitto/kustomization.yaml
+++ b/kubernetes/apps/stargate-command/mosquitto/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./users.sops.yaml
+  # - ./definition.yaml

--- a/kubernetes/apps/stargate-command/mosquitto/users.sops.yaml
+++ b/kubernetes/apps/stargate-command/mosquitto/users.sops.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mosquitto-secret
+type: Opaque
+stringData:
+  mosquitto_username: ENC[AES256_GCM,data:SG2CGFh4MCYX,iv:o0zgaY4qe7mpP30SzRBjZ3VytS3EzfEH5s6n9Yy5lh0=,tag:Q5fYI4639iGAOkvbakB1RA==,type:str]
+  mosquitto_password: ENC[AES256_GCM,data:u93qTTA4RBqcacOdvFf7QAgk0AeSCXkfIxcSIN7h,iv:o0TWZwikag4zfLujCepgK/8/5WjVnnqu5X3AIbGp90U=,tag:1nDaM/KI1/ZsECEr/oz0ow==,type:str]
+  mosquitto_pwd: ENC[AES256_GCM,data:S0mY4IRbaJkR2R0nfg1SKDfyOmaG2B8fkB04PFshd8D9WT2G31OuUBs=,iv:yJx3u/Rqt3MvaAPLr+oFclUERpnOD3QH41f5GnSUF1c=,tag:P/7kZ6OgjpBNBRT3MKIA+g==,type:str]
+  mosquitto-0.conf: ENC[AES256_GCM,data:K23hU6BktljWLEjn7cdULhOws3pa76JBqKJMjR/05rwY17co2NQsotjgYGMOOl2KTC21H4whNVWw7SrTWFlnrd2fk04DqIMRHOz0VaBK98xWHWZJsheJxLK6O+AwU2roIstl65mhjeKORaqnYixPAvM6G0ZB9P54UasCspdXBJIlEJl8w6AdHrmzGOSgSfiNy6tImNr6P2pyCTo3pYE=,iv:Byihj/AZ+zmHSjf+dWy3pyLxjLuV9v1AiESDMVusrao=,tag:YF5ixQF3Qch4NfjZGJXdTA==,type:str]
+  mosquitto-1.conf: ENC[AES256_GCM,data:+zK7HDld9iuqBJFYJnlR3+DhZe3eZpb2Wos1X4C9Rc7buHiwJk+Ll7eki0qfdrp3NK8ES76Y6veKRgkAwux8uPRqlcznc1ITq902yqx+pbaAv7KvVMuTFEMmk/CfO7t9FukcLmH03luY3rC5UxJFUA0+ts5HhTBnm0upYiJ7NbmC4Go/xCK0iFm6oAyIWfM7bWmkMxAvhSy6s/qOicsGFJ95xR3bHtlq4MbneJJKgSf4eUtfGETLUt66hjJ8Y5WOO0BIXu2hgcK1afadTsYDwkuQ8/W2l1H59R/k2PWw/k5JmVa/xbOL02MBFlu+XTg2cg58DAU=,iv:GJL06QklspUSF8pg4E/XhPKn2SHv8MLz6Rem39I5Lt4=,tag:Uz9IvUJDyJM6K+lZtMMGkw==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4VmI4cng4bzdKWVNuc3J2
+        MTNGZllUVkJuK3d5OWlHMmI4QlFPaTdRelgwCjMrVWJZWDJtR0xIOGVqUjZjZnox
+        QWc2K1E2MG9OYno1MXVUa25nSWRrMXMKLS0tIEk4L1QwcEJ1djNsd09NelcwSWJv
+        cmhobnI0MDd5dXpJRkR5ZGlHbVZ6ZjgKKt2b5f5mFAYeZH8HYltsCsh5oGN+Smmp
+        UpDrA2fLVATS9JBKgsf2zNbEk/FqDFKSHY88j3VReiCLdMoP0jZvWg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eurl2t7pepw66guv8m7lxh5fjhs4t4frsntqjp08lmypwudlsp7qdusgnf
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKUEpmMGFyczQrd2FhY1FM
+        b2FOc1Vmam1SSW8rakVSdUpKWWNNaEdqNjNBCmtHM05YY2lrZkJhQmp3K09GcWFC
+        ZWwwNFI2c016N3ZNMlBmMVZ6OVA3L1kKLS0tIDY0NHRzWHhJTTJFaEJQa0FweGw5
+        SFY1azdaRFJzaThQT0YyRjNrMlV0TzgKWQ6je0Q+fgFFSUt/mGTSVq3e8v99wtQF
+        tgmHT/kUNYb/JIG6nVRGLV7+6L6z7jvDAtVY4lNcO/fG37XJPzZ4DQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2025-08-21T19:30:08Z"
+  mac: ENC[AES256_GCM,data:MNfAvbZw6FRqAbXedrSqepgAatFuwN/60ofNGN6oypYgDXc3ohsML2VTQ91NOGbhpQvgaLcgHRHLekBQlMJFZn0wtydND2B4JJkyzPvQHQpbSrNang5zmSB0kBrB9qYNCEpRY95mFo/mM9B6GsXdjbJxjNFfSxJaE8R13FyxbmI=,iv:UDfWJnqnJbyI7Vkb7LG9zc0vq/4uv1Np8QHmYDi6pok=,tag:BTNc6EOCxRF0m6qyrKceFA==,type:str]
+  mac_only_encrypted: true
+  version: 3.10.2

--- a/kubernetes/apps/stargate-command/secrets/cloudflare-tunnel.yaml
+++ b/kubernetes/apps/stargate-command/secrets/cloudflare-tunnel.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+#
+# NOTE: this is EQUESTRIA's tunnel item, not SGC's. SGC's own token is at
+# kubernetes/apps/network/cloudflare-tunnel/secret.yaml. That crossover is
+# pre-existing and is preserved deliberately.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-tunnel
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: cloudflare-tunnel
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/mgksuktp4tea6hbh5kctzdmbiu ("Equestria Cloudflare Tunnel")
+        key: shared/equestria-cloudflare-tunnel

--- a/kubernetes/apps/stargate-command/secrets/home-assistant.yaml
+++ b/kubernetes/apps/stargate-command/secrets/home-assistant.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+#
+# THE REWRITE IS LOAD-BEARING. A field name here contains a space, which is not
+# a legal Kubernetes Secret key, so without it the API server rejects the whole
+# Secret. The 1Password Operator sanitised the same way, which is why the live
+# Secret already reads with dashes — this reproduces it exactly rather than
+# approximating it with the repo's usual [\W] -> _ rule.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-assistant-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: home-assistant-credentials
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/mcrhsiy556kflhq757l3mi4lwa
+        key: shared/eris-home-assistant-credentials
+      rewrite:
+        - regexp:
+            source: "[^-._a-zA-Z0-9]"
+            target: "-"

--- a/kubernetes/apps/stargate-command/secrets/ks.yaml
+++ b/kubernetes/apps/stargate-command/secrets/ks.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app sgc-secrets
+  namespace: &namespace stargate-command
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: onepassword-connect
+      namespace: kube-system
+    - name: external-secrets
+      namespace: kube-system
+  path: ./kubernetes/apps/stargate-command/secrets
+  prune: true
+  # Kept deliberately, NOT migration-sweep scaffolding. This namespace runs the
+  # live home-automation stack (Home Assistant, Mosquitto, Matter, chrony) and
+  # its fate is decided in piece 22, not here. Until then a Kustomization
+  # ownership change must never be able to cascade-delete it.
+  # See docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/stargate-command/secrets/kustomization.yaml
+++ b/kubernetes/apps/stargate-command/secrets/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./truenas.yaml
+  - ./unifi.yaml
+  - ./home-assistant.yaml
+  - ./cloudflare-tunnel.yaml
+  - ./media-management.yaml

--- a/kubernetes/apps/stargate-command/secrets/media-management.yaml
+++ b/kubernetes/apps/stargate-command/secrets/media-management.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+#
+# FIVE KEYS ARE DROPPED — credential, ersatztv_token, nextpvr_token,
+# notesPlain and username. All five render 0 bytes today: 1Password carries
+# them with EMPTY values and Phase 4 did not migrate empty-valued fields, so
+# they are absent in OpenBao. No pod, no manifest and no valuesFrom in any repo
+# reads them; checked before removing them.
+#
+# One key GAINS a real value: omdb_apikey, written into OpenBao during the
+# kometa fix (equestria-cluster#3087) where 1Password held it empty.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: media-management-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: media-management-credentials
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Media Management Secrets
+        key: shared/media-management-secrets

--- a/kubernetes/apps/stargate-command/secrets/truenas.yaml
+++ b/kubernetes/apps/stargate-command/secrets/truenas.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: truenas-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: truenas-credentials
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/nvvnzwmhywhgjf7uywkkyq7jxy
+        key: shared/eris-truenas-credentials

--- a/kubernetes/apps/stargate-command/secrets/unifi.yaml
+++ b/kubernetes/apps/stargate-command/secrets/unifi.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: unifi-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: unifi-credentials
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/dk2j2cscqjmfp3jlibkc5tx6hq ("Unifi Discord" — the UUID resolves to a title unrelated to this Secret's name; pre-existing)
+        key: shared/unifi-discord


### PR DESCRIPTION
**Pre-flight for the root flip caught this.** `stargate-command` was the *only* namespace present in equestria's `kubernetes/apps` and absent here.

## It's not staged placeholders

All five Kustomizations are live and `Ready`, running the actual home-automation stack:

```
chrony-0                          1/1   Running   29h
home-assistant-6fcbb9cfc6-nl6rc   2/2   Running   29h
matter-d79959b5f-qbzql            1/1   Running   30h
mosquitto-0                       1/1   Running   30h
mosquitto-1                       1/1   Running   29h
```

Plus 19 HelmRelease/PVC/Service objects between them.

## What the flip would have done without this

Nothing would have been *deleted* — `prune: false` is live, and all five carry `deletionPolicy: Orphan`. But their `sourceRef` is `GitRepository/flux-system`, which re-resolves to **this repo** at the flip. Their paths wouldn't exist here, so all five would go `NotReady` on "path not found".

**174/174 → 169/174, with the home-automation stack running unmanaged.**

## Ported as a no-op, same principle as #804

- **`sourceRef` stays `flux-system`** (the self GitRepository), *not* `home-operations`. The other 16 namespaces had to use `home-operations` because they migrated *ahead of* the flip via `-ref` redirects. This one migrates *at* the flip, so the self reference is both correct and already what the live objects say.
- **`deletionPolicy: Orphan` is kept**, not stripped as the sweep convention normally does on arrival. This namespace's fate is decided in piece 22; until then nothing should be able to cascade-delete Home Assistant. The comment is rewritten to say that rather than claiming to be migration scaffolding.

## Verification

```
object sets (kind/name)          IDENTICAL
lines only in equestria's render 0        ← nothing lost
lines only in this render        decryption + substituteFrom (build-time injection)
```

Those injected fields match the live objects exactly, all five:

```
chrony           sops/sops-age | cluster-secrets  cluster-versions  shared-secrets
home-assistant   sops/sops-age | cluster-secrets  cluster-versions  shared-secrets
matter           sops/sops-age | cluster-secrets  cluster-versions  shared-secrets
mosquitto        sops/sops-age | cluster-secrets  cluster-versions  shared-secrets
sgc-secrets      sops/sops-age | cluster-secrets  cluster-versions  shared-secrets
```

equestria gets them injected at *apply* time by `cluster-apps`; this repo at *build* time via `components/common`. Same applied object.

**This is the last blocker before the flip.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)