### PR TITLE
docs(openbao): correct the documented ESO policy scope

### DIFF
--- a/components/openbao/clusterAuth.ts
+++ b/components/openbao/clusterAuth.ts
@@ -34,7 +34,14 @@
  *      `bootstrap/openbao/equestria-init.sh` write_policies().
  *   2. An `eso-<clusterKey>` policy. Those are already written for every
  *      cluster by the same script, granting read on `secrets/shared/*` plus
- *      `secrets/clusters/<key>/*`.
+ *      `secrets/clusters/*` — every cluster subtree, not just this cluster's.
+ *      It was once scoped to `secrets/clusters/<key>/*`, which only works
+ *      while a secret's readers all run on the cluster it is filed under.
+ *      They do not: alpha-site is a Dockge host, so no `eso-alpha-site` role
+ *      exists to grant, yet `clusters/alpha-site/apps/authentik/token` is read
+ *      by two workloads on equestria. Under the old scope those got a 403 and
+ *      blocked 15 Kustomizations behind `pulumi-secrets`. Still read-only;
+ *      `secrets/shared/*` is still where genuinely estate-wide values belong.
  *
  * REACHABILITY IS A PRECONDITION, not an assumption. OpenBao dials the API
  * server on every login, so the cluster running OpenBao must be able to reach
@@ -65,8 +72,10 @@ export interface OpenBaoClusterAuthArgs {
   globals: GlobalResources;
   /**
    * The cluster's `CLUSTER_KEY` (`equestria`, `sgc`, …). Drives the derived
-   * mount path and policy name, and must match the `secrets/clusters/<key>/`
-   * subtree the `eso-<key>` policy grants.
+   * mount path and policy name, and names the `secrets/clusters/<key>/`
+   * subtree this cluster's own secrets are filed under. Since the widening to
+   * `secrets/clusters/*` it no longer bounds what `eso-<key>` can READ — it is
+   * a filing convention now, not a permission boundary.
    */
   clusterKey: string;
   /**


### PR DESCRIPTION
Companion to [vault#197](https://github.com/david-driscoll/vault/pull/197). Comments only, no behaviour change.

The header block in `clusterAuth.ts` says `eso-<clusterKey>` grants `secrets/shared/*` plus `secrets/clusters/<key>/*`. That stops being true once vault#197 widens both ESO policies to `secrets/clusters/*`.

Worth recording *why*, because the narrower scope reads like the more careful choice and someone will otherwise try to restore it: it only holds while a secret's readers all run on the cluster it's filed under, and they don't. **alpha-site is a Dockge host**, so `for cluster in equestria sgc` never mints an `eso-alpha-site` role and nothing can ever be granted `clusters/alpha-site/*` — yet `clusters/alpha-site/apps/authentik/token` is read by two workloads on equestria (`pulumi/authentik-secret` and `equestria/dynacat-env`). Under the old scope both got a 403 and blocked 15 Kustomizations behind `pulumi-secrets`.

Also corrects the `clusterKey` field doc, which claimed the key "must match the `secrets/clusters/<key>/` subtree the `eso-<key>` policy grants". It no longer bounds reads at all — it's a filing convention now, not a permission boundary. Leaving that as-is would have been the more misleading half, since it reads as an invariant you can rely on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)