### PR TITLE
fix(alpha-site): stage authentik on non-conflicting hostnames

### DIFF
--- a/docker/alpha-site/authentik/.ignore
+++ b/docker/alpha-site/authentik/.ignore
@@ -59,3 +59,31 @@
 # After deleting this file, `pulumi up` on stacks/home deploys authentik here
 # against a FRESH, EMPTY database. Confirm it starts healthy against that empty
 # DB before restoring anything into it.
+#
+# ---------------------------------------------------------------------------
+# WHAT THE CUTOVER STILL HAS TO FLIP (this stack deploys on STAGING names)
+# ---------------------------------------------------------------------------
+#
+# Unlocking does NOT make this instance answer for the estate's SSO hostnames,
+# on purpose. compose.yaml routes only:
+#
+#      authentik.${CLUSTER_DOMAIN}          (as.driscoll.tech)
+#      authentik-as.${tailscaleDomain}
+#
+# because every `Host(...)` rule here becomes real infrastructure — a StandardDns
+# CNAME or a tailscale.Service — so naming the production aliases would repoint
+# live SSO DNS on deploy, against records external-dns is publishing from SGC's
+# HTTPRoute at the same time. Verified live 2026-08-15: all of
+# authentik/iris/canterlot.driscoll.tech resolve to SGC's gateway, and
+# `svc:authentik` is already taken on the tailnet.
+#
+# At cutover (section 4 step 5), in ONE change:
+#   - swap compose.yaml's two router rules for the three vanity aliases
+#   - point definition.yaml's `url` at authentik.${ROOT_DOMAIN} and add the
+#     per-alias gatus checks
+#   - rename definition.yaml's `spec.name` back to plain "Authentik" ONLY after
+#     SGC's own definition is gone — until then the "(Alpha Site)" suffix is what
+#     stops Gatus panicking on a duplicate (name, group) and taking estate-wide
+#     monitoring down with it (piece 27)
+#   - remove the three hostnames from SGC's HelmRelease HTTPRoute and confirm
+#     external-dns has retracted them from all three providers FIRST

--- a/docker/alpha-site/authentik/compose.yaml
+++ b/docker/alpha-site/authentik/compose.yaml
@@ -95,20 +95,39 @@ services:
       autoheal: true
       traefik.enable: true
 
-      # All three vanity aliases answer here, because all three answer on ONE
-      # HTTPRoute in SGC today (section 1.4) and every cluster's outposts and
-      # Dockge hosts know authentik by a cluster-specific one:
-      #   canterlot -> equestria, celestia, luna, skystar
-      #   iris      -> sgc, alpha-site
-      #   authentik -> the chart's own default, and DockgeLxc's remote-host fallback
+      # STAGING HOSTNAMES — deliberately NOT the production vanity aliases.
+      #
+      # Every `Host(...)` rule in this file is parsed by DockgeLxc's hostRegex
+      # (components/DockgeLxc.ts:1061) and turned into infrastructure, not just
+      # routing: a name under the tailnet domain becomes a `tailscale.Service`
+      # (`svc:<name>`), and any other name becomes a StandardDns CNAME pointing at
+      # this Dockge host. So naming the production aliases here does not merely
+      # duplicate a route — it REPOINTS LIVE SSO DNS the moment the stack deploys,
+      # against records external-dns is simultaneously publishing from SGC's
+      # HTTPRoute. Two writers on the same names, one of which has wiped live DNS
+      # before. Verified 2026-08-15, all four are live and in use:
+      #   authentik/iris/canterlot.driscoll.tech -> odyssey (SGC gateway), 10.10.209.101
+      #   authentik.<tailnet>                    -> 100.106.100.188
+      #
+      # So staging runs on names nothing else claims. The cutover swaps these two
+      # rules for the three vanity aliases in the SAME change that removes them
+      # from SGC's HTTPRoute — see section 4 step 5 of
+      # docs/cluster-consolidation/07-authentik-to-alpha-site.md, and the
+      # "cutover" section of the .ignore in this directory.
+      #
       # Issuer URLs do not change in this migration; only what answers behind
       # them does, which is why no app's OIDC config is touched.
-      traefik.http.routers.authentik.rule: Host(`authentik.${searchDomain}`) || Host(`iris.${searchDomain}`) || Host(`canterlot.${searchDomain}`)
+      traefik.http.routers.authentik.rule: Host(`authentik.${CLUSTER_DOMAIN}`)
       traefik.http.routers.authentik.entrypoints: websecure
       traefik.http.routers.authentik.tls.certresolver: le
       traefik.http.routers.authentik.service: authentik
 
-      traefik.http.routers.authentik-tailscale.rule: Host(`authentik.${tailscaleDomain}`)
+      # authentik-as, NOT authentik: `svc:authentik` already exists on the tailnet
+      # (and DockgeLxc:700 hands remote hosts `authentik.<tailnet>` as their
+      # CLUSTER_AUTHENTIK_DOMAIN). Claiming it here would both collide on the
+      # service name and silently repoint every remote Dockge host's outpost at
+      # this empty instance.
+      traefik.http.routers.authentik-tailscale.rule: Host(`authentik-as.${tailscaleDomain}`)
       traefik.http.routers.authentik-tailscale.entrypoints: tailscale
       traefik.http.routers.authentik-tailscale.service: authentik
 
@@ -156,9 +175,8 @@ services:
 
 x-dockge:
   urls:
-    - https://authentik.${searchDomain}
-    - https://iris.${searchDomain}
-    - https://canterlot.${searchDomain}
+    - https://authentik.${CLUSTER_DOMAIN}
+    - https://authentik-as.${tailscaleDomain}
 
 networks:
   dockge_default:

--- a/docker/alpha-site/authentik/definition.yaml
+++ b/docker/alpha-site/authentik/definition.yaml
@@ -5,10 +5,21 @@ kind: ApplicationDefinition
 metadata:
   name: authentik
 spec:
-  name: Authentik
+  # "(Alpha Site)", not bare "Authentik", and this is load-bearing while SGC is
+  # still live. addGatusInstances builds each endpoint's Gatus name from
+  # spec.name, and Gatus enforces global uniqueness on (name, group) across the
+  # whole merged config from every cluster — it PANICS on a duplicate rather than
+  # skipping it, which takes down monitoring for the entire estate, not just this
+  # endpoint. That exact failure happened on 2026-08-13 staging tsidp; see
+  # docs/cluster-consolidation/27-migration-churn-failure-modes.md. SGC's copy
+  # publishes ("Authentik ", "Applications"), so this must not be able to collide.
+  # Rename to plain "Authentik" only once SGC's definition is gone.
+  name: Authentik (Alpha Site)
   category: Infrastructure
   description: Authentik is an open-source identity provider focused on flexibility and security.
-  url: &url https://authentik.${searchDomain}
+  # Staging hostname — see compose.yaml's router comment for why this is not the
+  # production vanity alias. Flipped at cutover.
+  url: &url https://authentik.${CLUSTER_DOMAIN}
   icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/authentik.svg
   # NO `authentik:` block, and there never will be one. Authentik cannot be an
   # OAuth client of itself, and this host serves its own forwardAuth from the
@@ -18,34 +29,20 @@ spec:
   # NO `access_policy` either, for the same reason: there is no provider for a
   # policy to bind to. Authentik's own admin interface is gated by authentik.
   gatus:
-    # Load-bearing, not cosmetic. Once this host answers for the vanity aliases,
-    # every OIDC login and every outpost in the estate depends on it — and it is
-    # a single Pi on a single PoE switch (section 6, accepted).
+    # One check while staging, against the staging hostname. /-/health/live/ is
+    # authentik's unauthenticated liveness endpoint; it answers before and
+    # independently of a working login flow.
     #
-    # /-/health/live/ is authentik's unauthenticated liveness endpoint; it
-    # answers before and independently of a working login flow.
-    - name: Authentik
-      group: ${CLUSTER_TITLE}
-      url: https://authentik.${searchDomain}/-/health/live/
+    # Deliberately NOT checking canterlot/iris yet: those names still resolve to
+    # SGC, so checks against them would report green for a server this stack has
+    # nothing to do with — monitoring theatre that would go on passing straight
+    # through a failed cutover. They are added in the cutover change, alongside
+    # the router flip, when they actually point here. At that moment they become
+    # load-bearing: every OIDC login and every outpost in the estate depends on a
+    # single Pi on a single PoE switch (section 6, accepted), and "one alias did
+    # not repoint" is a failure only a per-alias check can see.
+    - url: https://authentik.${CLUSTER_DOMAIN}/-/health/live/
       method: GET
       interval: 1m
-      conditions:
-        - "[STATUS] == 204"
-    # The two vanity aliases get their own checks rather than riding on the one
-    # above: they are separate DNS names published by separate providers, and the
-    # failure this needs to catch is "one alias did not repoint", which a check
-    # against the primary hostname cannot see.
-    - name: Authentik (canterlot alias)
-      group: ${CLUSTER_TITLE}
-      url: https://canterlot.${searchDomain}/-/health/live/
-      method: GET
-      interval: 5m
-      conditions:
-        - "[STATUS] == 204"
-    - name: Authentik (iris alias)
-      group: ${CLUSTER_TITLE}
-      url: https://iris.${searchDomain}/-/health/live/
-      method: GET
-      interval: 5m
       conditions:
         - "[STATUS] == 204"

--- a/docs/cluster-consolidation/07-authentik-to-alpha-site.md
+++ b/docs/cluster-consolidation/07-authentik-to-alpha-site.md
@@ -522,6 +522,19 @@ outpost-token minting (`components/DockgeLxc.ts:791`) for every other Dockge hos
    external-dns retract them from cloudflare/technitium/unifi, and confirm all three are gone from
    each provider before publishing the alpha-site side. Leaving the `HTTPRoute` hostnames in place
    means external-dns re-asserts them at SGC's gateway and wins.
+
+   **"Publishing the alpha-site side" is a concrete edit, not a DNS console action.** The stack
+   deploys on staging names (`authentik.${CLUSTER_DOMAIN}`, `authentik-as.${tailscaleDomain}`)
+   precisely so that unlocking it cannot touch live SSO DNS: `DockgeLxc`'s `hostRegex`
+   (`components/DockgeLxc.ts:1061`) turns every `Host(...)` rule in a compose file into either a
+   `StandardDns` CNAME or a `tailscale.Service`, so naming the production aliases there *is* a DNS
+   change — made by a second writer, against records external-dns is publishing at the same moment.
+   The flip is therefore: swap `docker/alpha-site/authentik/compose.yaml`'s two router rules for the
+   three vanity aliases, repoint `definition.yaml`'s `url`, add the per-alias gatus checks, and drop
+   the `(Alpha Site)` suffix from `spec.name` — but that last one **only once SGC's own
+   `ApplicationDefinition` is gone**, since until then the distinct name is what keeps Gatus from
+   panicking on a duplicate `(name, group)` and taking estate-wide monitoring down with it
+   ([27](27-migration-churn-failure-modes.md)).
 6. **Repoint `AUTHENTIK_URL`/`AUTHENTIK_TOKEN`** in OpenBao (§3.5), then confirm reachability
    **from a pod in equestria**, not from a workstation — `stacks/authentik` reconciles in-cluster.
 7. **Post-check:** every outpost re-registers and reports healthy against the new server


### PR DESCRIPTION
Follow-up to #808, and a **blocker on unlocking that stack's `.ignore`**. Also folds the §3.1 fsync result and the cutover detail back into the plan doc.

## The bug

The stack named the three production vanity aliases plus `authentik.<tailnet>` in its Traefik rules. That is not a routing duplicate — `DockgeLxc`'s `hostRegex` ([`components/DockgeLxc.ts:1061`](https://github.com/david-driscoll/home-operations/blob/main/components/DockgeLxc.ts#L1061)) turns **every `Host(...)` rule in a compose file into infrastructure**: a name under the tailnet domain becomes a `tailscale.Service`, anything else becomes a `StandardDns` CNAME pointing at the Dockge host.

So unlocking the stack would have repointed **live SSO DNS on deploy**, as a second writer against the records external-dns publishes from SGC's `HTTPRoute`. This estate has had `StandardDns` wipe live records before.

Verified live 2026-08-15 — all four names are in use:

| Name | Currently resolves to |
|---|---|
| `authentik` / `iris` / `canterlot.driscoll.tech` | `odyssey.driscoll.tech` → `10.10.209.101` (SGC gateway) |
| `authentik.<tailnet>` | `100.106.100.188` |

`authentik.<tailnet>` is the worse of the two: `DockgeLxc:700` hands remote hosts *exactly that name* as their `CLUSTER_AUTHENTIK_DOMAIN`, so claiming it would silently repoint every remote Dockge host's outpost at an empty authentik — on top of colliding on the `svc:` name.

Staging now runs on `authentik.${CLUSTER_DOMAIN}` and `authentik-as.${tailscaleDomain}`, which nothing claims.

## Second failure mode, same family

`definition.yaml`'s `spec.name` becomes **`Authentik (Alpha Site)`**. `addGatusInstances` derives each endpoint's Gatus name from `spec.name`, and Gatus enforces global uniqueness on `(name, group)` across the merged config from *every* cluster — it **panics** on a duplicate rather than skipping it, which stops it publishing any results at all and takes estate-wide monitoring down. That exact failure happened staging `tsidp` on 2026-08-13 ([piece 27](https://github.com/david-driscoll/home-operations/blob/main/docs/cluster-consolidation/27-migration-churn-failure-modes.md)). SGC publishes `("Authentik ", "Applications")`; the suffix makes a collision impossible. It comes off only once SGC's definition is gone.

The two vanity-alias gatus checks are **dropped for now** rather than kept: those names still resolve to SGC, so the checks would report green for a server this stack has nothing to do with — and would go on passing straight through a failed cutover. They return in the cutover change, when they actually point here.

## Docs

The `.ignore` gains a section spelling out what the cutover must still flip, and §4 step 5 of the plan now states that "publishing the alpha-site side" is this concrete edit, not a DNS console action.

## Verification

- [x] Both YAML files parse; no stale `${searchDomain}` references remain in the stack
- [x] All four conflicting names confirmed live via `dig` (table above)
- [x] Gatus `(name, group)` pairs confirmed distinct from SGC's
- [ ] `pulumi preview` on `stacks/home` still shows no diff (`.ignore` unchanged, stack still gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)