### PR TITLE
feat(alpha-site): step 5 — authentik claims the estate's SSO names

### DIFF
--- a/docker/alpha-site/authentik/compose.yaml
+++ b/docker/alpha-site/authentik/compose.yaml
@@ -117,16 +117,33 @@ services:
       #
       # Issuer URLs do not change in this migration; only what answers behind
       # them does, which is why no app's OIDC config is touched.
-      traefik.http.routers.authentik.rule: Host(`authentik.${CLUSTER_DOMAIN}`)
+      # CUTOVER (step 5). These three are the estate's SSO names, released by
+      # stargate-command-cluster#1831 and confirmed retracted from cloudflare,
+      # technitium and unifi before this landed. Every cluster's outposts and
+      # Dockge hosts know authentik by one of them:
+      #   canterlot -> equestria, celestia, luna, skystar
+      #   iris      -> sgc, alpha-site
+      #   authentik -> the chart default, and AUTHENTIK_URL for every Pulumi stack
+      # Issuer URLs do not change; only what answers behind them does.
+      #
+      # authentik.${CLUSTER_DOMAIN} stays alongside them, so this host keeps a
+      # name of its own that is independent of the vanity set.
+      traefik.http.routers.authentik.rule: Host(`authentik.${searchDomain}`) || Host(`iris.${searchDomain}`) || Host(`canterlot.${searchDomain}`) || Host(`authentik.${CLUSTER_DOMAIN}`)
       traefik.http.routers.authentik.entrypoints: websecure
       traefik.http.routers.authentik.tls.certresolver: le
       traefik.http.routers.authentik.service: authentik
 
-      # authentik-as, NOT authentik: `svc:authentik` already exists on the tailnet
-      # (and DockgeLxc:700 hands remote hosts `authentik.<tailnet>` as their
-      # CLUSTER_AUTHENTIK_DOMAIN). Claiming it here would both collide on the
-      # service name and silently repoint every remote Dockge host's outpost at
-      # this empty instance.
+      # STILL authentik-as, deliberately, even at cutover. `svc:authentik` on the
+      # tailnet is a SEPARATE name from the three public ones this step moves, and
+      # it is still owned by SGC. Claiming it here would collide on the service
+      # name — the failure mode that produces a Terminating service and a stuck
+      # finalizer in this estate.
+      #
+      # It does still need to move: DockgeLxc:700 hands `remote: true` hosts
+      # `authentik.<tailnet>` as their CLUSTER_AUTHENTIK_DOMAIN, and
+      # stacks/ocracoke is such a host — so its outpost keeps pointing at SGC
+      # until that name migrates. That is its own release-then-claim pair, on the
+      # same pattern as this one, and it must happen before SGC is scaled to zero.
       traefik.http.routers.authentik-tailscale.rule: Host(`authentik-as.${tailscaleDomain}`)
       traefik.http.routers.authentik-tailscale.entrypoints: tailscale
       traefik.http.routers.authentik-tailscale.service: authentik
@@ -175,8 +192,10 @@ services:
 
 x-dockge:
   urls:
+    - https://authentik.${searchDomain}
+    - https://iris.${searchDomain}
+    - https://canterlot.${searchDomain}
     - https://authentik.${CLUSTER_DOMAIN}
-    - https://authentik-as.${tailscaleDomain}
 
 networks:
   dockge_default:

--- a/docker/alpha-site/authentik/definition.yaml
+++ b/docker/alpha-site/authentik/definition.yaml
@@ -17,9 +17,8 @@ spec:
   name: Authentik (Alpha Site)
   category: Infrastructure
   description: Authentik is an open-source identity provider focused on flexibility and security.
-  # Staging hostname — see compose.yaml's router comment for why this is not the
-  # production vanity alias. Flipped at cutover.
-  url: &url https://authentik.${CLUSTER_DOMAIN}
+  # The estate's primary SSO name — this host answers for it as of the cutover.
+  url: &url https://authentik.${searchDomain}
   icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/authentik.svg
   # NO `authentik:` block, and there never will be one. Authentik cannot be an
   # OAuth client of itself, and this host serves its own forwardAuth from the
@@ -42,12 +41,35 @@ spec:
     # single Pi on a single PoE switch (section 6, accepted), and "one alias did
     # not repoint" is a failure only a per-alias check can see.
     #
-    # 200, not 204. Verified against the live server after deploy:
-    # /-/health/live/ and /-/health/ready/ both answer 200. The 204 this
-    # originally asserted was wrong, so the check could never pass — it sat red
-    # from the moment the stack came up while the endpoint itself was healthy.
-    - url: https://authentik.${CLUSTER_DOMAIN}/-/health/live/
+    # 200, not 204. Verified against the live server: /-/health/live/ and
+    # /-/health/ready/ both answer 200. The 204 originally asserted here could
+    # never pass, and sat red while the endpoint was healthy.
+    - url: https://authentik.${searchDomain}/-/health/live/
       method: GET
       interval: 1m
+      conditions:
+        - "[STATUS] == 200"
+    # The two aliases now get their own checks, which they could not have while
+    # they still resolved to SGC — a check against them would have reported green
+    # for a server this stack had nothing to do with, and gone on passing straight
+    # through a failed cutover. They are load-bearing from here: every OIDC login
+    # and every outpost in the estate reaches this host by one of these three
+    # names, and "one alias did not repoint" is a failure only a per-alias check
+    # can see.
+    - url: https://canterlot.${searchDomain}/-/health/live/
+      method: GET
+      interval: 5m
+      conditions:
+        - "[STATUS] == 200"
+    - url: https://iris.${searchDomain}/-/health/live/
+      method: GET
+      interval: 5m
+      conditions:
+        - "[STATUS] == 200"
+    # Independent of the vanity set, so a DNS problem with those names is
+    # distinguishable from the server itself being down.
+    - url: https://authentik.${CLUSTER_DOMAIN}/-/health/live/
+      method: GET
+      interval: 5m
       conditions:
         - "[STATUS] == 200"

--- a/docs/cluster-consolidation/07-authentik-to-alpha-site.md
+++ b/docs/cluster-consolidation/07-authentik-to-alpha-site.md
@@ -515,9 +515,16 @@ AUTHENTIK_TOKEN = "ref+openbao://secrets/clusters/alpha-site/apps/authentik/toke
 AUTHENTIK_URL   = "ref+openbao://secrets/clusters/alpha-site/apps/authentik/token#/url"
 ```
 
+> **Superseded 2026-08-16 — see §4 step 6.** The section below describes this as a secret-value
+> update. It is not: `AUTHENTIK_URL` is `https://authentik.driscoll.tech`, one of the three vanity
+> names step 5 moves, so the DNS flip repoints every consumer on its own. The token is identical on
+> both sides because alpha-site's database is a restore of SGC's. No OpenBao edit is required —
+> only confirmation from inside equestria. The text below is kept for the consumer list, which is
+> still correct.
+
 These are Pulumi *provider* inputs for `stacks/authentik`, which manages authentik's objects via
 `@pulumi/authentik` — it does not deploy authentik itself. No code change is needed here; the
-repoint is a **secret-value update**: after alpha-site's authentik is up and has a fresh API
+repoint was expected to be a **secret-value update**: after alpha-site's authentik is up and has a fresh API
 token, update the `url` and `credential` fields of the `secrets/clusters/alpha-site/apps/authentik/token` OpenBao
 secret. Every consumer (`stacks/authentik`, `components/DockgeLxc.ts:774`'s outpost-token
 minting, `stacks/applications/kubernetes.ts`) reads from that one place.
@@ -573,8 +580,22 @@ outpost-token minting (`components/DockgeLxc.ts:791`) for every other Dockge hos
    `ApplicationDefinition` is gone**, since until then the distinct name is what keeps Gatus from
    panicking on a duplicate `(name, group)` and taking estate-wide monitoring down with it
    ([27](27-migration-churn-failure-modes.md)).
-6. **Repoint `AUTHENTIK_URL`/`AUTHENTIK_TOKEN`** in OpenBao (§3.5), then confirm reachability
-   **from a pod in equestria**, not from a workstation — `stacks/authentik` reconciles in-cluster.
+6. **`AUTHENTIK_URL`/`AUTHENTIK_TOKEN` — verified 2026-08-16 to need no change at all.** §3.5
+   described this as a secret-value update. It is not, because
+   `AUTHENTIK_URL = https://authentik.driscoll.tech` — **a vanity name, one of the three step 5
+   moves.** So the DNS flip *is* the Pulumi repoint: every consumer follows DNS with no secret
+   edit. And `AUTHENTIK_TOKEN` needs no change either, because alpha-site's database is a restore
+   of SGC's and carries the identical token (checked by comparing the two OpenBao values without
+   printing them). What remains here is confirmation, not action: check reachability **from a pod
+   in equestria**, not from a workstation, since `stacks/authentik` reconciles in-cluster.
+
+   **The tailnet name is a THIRD family and does not move with the other two.** `DockgeLxc.ts:700`
+   hands `remote: true` hosts `authentik.${tailscaleDomain}` — not a public vanity name — as their
+   `CLUSTER_AUTHENTIK_DOMAIN`. `stacks/ocracoke` is such a host. That name is the tailscale service
+   `svc:authentik`, still owned by SGC, and it needs its own release-then-claim pair on the same
+   pattern as step 5. Claiming it early collides on the service name, which in this estate produces
+   a `Terminating` service and a stuck finalizer. **It must migrate before SGC is scaled to zero in
+   step 9**, or ocracoke's outpost is left pointing at a dead server.
 7. **Post-check:** every outpost re-registers and reports healthy against the new server
    (`authentik-remote-cluster` on both equestria and sgc, plus every Dockge-hosted sidecar
    outpost); `forwardAuth`-gated apps still authenticate; a full login round-trip on at least one


### PR DESCRIPTION
**Claim half of the cutover. Merge only AFTER [stargate-command-cluster#1831](https://github.com/david-driscoll/stargate-command-cluster/pull/1831) has landed and its three names have been observed to retract from all three external-dns providers.**

`authentik`/`iris`/`canterlot.${searchDomain}` now route to alpha-site, joined by `authentik.${CLUSTER_DOMAIN}` so the host keeps a name independent of the vanity set — which is what makes "DNS problem with those three" distinguishable from "the server is down".

The two alias gatus checks arrive with them. They couldn't exist earlier: while the aliases resolved to SGC, a check against them would have reported green for a server this stack had nothing to do with, and gone on passing straight through a failed cutover.

## `spec.name` deliberately keeps its `(Alpha Site)` suffix

SGC's `ApplicationDefinition` still exists and still publishes gatus entries. Gatus **panics** on a duplicate `(name, group)` rather than skipping it, taking estate-wide monitoring down — as it did on 2026-08-13. The suffix comes off when SGC's definition goes, not here.

## Two corrections to the plan, both verified rather than reasoned

**Step 6 / §3.5 said the `AUTHENTIK_URL` repoint is a secret-value update. It isn't.** `AUTHENTIK_URL` is `https://authentik.driscoll.tech` — *one of the three names step 5 moves*. So **the DNS flip is itself the Pulumi repoint**; every consumer follows DNS with no OpenBao edit. `AUTHENTIK_TOKEN` needs no change either, since alpha-site's database is a restore of SGC's and carries the identical token (compared without printing either value). What remains is confirmation from inside equestria, not action.

**The tailnet name is a third family that does not move with the other two.** `DockgeLxc.ts:700` hands `remote: true` hosts `authentik.${tailscaleDomain}` — not a public vanity name — as their `CLUSTER_AUTHENTIK_DOMAIN`, and `stacks/ocracoke` is such a host. That name is the tailscale service `svc:authentik`, still owned by SGC, and it needs its own release-then-claim pair on this same pattern. Claiming it early collides on the service name, which in this estate produces a `Terminating` service and a stuck finalizer. **It must migrate before SGC is scaled to zero in step 9**, or ocracoke's outpost is left pointing at a dead server. This PR deliberately keeps `authentik-as.${tailscaleDomain}`.

## The flip sequence

1. Fresh dump/restore (repeat of step 3, ~9 min) so the copy is current at the moment of the flip
2. Merge stargate-command-cluster#1831
3. **Confirm retraction across cloudflare, technitium and unifi** — not one resolver's view
4. Merge this
5. `stacks/home` run — Pulumi now targets alpha-site by DNS
6. Post-checks: every outpost re-registers, login round-trip per outpost type

I'll drive 1, 3, 5 and 6 and stop at the first gate that fails.

## Rollback

Restore the three `hostnames` lines in SGC's HTTPRoute and revert this. SGC's database, PVC and CNPG role are untouched throughout. The deadline is database divergence: after the flip, every login and object write lands on alpha-site alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)