### PR TITLE
feat(flux): restore prune, and protect the cert-manager CRDs (piece 21 Phase C step 4)

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -18,6 +18,16 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/cert-manager/cert-manager
   prune: true
+  # The cert-manager HelmRelease installs the cert-manager CRDs
+  # (`crds: CreateReplace`) -- certificates, issuers, clusterissuers,
+  # certificaterequests, orders, challenges. Deleting this Kustomization
+  # without this would cascade into those CRDs and take every Certificate in
+  # the cluster with them (9 live today), plus every Issuer. Same failure
+  # class as the Traefik CRD cascade in
+  # docs/cluster-consolidation/26-bootstrap-apps-to-pulumi.md, and it was on
+  # the protect list but never actually landed here -- caught by the
+  # deletionPolicy audit at the end of piece 21 Phase C.
+  deletionPolicy: Orphan
   wait: true
   force: false
   retryInterval: 2m

--- a/kubernetes/apps/cert-manager/trust-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/trust-manager/ks.yaml
@@ -16,6 +16,10 @@ spec:
       namespace: cert-manager
   path: ./kubernetes/apps/cert-manager/trust-manager
   prune: true
+  # Installs the trust-manager CRDs (`crds: CreateReplace`) -- bundles.trust.
+  # cert-manager.io. Same reasoning as cert-manager/ks.yaml next door: a
+  # Kustomization ownership change must never be able to cascade into a CRD.
+  deletionPolicy: Orphan
   wait: true
   force: false
   interval: 1h

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -8,8 +8,8 @@
 # equestria-cluster at this same relative path; this copy only becomes live at
 # the Phase C root flip, when `instance.sync.url` changes to this repo.
 #
-# One deliberate difference from equestria-cluster's copy is recorded at its
-# site below: `prune: false`.
+# This is now the live root: equestria-cluster is no longer a GitOps source.
+# Phase C is complete and prune is restored on both Kustomizations below.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -22,21 +22,14 @@ spec:
       name: sops-age
   interval: 1h
   path: ./kubernetes/flux/meta
-  # THE deliberate difference vs equestria-cluster (`prune: true` there).
-  #
-  # TEMPORARY, and load-bearing. At the instant of the Phase C flip both roots
-  # re-diff their entire apply set against a tree they have never read before.
-  # If anything in this repo is missing or misnamed, `prune: true` would
-  # garbage-collect the live objects rather than report drift -- at this
-  # cluster's scale, most of it. With `prune: false` the same gap surfaces as
-  # drift you can read and fix, which is the whole reason Phase B exists as a
-  # separate step from Phase C.
-  #
-  # Restore to `true` in Phase C step 4, AFTER `flux get kustomizations -A`
-  # confirms every Applied revision is a home-operations SHA and nothing is
-  # NotReady. Re-enabling prune is its own deliberate act; do not bundle it
-  # into the flip commit.
-  prune: false
+  # Restored 2026-08-14, Phase C step 4. This was `false` across the root flip
+  # so that an incomplete tree would surface as drift rather than as garbage
+  # collection; that window is closed. Re-enabled only after ALL of: the flip
+  # settled on this repo, the 16 -ref stubs were deleted by hand, cluster-apps
+  # re-owned all 155 children, and a dry run confirmed prune had nothing to
+  # collect -- 401 rendered objects against 401 inventory entries, zero
+  # difference.
+  prune: true
   retryInterval: 2m
   sourceRef:
     kind: GitRepository
@@ -62,9 +55,9 @@ spec:
       namespace: flux-system
   interval: 1h
   path: ./kubernetes/apps
-  # See the note on cluster-meta above -- same reason, and this is the one
+  # See the note on cluster-meta above -- same restore, and this is the one
   # that matters: cluster-apps owns the entire ./kubernetes/apps apply set.
-  prune: false
+  prune: true
   retryInterval: 2m
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Closes out Phase C. Two changes.

## 1. `prune: true` restored on both roots

It was `false` across the flip so an incomplete tree would surface as *drift* rather than as *garbage collection*. Keeping it open is what absorbed the flip-flop loop between #810 and equestria#3172 without a single deletion.

Re-enabled only after all four preconditions held:

- ✅ flip settled on this repo (`GitRepository/flux-system` stable)
- ✅ 16 `-ref` stubs deleted by hand, **while prune was still off**
- ✅ `cluster-apps` re-owned all 155 children (owner label `<ns>-ref` → `cluster-apps`)
- ✅ dry run: prune has **nothing** to collect

```
rendered by git    : 401
cluster-apps inv   : 401
WOULD BE PRUNED    : 0
```

> ⚠️ The first run of that dry run reported **17 `Middleware/local-user` would be pruned** — a false positive from concatenating `kustomize build` outputs without `---` separators, which let the last doc of each namespace merge into the first doc of the next so PyYAML dropped resources on duplicate keys. `local-user` is defined in `components/common` and referenced by 36 live routes. Corrected run above renders all 18 of them and shows zero drift. Worth knowing if anyone rebuilds this check.

## 2. `deletionPolicy: Orphan` on cert-manager and trust-manager

Found by auditing every `deletionPolicy` in the tree now the migration is done. **37 entries, all deliberate, zero sweep scaffolding left** — the migration correctly stripped the blanket annotations.

But **`cert-manager` was on the protect list and never landed here**, presumably stripped on arrival with the rest of the sweep.

Both install CRDs:

```
cert-manager   crds: CreateReplace  → certificates, issuers, clusterissuers,
                                      certificaterequests, orders, challenges
trust-manager  crds: CreateReplace  → bundles.trust.cert-manager.io
```

Deleting either Kustomization would cascade into those CRDs and take **every instance cluster-wide** — 9 live Certificates today, plus every Issuer. Exactly what destroyed the Traefik CRDs in piece 26.

`cert-issuers` and `trust-bundles` are deliberately left at the default: they hold *instances*, not CRDs, so losing them is recoverable by reconciling. Blanket-Orphaning instance-level Kustomizations is what the sweep cleanup was undoing.

## Verify after merge

```bash
kubectl get kustomization -n flux-system cluster-meta cluster-apps \
  -o custom-columns='NAME:.metadata.name,PRUNE:.spec.prune'   # both true

kubectl get kustomization -A --no-headers | awk '$4!="True"'  # empty
kubectl get crd | grep -cE 'cert-manager|trust'               # still 7
kubectl get certificate -A --no-headers | wc -l               # still 9
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)