### PR TITLE
fix(traefik): add 172.16.0.0/12 to the dockge internal-network allowlist

### DIFF
--- a/docker/_common/traefik/definition.yaml
+++ b/docker/_common/traefik/definition.yaml
@@ -18,7 +18,23 @@ spec:
   # providers, so each host keeps a non-empty proxyProviders list and its
   # Outpost resource survives (components/DockgeLxc.ts:748).
   gatus:
-    - url: *url
+    # Probe the dashboard on the TAILSCALE entrypoint, not the public one.
+    # `dashboard-tailscale` (compose.yaml) deliberately carries no middleware,
+    # so this genuinely exercises the dashboard -- verified 200 from the Gatus
+    # host for all four dockge hosts.
+    #
+    # Do NOT point this at `internal.${CLUSTER_DOMAIN}` and do NOT widen
+    # `internal-network@file` to make that pass. Those hosts publish traefik's
+    # :443 through docker with `userland-proxy` enabled (no /etc/docker/
+    # daemon.json), so docker-proxy re-originates every connection from the
+    # bridge gateway: traefik observes 172.18.0.1 as the client for ALL
+    # traffic -- LAN, tailnet and public internet alike. Adding 172.16.0.0/12
+    # (or 172.18.0.1/32) to the allowlist would therefore not "allow Gatus",
+    # it would allow everyone, silently turning the break-glass gate on an
+    # admin dashboard into no gate at all. Restoring a meaningful ipAllowList
+    # needs real client IPs first (userland-proxy false, host networking, or
+    # PROXY protocol) -- tracked separately.
+    - url: "https://internal-${host}.${tailscaleDomain}"
       method: GET
       conditions:
         - "[STATUS] == 200"

--- a/docker/_common/traefik/definition.yaml
+++ b/docker/_common/traefik/definition.yaml
@@ -18,23 +18,7 @@ spec:
   # providers, so each host keeps a non-empty proxyProviders list and its
   # Outpost resource survives (components/DockgeLxc.ts:748).
   gatus:
-    # Probe the dashboard on the TAILSCALE entrypoint, not the public one.
-    # `dashboard-tailscale` (compose.yaml) deliberately carries no middleware,
-    # so this genuinely exercises the dashboard -- verified 200 from the Gatus
-    # host for all four dockge hosts.
-    #
-    # Do NOT point this at `internal.${CLUSTER_DOMAIN}` and do NOT widen
-    # `internal-network@file` to make that pass. Those hosts publish traefik's
-    # :443 through docker with `userland-proxy` enabled (no /etc/docker/
-    # daemon.json), so docker-proxy re-originates every connection from the
-    # bridge gateway: traefik observes 172.18.0.1 as the client for ALL
-    # traffic -- LAN, tailnet and public internet alike. Adding 172.16.0.0/12
-    # (or 172.18.0.1/32) to the allowlist would therefore not "allow Gatus",
-    # it would allow everyone, silently turning the break-glass gate on an
-    # admin dashboard into no gate at all. Restoring a meaningful ipAllowList
-    # needs real client IPs first (userland-proxy false, host networking, or
-    # PROXY protocol) -- tracked separately.
-    - url: "https://internal-${host}.${tailscaleDomain}"
+    - url: *url
       method: GET
       conditions:
         - "[STATUS] == 200"

--- a/docker/_common/traefik/dynamic/middlewares.yaml
+++ b/docker/_common/traefik/dynamic/middlewares.yaml
@@ -12,6 +12,27 @@ http:
       ipAllowList:
         sourceRange:
           - 10.0.0.0/8
+          # Required on a Docker host, and the reason the dashboard check was
+          # red 0/50. Tailnet-originated requests are proxied into the
+          # container by tailscaled running on the host, so traefik sees the
+          # bridge gateway (172.18.0.1 on celestia/luna, 172.19.0.1 on
+          # alpha-site) rather than the caller's 100.64/10 address. Measured
+          # inside traefik's netns: a held connection from alpha-site appears
+          # as 172.18.0.1.
+          #
+          # This does NOT widen the gate to the internet. `internal.<domain>`
+          # has no public record -- it resolves only to a 100.64/10 CGNAT
+          # address -- so the sole ways in are the tailnet (authenticated by
+          # Tailscale) and the LAN. LAN callers keep their real source via
+          # Docker's DNAT rule (`! -i br-...`, no inbound masquerade), verified
+          # as 10.10.216.234 for a request from luna, and are already matched
+          # by 10.0.0.0/8 above. What it does newly admit is other containers
+          # on the host's own bridge, which are on the trusted host already.
+          #
+          # Also restores parity with the estate's own definition of internal:
+          # crowdsec's `driscoll/internal-networks` lists this same range
+          # (kubernetes/apps/network/crowdsec/values.yaml).
+          - 172.16.0.0/12
           - 192.168.0.0/16
           - 100.64.0.0/10
     errors:

--- a/docker/_common/traefik/dynamic/middlewares.yaml
+++ b/docker/_common/traefik/dynamic/middlewares.yaml
@@ -12,29 +12,9 @@ http:
       ipAllowList:
         sourceRange:
           - 10.0.0.0/8
-          # Required on a Docker host, and the reason the dashboard check was
-          # red 0/50. Tailnet-originated requests are proxied into the
-          # container by tailscaled running on the host, so traefik sees the
-          # bridge gateway (172.18.0.1 on celestia/luna, 172.19.0.1 on
-          # alpha-site) rather than the caller's 100.64/10 address. Measured
-          # inside traefik's netns: a held connection from alpha-site appears
-          # as 172.18.0.1.
-          #
-          # This does NOT widen the gate to the internet. `internal.<domain>`
-          # has no public record -- it resolves only to a 100.64/10 CGNAT
-          # address -- so the sole ways in are the tailnet (authenticated by
-          # Tailscale) and the LAN. LAN callers keep their real source via
-          # Docker's DNAT rule (`! -i br-...`, no inbound masquerade), verified
-          # as 10.10.216.234 for a request from luna, and are already matched
-          # by 10.0.0.0/8 above. What it does newly admit is other containers
-          # on the host's own bridge, which are on the trusted host already.
-          #
-          # Also restores parity with the estate's own definition of internal:
-          # crowdsec's `driscoll/internal-networks` lists this same range
-          # (kubernetes/apps/network/crowdsec/values.yaml).
-          - 172.16.0.0/12
           - 192.168.0.0/16
           - 100.64.0.0/10
+          - 172.16.0.0/12
     errors:
       errors:
         status:


### PR DESCRIPTION
> Rewritten to do this via the middleware, per review. My earlier objection — that widening the allowlist would expose the dashboard to the internet — **was wrong**, and I've since measured the thing I had only inferred. Evidence below.

## The bug

`Cluster: {Alpha Site,Celestia,Skystar}/Traefik Dashboard` have been red **0/50 — never once green**, always 403.

Tailnet-originated requests are proxied into the container by `tailscaled` running on the host, so traefik sees the **bridge gateway** rather than the caller's `100.64/10` address. Measured inside traefik's own netns — holding a connection open from alpha-site took the peer count 7 → 8, the new peer being:

```
1 ESTAB [::ffff:172.18.0.1]:38722
```

`172.16.0.0/12` was absent from `internal-network`, so every tailnet caller — Gatus included — was refused.

## Why this does not open the dashboard to the internet

This was my original objection. It doesn't hold:

- **The internet cannot reach it.** `internal.celestia.driscoll.tech` has no public record — it resolves only to `100.111.30.100`, a `100.64/10` CGNAT address. The only ingress paths are the tailnet (authenticated by Tailscale) and the LAN.
- **LAN callers keep their real source**, so they were never relying on this. Docker's DNAT rule is scoped `! -i br-...` with no inbound masquerade. Verified: a held connection from luna over the LAN path appears to traefik as `10.10.216.234` — already matched by `10.0.0.0/8`.

I had assumed public traffic would arrive with the same apparent source as the tailnet path. It doesn't — only the tailscale-proxied path collapses to the gateway.

## What it does change

Containers on the host's own docker bridge can now reach the dashboard. They're on the trusted host already, so this is a modest and deliberate widening — worth naming rather than glossing.

A `/32` on the gateway would be tighter, but the bridge subnet differs per host (`172.18.0.1` on celestia and luna, `172.19.0.1` on alpha-site) and this file is shared via `_common`, so `/12` is the granularity that covers all of them.

## Parity

This restores agreement with the estate's own definition of "internal" — crowdsec's `driscoll/internal-networks` already lists this exact range alongside the other three:

```yaml
- "10.0.0.0/8"
- "172.16.0.0/12"     # <- present there, missing here
- "192.168.0.0/16"
- "100.64.0.0/10"
```

The file's own comment says it is "the Dockge-side equivalent of the cluster's network/internal-network Middleware, same intent, same ranges minus the two Kubernetes-only ones" — so the omission reads as an oversight rather than a decision.

## Verification after this lands

The middleware is a traefik file provider, so it hot-reloads once Pulumi ships the file to the hosts:

- [ ] `https://internal.{celestia,skystar,alpha-site}.driscoll.tech` returns 200 from the Gatus host instead of 403
- [ ] The three `Traefik Dashboard` checks go green for the first time

## Two things found along the way, not changed here

1. **luna is on a different middleware.** `traefik.http.routers.dashboard.middlewares` is `authentik-outpost@docker` on luna but `internal-network@file` on the other three. Luna's check was green only because it was testing something else entirely. Worth reconciling.
2. **The second gatus entry in `definition.yaml` is a Neo4j check.** `tcp://internal.${CLUSTER_DOMAIN}:7687` — 7687 is the bolt port, and [`_common/neo4j/definition.yaml`](docker/_common/neo4j/definition.yaml) has the identical stanza. It surfaces as a confusingly-named "Traefik Dashboard 2". Left alone since it's green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)