### PR TITLE
fix(traefik): stop crowdsec-bouncer aliasing itself in the network namespace

### DIFF
--- a/kubernetes/apps/network/traefik/middleware/crowdsec.yaml
+++ b/kubernetes/apps/network/traefik/middleware/crowdsec.yaml
@@ -3,7 +3,21 @@
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: crowdsec-bouncer
+  # NOT `crowdsec-bouncer`. components/common/middleware.yaml defines a
+  # per-namespace alias of that name, and `network` includes components/common
+  # like every other namespace -- so both manifests targeted
+  # network/crowdsec-bouncer, the alias won, and this plugin config was
+  # overwritten in-cluster by a chain pointing at itself:
+  #
+  #   recursion detected in middleware:
+  #     equestria-crowdsec-bouncer -> network-crowdsec-bouncer
+  #                                -> network-crowdsec-bouncer
+  #
+  # Traefik then dropped every router carrying the filter. Distinct names keep
+  # the alias and the implementation from colliding in the one namespace that
+  # holds both. Routes still reference `crowdsec-bouncer` (the alias); only
+  # this object is renamed.
+  name: crowdsec-bouncer-plugin
 spec:
   plugin:
     # This key MUST match the key under `experimental.plugins` in

--- a/kubernetes/components/common/middleware.yaml
+++ b/kubernetes/components/common/middleware.yaml
@@ -61,12 +61,24 @@ kind: Middleware
 # property it exists to guarantee. The plugin config stays single-source in
 # `network` and this only forwards to it -- the same shape `local-user` and
 # `authenticated-user` above already use.
+#
+# The target is `crowdsec-bouncer-PLUGIN`, and the distinct name is load-bearing.
+# This component is applied to EVERY namespace, `network` included, so an alias
+# named the same as its target collides there: both manifests write
+# network/crowdsec-bouncer, the alias wins, and the plugin config is replaced
+# in-cluster by a chain pointing at itself --
+#
+#   recursion detected in middleware:
+#     equestria-crowdsec-bouncer -> network-crowdsec-bouncer
+#                                -> network-crowdsec-bouncer
+#
+# -- after which Traefik drops every router carrying the filter. The chain
+# entries above get away with a bare `namespace: network` only because no
+# namespace defines an `error-pages`/`outpost`/`internal-network` of its own.
 metadata:
   name: crowdsec-bouncer
 spec:
   chain:
     middlewares:
-      # Not self-referential: this object is `<ns>/crowdsec-bouncer`, the target
-      # is `network/crowdsec-bouncer`. Traefik keys middlewares by name@namespace.
-      - name: crowdsec-bouncer
+      - name: crowdsec-bouncer-plugin
         namespace: network


### PR DESCRIPTION
> **Regression from #848 — mine. Worth merging promptly:** the live plugin config, including the `enabled: false` kill switch, is currently overwritten in-cluster.

## What broke

#848 added a per-namespace `crowdsec-bouncer` alias to `components/common/middleware.yaml`. My comment on it asserted:

> *Not self-referential: this object is `<ns>/crowdsec-bouncer`, the target is `network/crowdsec-bouncer`.*

True for every namespace except the one that matters. `components/common` is applied to **every** namespace, and [`apps/network/kustomization.yaml:8`](kubernetes/apps/network/kustomization.yaml) includes it like the rest — so in `network`, both manifests wrote the same object. The alias won:

```console
$ kubectl get middleware crowdsec-bouncer -n network -o jsonpath='{.spec}'
{"chain":{"middlewares":[{"name":"crowdsec-bouncer","namespace":"network"}]}}
```

The plugin config was replaced by a chain pointing at itself. Traefik refused it:

```
ERR could not instantiate middleware network-crowdsec-bouncer@kubernetescrd:
    recursion detected in middleware:
      equestria-crowdsec-bouncer -> network-crowdsec-bouncer
                                 -> network-crowdsec-bouncer
```

…and dropped every router carrying the filter, on both entrypoints. whoami went green at `03:34:21`, then back to 404 at ~03:40 when the component reconciled into `network`. Gatus shows the round trip: 38/50.

## The fix

Rename the implementation to `crowdsec-bouncer-plugin` and point the alias at it, so alias and target no longer collide in the one namespace that holds both.

- `network/crowdsec-bouncer-plugin` → the plugin config (single source, kill switch intact)
- `<ns>/crowdsec-bouncer` → chain to `crowdsec-bouncer-plugin@network`
- `network/crowdsec-bouncer` → the alias, now pointing at a *different* object. No recursion.

**Routes are untouched** — they still reference `crowdsec-bouncer`, which is the alias.

## Why the sibling chains didn't hit this

`local-user` and `authenticated-user` chain to `error-pages`/`outpost`/`internal-network` with a bare `namespace: network` and are fine — but only because no namespace defines objects with *those* names. That's a property of the names, not a pattern that generalises. I've noted it in both files so the next alias isn't written the same way.

## Verification

- `kubectl kustomize kubernetes/apps/network/traefik/middleware` → renders `crowdsec-bouncer-plugin` with `spec.plugin` intact
- Alias resolves to `[{name: crowdsec-bouncer-plugin, namespace: network}]`
- No remaining same-name definitions across both files

After merge: whoami returns 200/302 and stays there, and the `recursion detected` errors stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)