### PR TITLE
fix(flux): point this repo's own sync url at itself -- breaks the flip-flop

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/helm/values.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/helm/values.yaml
@@ -15,7 +15,7 @@ instance:
   sync:
     name: flux-system
     kind: GitRepository
-    url: "https://github.com/david-driscoll/equestria-cluster.git"
+    url: "https://github.com/david-driscoll/home-operations.git"
     ref: "refs/heads/main"
     path: kubernetes/flux/cluster
   kustomize:


### PR DESCRIPTION
## 🚨 Urgent — the cluster is oscillating right now

`GitRepository/flux-system` is flipping between `equestria-cluster` and `home-operations` on a ~20-second cycle. Observed live:

```
t+5s   FluxInstance=equestria-cluster.git   GitRepository=equestria-cluster.git
t+10s  FluxInstance=home-operations.git     GitRepository=home-operations.git
t+15s  FluxInstance=home-operations.git     GitRepository=home-operations.git
t+25s  FluxInstance=equestria-cluster.git   GitRepository=equestria-cluster.git
t+40s  FluxInstance=equestria-cluster.git   GitRepository=equestria-cluster.git
```

## Cause — a mistake in #804

#804 deliberately kept `flux-instance/helm/values.yaml` **byte-identical** to equestria's, so the flip would apply zero diff. That reasoning was correct for every other file in the namespace and wrong for exactly this one: **`values.yaml` is not passive content, it is the pointer itself.**

Byte-identical *at that time* meant it still said `url: equestria-cluster.git`. So the instant the flip took effect, the destination tree started telling Flux to sync from the source tree:

1. equestria#3172 sets **equestria's** `values.yaml` → `home-operations`
2. `flux-instance` (reading equestria) applies it → `GitRepository` → `home-operations`
3. `cluster-apps` now reads **home-operations**, applies **its** `values.yaml`, which still says `equestria-cluster` → `GitRepository` → `equestria-cluster`
4. `cluster-apps` reads equestria again, which says `home-operations` → **goto 2**

The flip has to land in whichever copy *wins* after the flip — and that's this one.

## The fix

```diff
-    url: "https://github.com/david-driscoll/equestria-cluster.git"
+    url: "https://github.com/david-driscoll/home-operations.git"
```

Both copies now agree on `home-operations`, so whichever source a given reconcile happens to read, the answer is the same. The loop terminates and settles here.

## Nothing was destroyed

`prune: false` is live on both `cluster-meta` and `cluster-apps` — this is exactly the failure class it was put there to absorb. The 88 not-ready Kustomizations are dependency cascades from reconciles being repeatedly interrupted (`dependency 'volsync-system/volsync' is not ready`, etc.), **not** deletions. They should resolve once the source stops moving.

## After merge

```bash
# url must stay put across several polls
for i in $(seq 6); do kubectl get gitrepository flux-system -n flux-system \
  -o jsonpath='{.spec.url}{"\n"}'; sleep 10; done

kubectl get kustomization -A --no-headers | awk '$4!="True"' | wc -l   # → 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)