### PR TITLE
fix(longhorn): let Prometheus scrape manager metrics past the 1.12 NetworkPolicies

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/kustomization.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - ./helmrelease.yaml
 - ./definition.yaml
 - ./recurringjob.yaml
+- ./networkpolicy.yaml
 - ./rules
 configMapGenerator:
   - name: longhorn-config

--- a/kubernetes/apps/longhorn-system/longhorn/networkpolicy.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/networkpolicy.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master-standalone-strict/networkpolicy-networking-v1.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+# Restores Prometheus' ability to scrape Longhorn's metrics.
+#
+# Longhorn 1.12 turned its bundled NetworkPolicies on by default, and the chart's
+# `longhorn-manager` policy admits only same-namespace peers (longhorn-manager,
+# longhorn-ui, longhorn-csi-plugin, recurring-job pods). Prometheus runs in
+# `observability`, matches none of them, and a NetworkPolicy selecting a pod is
+# deny-by-default for everything it does not name -- so every scrape of
+# longhorn-backend:9500 started failing the moment the upgrade landed:
+#
+#   TargetDown: 100% of the longhorn-backend/longhorn-backend targets
+#               in longhorn-system namespace are down
+#
+# equestria began alerting at the exact minute 1.12.1 installed; SGC has been
+# alerting since its own 1.12.1 upgrade on 2026-08-14. Longhorn itself was never
+# unhealthy -- longhorn-manager still LISTENs on 9500 and the Service still has a
+# full set of endpoints. Only the scrape path was severed, which is the
+# unpleasant flavour of this bug: the storage-layer dashboards and alerts go
+# quiet while storage looks fine.
+#
+# Additive rather than `networkPolicies.enabled: false`. NetworkPolicies are
+# additive by design, so this grants exactly one port to exactly one namespace
+# and leaves the chart's isolation intact; disabling the chart flag would drop
+# every policy it ships to fix one scrape.
+metadata:
+  name: longhorn-manager-allow-prometheus
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # Matched on the immutable `kubernetes.io/metadata.name` label the
+        # apiserver maintains, not a hand-applied one that could drift.
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - protocol: TCP
+          port: 9500


### PR DESCRIPTION
## The bug

Longhorn 1.12 turned its bundled NetworkPolicies **on by default**. The chart's `longhorn-manager` policy admits only same-namespace peers:

```
podSelector: app=longhorn-manager
podSelector: app=longhorn-ui
podSelector: app=longhorn-csi-plugin
podSelector: recurring-job.longhorn.io (exists)
```

All `podSelector`, no `namespaceSelector` — so same-namespace only. Prometheus runs in `observability`, matches none of them, and a NetworkPolicy selecting a pod is deny-by-default for anything it doesn't name. Every scrape of `longhorn-backend:9500` broke the moment the upgrade landed:

```
TargetDown: 100% of the longhorn-backend/longhorn-backend targets
            in longhorn-system namespace are down
```

## Both clusters, and the timestamps prove it

| cluster | alerting since | why |
|---|---|---|
| equestria | `2026-08-16T00:35:35` | the exact minute 1.12.1 installed |
| sgc | `2026-08-14T03:44:11` | its own 1.12.1 upgrade |

I initially read equestria's as churn from the install I'd just run. It wasn't — SGC had been quietly alerting the same way for two days, and that's what identified the real cause.

## Longhorn was never unhealthy

This is the unpleasant flavour of the bug: storage-layer dashboards and alerts go quiet while storage itself is fine.

- `longhorn-manager` still `LISTEN`s on 9500 (`10.206.2.106:9500`, checked inside its netns)
- `Service/longhorn-backend` still has a full set of endpoints
- All **191 volumes healthy**, zero degraded

Verified by curling `10.206.0.139:9500/metrics` from a pod in another namespace: `HTTP 000` — blocked at the policy, not refused by the process.

## The fix

Additive, rather than `networkPolicies.enabled: false`. NetworkPolicies union, so this grants exactly one port to exactly one namespace and leaves the rest of the chart's isolation intact. Disabling the chart flag would drop every policy it ships in order to fix one scrape.

```yaml
podSelector:
  matchLabels: { app: longhorn-manager }
ingress:
  - from:
      - namespaceSelector:
          matchLabels: { kubernetes.io/metadata.name: observability }
        podSelector:
          matchLabels: { app.kubernetes.io/name: prometheus }
    ports:
      - { protocol: TCP, port: 9500 }
```

Matched on `kubernetes.io/metadata.name` — the immutable label the apiserver maintains — rather than a hand-applied one that could drift.

## Verification after merge

- [ ] `TargetDown` for `longhorn-backend` clears on equestria
- [ ] Longhorn panels in Grafana repopulate
- [ ] Scrape from an `observability` pod to `:9500/metrics` returns 200

## Follow-up

**SGC needs the same change in its own repo** — not included here. Its alert predates this one by two days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)