### PR TITLE
fix(alpha-site): authentik health check asserts 200, not 204

### DIFF
--- a/docker/alpha-site/authentik/definition.yaml
+++ b/docker/alpha-site/authentik/definition.yaml
@@ -41,8 +41,13 @@ spec:
     # load-bearing: every OIDC login and every outpost in the estate depends on a
     # single Pi on a single PoE switch (section 6, accepted), and "one alias did
     # not repoint" is a failure only a per-alias check can see.
+    #
+    # 200, not 204. Verified against the live server after deploy:
+    # /-/health/live/ and /-/health/ready/ both answer 200. The 204 this
+    # originally asserted was wrong, so the check could never pass — it sat red
+    # from the moment the stack came up while the endpoint itself was healthy.
     - url: https://authentik.${CLUSTER_DOMAIN}/-/health/live/
       method: GET
       interval: 1m
       conditions:
-        - "[STATUS] == 204"
+        - "[STATUS] == 200"


### PR DESCRIPTION
My bug, caught by watching the #836 deploy.

The Gatus check I wrote for the alpha-site authentik stack asserts `[STATUS] == 204` on `/-/health/live/`. Authentik answers **200** there. Verified against the live server now that it's deployed:

```
/-/health/live/        HTTP 200
/-/health/ready/       HTTP 200
```

So the check could never pass. `infrastructure_authentik-(alpha-site)` went red the moment the stack came up and stayed red across every interval, while the endpoint underneath it was healthy the whole time.

That's the worst shape for a monitoring bug: it trains you to ignore the one signal that becomes load-bearing at cutover, when this host starts answering for the estate's SSO.

One-line fix, with the verified codes recorded inline so the next person doesn't have to re-derive them.

## The rest of the deploy is green

- All three containers healthy — `authentik-server` took ~6 min to pass its first healthcheck, which is the empty-DB schema migration on a Pi (`start_period: 300s` was sized right)
- Let's Encrypt cert issued via DNS-01 **on the first attempt** — the split-horizon trap that bites this estate didn't fire; the pinned public resolvers in `_common/traefik/config.yaml` did their job
- Endpoint serves 200 on the health path and 302 on `/` (redirect into the login flow) through a valid chain
- **The three production vanity names are untouched** — `authentik`/`iris`/`canterlot.driscoll.tech` still resolve to SGC's gateway at `10.10.209.101`. The staging rename from #831 did exactly what it was for
- **No Gatus collision** — this endpoint registered as `infrastructure_authentik-(alpha-site)` alongside SGC's `applications_authentik`, which stayed green throughout. That was piece 27's estate-wide panic risk, avoided by the `(Alpha Site)` suffix
- Pi memory: 3478 MiB available with authentik up, comfortably better than the ~1.2–1.7 GiB the plan projected (single replica here vs. the two-replica measurement it was derived from)

🤖 Generated with [Claude Code](https://claude.com/claude-code)