### PR TITLE
fix(tsidp): complete the equestria cutover (runbook 14 step 4)

### DIFF
--- a/kubernetes/apps/tailscale-system/idp/tsidp.yaml
+++ b/kubernetes/apps/tailscale-system/idp/tsidp.yaml
@@ -33,7 +33,7 @@ spec:
       *app :
         annotations:
           reloader.stakater.com/auto: "true"
-        replicas: 0 # staging: piece 14 flips this to 1 at cutover
+        replicas: 1 # cutover complete 2026-08-15 (runbook 14 step 4)
         pod:
           restartPolicy: Always
           terminationGracePeriodSeconds: 30


### PR DESCRIPTION
## Why

`idp.opossum-yo.ts.net` has been offline for ~1 day. SGC's tsidp was removed in `stargate-command-cluster` [`c18b499f`](https://github.com/david-driscoll/stargate-command-cluster/commit/c18b499fb) on 2026-08-13 16:14 EDT, which pruned the Deployment **and its PVC**. Equestria's replacement stayed pinned at `replicas: 0`, so [step 4 of the cutover runbook](docs/cluster-consolidation/14-cutover-runbook.md) never ran.

**Downstream:** Authentik's `tailscale` OAuth source does dynamic client registration against `https://idp.<tailnet>/register` ([`flows.ts:215`](components/authentik/flows.ts)). That DCR fails while tsidp is down, so `PUT /api/v3/sources/oauth/tailscale/` returns 400 and the `authentik` Pulumi stack has failed **29×** and is `Stalled: UpdateFailed`. Proxmox hosts and PBS register the same way.

## The trap

Equestria's `tsidp` PVC was **empty** — the staging restore reported `No eligible snapshots found`. `/repository` is NFS `10.10.10.10:/mnt/stash/backup/${CLUSTER_CNAME}/volsync`, a **per-cluster** path, so equestria's repo was fresh and never saw SGC's data.

> Runbook step 3 calls `/repository/tsidp` "the shared repo key" and warns of a two-writer trap. That isn't accurate — the repos are per-cluster — and it's why staging restored nothing. Worth correcting in the doc.

Scaling up without restoring would have registered the node as `idp-1` and minted **new OIDC signing keys**, invalidating every registered client — exactly what happened to tsiam, which is still stranded on `tsiam-1`.

## What was done out of band

SGC's repo was intact at `/mnt/stash/backup/sgc/volsync/tsidp` (12 snapshots), and both clusters read the same restic password (`secrets/shared/volsync-password`). Snapshot `f34296d2` (2026-08-13 14:03 UTC — the last scheduled run before the disable commit) was restored directly into the PVC:

```
certs/  oidc-funnel-clients.json (310K)  oidc-key.json  tailscaled.state
```

`tailscaled.state` is what lets the node reclaim the `idp` hostname.

## Verification after merge

- [ ] Pod Ready, logs show hostname `idp.opossum-yo.ts.net` (not `idp-1`)
- [ ] `https://idp.opossum-yo.ts.net/.well-known/openid-configuration` → 200 (Gatus "Tailscale IDP")
- [ ] `authentik` Pulumi stack clears `Stalled` on next reconcile

## Still open (not in this PR)

`tsiam` stranded on `tsiam-1` with a regenerated signing key; SGC copy left deleted rather than `replicas: 0` as the runbook's step 7 intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)