### PR TITLE
feat(alpha-site): step 4 — authentik uses its own embedded outpost

### DIFF
--- a/docker/alpha-site/authentik-outpost/.ignore
+++ b/docker/alpha-site/authentik-outpost/.ignore
@@ -1,0 +1,18 @@
+# alpha-site does not run the authentik-outpost sidecar.
+#
+# This host runs authentik ITSELF, so the sidecar would be a second copy of the
+# proxy sitting beside the server that already contains one, holding an API token
+# minted over the network to reach a service on localhost. It uses the server's
+# built-in embedded outpost instead — see section 2.5 of
+# docs/cluster-consolidation/07-authentik-to-alpha-site.md, and the
+# useEmbeddedOutpost flag on this host's DockgeLxc in stacks/home/index.ts.
+#
+# getStackFiles skips a stack when EITHER docker/_common/<stack>/ or
+# docker/<host>/<stack>/ contains a .ignore, so this file suppresses the _common
+# stack on this host only. Every other Dockge host still gets it, and must — they
+# reach a REMOTE authentik and genuinely need the sidecar.
+#
+# Verified before landing (2026-08-16): nothing on this host routes through the
+# `authentik-outpost@docker` middleware. The Traefik dashboard stopped using it in
+# PR #806, and no other container on the host carries it in its labels — the
+# sidecar has been idle, logging only session-cleanup ticks.

--- a/docs/cluster-consolidation/07-authentik-to-alpha-site.md
+++ b/docs/cluster-consolidation/07-authentik-to-alpha-site.md
@@ -548,10 +548,33 @@ outpost-token minting (`components/DockgeLxc.ts:791`) for every other Dockge hos
 4. **Cut alpha-site over to the embedded outpost** (§2.5), before the DNS flip, so the host is
    already self-sufficient when it becomes the server: land the
    `docker/alpha-site/authentik-outpost/.ignore`, the `forwardAuth` address change, and the
-   `getOutpost` + `OutpostProviderAttachment` path; **preview first** and confirm the per-host
-   `Outpost` teardown moves its providers rather than orphaning them. Verify a `forwardAuth`-gated
-   route on alpha-site still authenticates *while SGC is still the server* — that isolates a
-   mistake in this step from a mistake in step 5.
+   `useEmbeddedOutpost` flag on this host's `DockgeLxc`.
+
+   **Two instructions this step used to carry do not survive contact with the live estate**
+   (verified 2026-08-16, before executing):
+
+   - *"Verify a `forwardAuth`-gated route on alpha-site still authenticates."* **There is no such
+     route.** Every container on the host was inspected: none carries the
+     `authentik-outpost@docker` middleware in its labels. The Traefik dashboard was the only
+     consumer and stopped being one when [#806](https://github.com/david-driscoll/home-operations/pull/806)
+     network-gated it. The sidecar has been idle, logging nothing but session-cleanup ticks.
+     `alloy` is the host's one proxy provider, and its route carries **no middleware at all**. So
+     this step's real blast radius is one registered-but-unrouted provider, and the gate as written
+     cannot be executed — do not invent a substitute that looks like it passed.
+   - *"Preview first."* `pulumi preview` is **not trustworthy on `stacks/home`**: it invents
+     phantom deletes (`StandardDns`, `TailnetKey`, `DeviceTags`) because `tailscale.ts` builds
+     resources inside `apply()` behind an `isDryRun` early return. A genuine one-resource change
+     would be indistinguishable from the noise. Judge this step from the **authentik API
+     afterwards** — the provider should end up attached to the embedded outpost — and from
+     `pulumi stack history`, not from preview output.
+
+   **Where the attachment actually lands, and why that is fine.** `createOutpost` talks to whatever
+   `AUTHENTIK_URL` points at, which at this point in the sequence is still **SGC**. So the
+   `OutpostProviderAttachment` this step creates is written into SGC's database, not into
+   alpha-site's restored copy. That is not a defect and needs no manual repair: step 6 repoints
+   `AUTHENTIK_URL` at alpha-site, and the `stacks/home` run in step 7's post-check then re-creates
+   the attachment against the new server. Worth knowing so the gap between steps 4 and 7 is not
+   mistaken for a failed step.
 5. **Repoint DNS/ingress** for `canterlot.driscoll.tech`, `iris.driscoll.tech`, and
    `authentik.driscoll.tech` from SGC to alpha-site's Dockge Traefik. **This is not a record
    edit** — all three are external-dns-published from the SGC `HTTPRoute` across three providers
@@ -835,10 +858,10 @@ re-bootstrap; you are back to the end of step 2. The only cost is the transfer.
    authentik alone (§2.2's footprint math holds), but worth resolving if this shared-Postgres
    pattern gets a second consumer on alpha-site.
    pattern gets a second consumer on alpha-site.
-6. **The embedded outpost's exact name is unverified** (§2.5). `getOutpost` matches on `name`;
-   authentik's built-in is conventionally `authentik Embedded Outpost`, but nothing in this repo
-   asserts that string. Read it off the live server before writing the lookup, or the data source
-   fails at apply time with a confusing error.
+6. ~~**The embedded outpost's exact name is unverified**~~ — **resolved 2026-08-16.** Read off the
+   live server via `/api/v3/outposts/instances/`: it is exactly `authentik Embedded Outpost`, which
+   is the default already coded into `DockgeLxc`. No `embeddedOutpostName` override is needed. It
+   carried 0 providers at the time of checking, as expected.
 7. **Whether any *other* Dockge host should follow alpha-site's pattern.** No, by construction —
    §2.5 applies only where authentik is local, and alpha-site is the only such host. Recorded so
    the `.ignore` is not later read as a general recommendation.

--- a/stacks/home/index.ts
+++ b/stacks/home/index.ts
@@ -1,6 +1,6 @@
 import type { AuthentikOutputs } from "@components/authentik.ts";
-import { baoKvSecret, baoProvenance } from "@components/bao.ts";
 import { BackupPlanDirector } from "@components/BackupPlanDirector.ts";
+import { baoKvSecret, baoProvenance } from "@components/bao.ts";
 import { Tailscale } from "@components/constants.ts";
 import { awaitOutput } from "@components/helpers.ts";
 import type { CredentialDefinition, PasswordDefinition, SshKeyDefinition } from "@components/store/index.ts";
@@ -10,8 +10,8 @@ import * as minio from "@pulumi/minio";
 import * as pulumi from "@pulumi/pulumi";
 import { DockgeLxc, getDockageProperties } from "../../components/DockgeLxc.ts";
 import { GlobalResources } from "../../components/globals.ts";
-import { OpenBaoOidc } from "../../components/openbao/oidc.ts";
 import { OpenBaoClusterAuth } from "../../components/openbao/clusterAuth.ts";
+import { OpenBaoOidc } from "../../components/openbao/oidc.ts";
 import { ProxmoxBackupServerLxc } from "../../components/ProxmoxBackupServerLxc.ts";
 import { getProxmoxProperties, ProxmoxHost } from "../../components/ProxmoxHost.ts";
 import { createGatusDnsUptime } from "../../components/StandardDns.ts";
@@ -192,7 +192,9 @@ if (globals.baoDualWriteEnabled) {
     { provider: globals.baoProvider },
   );
 } else {
-  pulumi.log.warn("No OpenBao credentials (BAO_TOKEN, or BAO_ROLE_ID + BAO_SECRET_ID) — skipping the OpenBao dual-write for Thanos S3 Storage. The shared/thanos-s3-storage path its ExternalSecrets read stays frozen until a credentialed run.");
+  pulumi.log.warn(
+    "No OpenBao credentials (BAO_TOKEN, or BAO_ROLE_ID + BAO_SECRET_ID) — skipping the OpenBao dual-write for Thanos S3 Storage. The shared/thanos-s3-storage path its ExternalSecrets read stays frozen until a credentialed run.",
+  );
 }
 
 const celestiaHost = new ProxmoxHost("celestia", {
@@ -258,6 +260,19 @@ const alphaSiteDockgeRuntime = new DockgeLxc("alpha-site-dockge", {
   sftpKey: sftpClientKey,
   legacyTun: true, // jiangcuo ARM64 Proxmox port stubs out mknod; dev2 passthrough is unusable
   monitor,
+  // This host runs authentik itself, so it uses the server's embedded outpost
+  // rather than the authentik-outpost sidecar, which is suppressed by
+  // docker/alpha-site/authentik-outpost/.ignore. Step 4 of section 4 in
+  // docs/cluster-consolidation/07-authentik-to-alpha-site.md.
+  //
+  // No embeddedOutpostName: the live server calls it exactly "authentik Embedded
+  // Outpost", the default in DockgeLxc — checked against the API rather than
+  // assumed, which closes open question 6 in that document.
+  useEmbeddedOutpost: true,
+  // The forwardAuth target moves from the sidecar's service name to the authentik
+  // server container on this host. Inert today — nothing here routes through that
+  // middleware — but it has to be right before this host answers for SSO.
+  authentikForwardAuthHost: "authentik-server",
 });
 
 const celestiaPbs = new ProxmoxBackupServerLxc("celestia-pbs", {


### PR DESCRIPTION
§4 step 4. Suppresses the `authentik-outpost` sidecar on alpha-site and points that host at the embedded outpost of the authentik it now runs itself, using the `useEmbeddedOutpost` / `authentikForwardAuthHost` args landed inert in #807.

## Two of the plan's own instructions for this step don't survive contact with the estate

I checked before executing, and corrected the plan rather than working around it quietly.

**"Verify a `forwardAuth`-gated route on alpha-site still authenticates."** — **There is no such route.** Every container on the host was inspected; none carries `authentik-outpost@docker` in its labels. The Traefik dashboard was the only consumer and stopped being one in #806. The sidecar has been idle, logging nothing but session-cleanup ticks:

```
{"event":"Starting session cleanup","logger":"authentik.outpost.proxyv2.filesystemstore", ...}
```

`alloy` is the host's single proxy provider (`alpha-site-alloy-29f650d`, on outpost `alpha-site-eeced1f`) and **its route carries no middleware at all**. So this step's real blast radius is one registered-but-unrouted provider. The gate as written can't be executed, and the plan now says that plainly rather than inviting a substitute check that merely looks like it passed.

**"Preview first."** — `pulumi preview` isn't trustworthy on `stacks/home`: it invents phantom deletes (`StandardDns`, `TailnetKey`, `DeviceTags`) because `tailscale.ts` builds resources inside `apply()` behind an `isDryRun` early return. A genuine one-resource change would be indistinguishable from that noise. The plan now directs you to judge this from the **authentik API afterwards** and from `pulumi stack history`.

## Open question 6, closed

The embedded outpost is named exactly **`authentik Embedded Outpost`** — read from `/api/v3/outposts/instances/`, not assumed. That's already `DockgeLxc`'s default, so no `embeddedOutpostName` override is needed. It carried 0 providers, as expected.

## Where the attachment lands — recorded so a gap isn't mistaken for a failure

`createOutpost` talks to whatever `AUTHENTIK_URL` points at, which at this point is still **SGC**. So the `OutpostProviderAttachment` this creates is written into SGC's database, not alpha-site's restored copy. That's not a defect and needs no manual repair: step 6 repoints the URL, and step 7's `stacks/home` run re-creates it against the new server.

## After merge, verify from the API rather than preview

The `alpha-site-alloy` provider should move off `alpha-site-eeced1f` and onto the embedded outpost, and the per-host `Outpost` should disappear. Since the provider is unrouted, a brief window with it unattached is harmless.

## Note

The `hk` pre-commit hook auto-fixed two pre-existing biome issues in `stacks/home/index.ts` (import ordering and one `pulumi.log.warn` wrap) that are unrelated to this change. Left in rather than fought, since they're the repo's own linter enforcing its own rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)