### PR TITLE
fix(traefik): alias crowdsec-bouncer into every namespace

### DIFF
--- a/kubernetes/apps/network/traefik/middleware/kustomization.yaml
+++ b/kubernetes/apps/network/traefik/middleware/kustomization.yaml
@@ -15,8 +15,14 @@ resources:
   - ./error-pages.yaml
   - ./default-cors.yaml
   - ./outpost.yaml
-  # Creates the crowdsec-bouncer Middleware object. Inert on its own: the
-  # plugin ships with `enabled: false` and no HTTPRoute references it yet.
+  # Creates the crowdsec-bouncer Middleware object in THIS namespace only, and
+  # holds the plugin config (including the `enabled: false` kill switch).
+  # Inert on its own: the plugin ships disabled.
+  #
+  # Routes do not reference this copy directly -- Traefik resolves an
+  # ExtensionRef in the route's own namespace, so each namespace gets a thin
+  # alias chaining here from components/common/middleware.yaml. Stage 3's
+  # whoami route (apps/equestria/utils/whoami) is the one live reference today.
   # See docs/crowdsec-enforcement-rollout.md before changing either.
   - ./crowdsec.yaml
   # - ./fail2ban.yaml

--- a/kubernetes/components/common/middleware.yaml
+++ b/kubernetes/components/common/middleware.yaml
@@ -37,3 +37,36 @@ spec:
         namespace: network
       - name: internal-network
         namespace: network
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/traefik.io/middleware_v1alpha1.json
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+# A per-namespace alias for network/crowdsec-bouncer. Traefik resolves an
+# HTTPRoute's ExtensionRef middleware in the ROUTE's own namespace, with no way
+# to name another one -- so a route in `equestria` asking for `crowdsec-bouncer`
+# looks up `equestria/crowdsec-bouncer` and nothing else. Only `network` had the
+# object, so the reference failed:
+#
+#   middleware "equestria-crowdsec-bouncer@kubernetescrd" does not exist
+#
+# and Traefik dropped the whole router, serving 404 for whoami -- which is
+# exactly the loud, single-route breakage the filter in
+# apps/equestria/utils/whoami/helmrelease.yaml was placed there to produce.
+#
+# Deliberately a chain alias rather than a copy of the plugin config. That
+# config carries the `enabled: false` kill switch that
+# apps/network/traefik/middleware/crowdsec.yaml calls "the standing rollback for
+# every enforcement stage"; duplicating it into every namespace would turn that
+# one line into ~18 lines that must be flipped together, which is precisely the
+# property it exists to guarantee. The plugin config stays single-source in
+# `network` and this only forwards to it -- the same shape `local-user` and
+# `authenticated-user` above already use.
+metadata:
+  name: crowdsec-bouncer
+spec:
+  chain:
+    middlewares:
+      # Not self-referential: this object is `<ns>/crowdsec-bouncer`, the target
+      # is `network/crowdsec-bouncer`. Traefik keys middlewares by name@namespace.
+      - name: crowdsec-bouncer
+        namespace: network


### PR DESCRIPTION
## The bug

`Cluster: Equestria/Who am I?` has been **404 since it was added — 0/50 in Gatus, never once green**.

Traefik resolves an HTTPRoute's `ExtensionRef` middleware in the **route's own namespace**, with no way to name a different one. The whoami route lives in `equestria` and asks for `crowdsec-bouncer`, but that object exists only in `network`:

```
ERR middleware "equestria-crowdsec-bouncer@kubernetescrd" does not exist
    routerName=httproute-equestria-traefik-whoami-gw-network-internal-ep-websecure-...
```

Traefik then drops the **entire router** on both entrypoints, so the host 404s.

## What it was not

I chased auth first; all of it is healthy:

- Authentik has the provider — the outpost logs `Loaded application` for `whoami.equestria.driscoll.tech` (`equestria-traefik-whoami-e8df5ac`)
- `Service/traefik-whoami` has a healthy endpoint (`10.206.3.133:80`)
- The HTTPRoute reports `Accepted=True` / `ResolvedRefs=True`

Gateway API accepts the route; Traefik rejects it later, when it can't resolve the filter. That gap is why the status fields all look fine.

## This is the canary working

whoami's filter carries this comment:

> *"It is deliberately the first route to reference the middleware: the plugin validates its config … so if the bouncer key is missing or unreadable this ONE route breaks loudly and everything else is untouched."*

It did break loudly, on exactly one route, as designed. The signal just went unread — and the cause turned out to be a missing object rather than a bad key.

## The fix

Add a per-namespace alias to `components/common/middleware.yaml`, which every namespace already includes — the same mechanism that puts `authenticated-user` in **18** namespaces.

```yaml
metadata:
  name: crowdsec-bouncer
spec:
  chain:
    middlewares:
      - name: crowdsec-bouncer
        namespace: network
```

Not self-referential: this object is `<ns>/crowdsec-bouncer`, the target is `network/crowdsec-bouncer`, and Traefik keys middlewares by `name@namespace`.

**Deliberately an alias, not a copy of the plugin config.** That config holds the `enabled: false` kill switch which `crowdsec.yaml` calls *"the standing rollback for every enforcement stage"* — copying it per-namespace would turn that one line into ~18 that must be flipped together, defeating the exact property it exists to provide. The plugin config stays single-source in `network`; the alias only forwards, the same shape `local-user` and `authenticated-user` already use.

**No enforcement change.** The plugin is still `enabled: false` and passes every request through. This only makes the reference resolvable.

Also refreshed the now-stale comment in `apps/network/traefik/middleware/kustomization.yaml`, which still claimed "no HTTPRoute references it yet".

## Verification after merge

- [ ] `https://whoami.equestria.driscoll.tech` returns 200/302 instead of 404
- [ ] `Cluster: Equestria/Who am I?` goes green for the first time
- [ ] No `does not exist` middleware errors in traefik logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)