### PR TITLE
fix(pulumi): pin pulumi-nodejs back to 3.254.0 — 3.257.0 cannot write state

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -199,7 +199,7 @@
       },
     },
     {
-      description: "Sppostgegel Group",
+      description: "Spegel Group",
       groupName: "Spegel",
       matchDatasources: [
         "docker"

--- a/kubernetes/apps/pulumi/applications/equestria.yaml
+++ b/kubernetes/apps/pulumi/applications/equestria.yaml
@@ -106,7 +106,7 @@ spec:
   workspaceTemplate:
     spec:
       # renovate: datasource=docker depName=ghcr.io/pulumi/pulumi-nodejs
-      image: ghcr.io/pulumi/pulumi-nodejs:3.257.0
+      image: ghcr.io/pulumi/pulumi-nodejs:3.254.0
       env:
         - name: GITHUB_TOKEN
           valueFrom:

--- a/kubernetes/apps/pulumi/applications/sgc.yaml
+++ b/kubernetes/apps/pulumi/applications/sgc.yaml
@@ -106,7 +106,7 @@ spec:
   workspaceTemplate:
     spec:
       # renovate: datasource=docker depName=ghcr.io/pulumi/pulumi-nodejs
-      image: ghcr.io/pulumi/pulumi-nodejs:3.257.0
+      image: ghcr.io/pulumi/pulumi-nodejs:3.254.0
       env:
         - name: GITHUB_TOKEN
           valueFrom:

--- a/kubernetes/apps/pulumi/authentik/stack.yaml
+++ b/kubernetes/apps/pulumi/authentik/stack.yaml
@@ -107,7 +107,7 @@ spec:
   workspaceTemplate:
     spec:
       # renovate: datasource=docker depName=ghcr.io/pulumi/pulumi-nodejs
-      image: ghcr.io/pulumi/pulumi-nodejs:3.257.0
+      image: ghcr.io/pulumi/pulumi-nodejs:3.254.0
       env:
         - name: GITHUB_TOKEN
           valueFrom:

--- a/kubernetes/apps/pulumi/backups/stack.yaml
+++ b/kubernetes/apps/pulumi/backups/stack.yaml
@@ -107,7 +107,7 @@ spec:
   workspaceTemplate:
     spec:
       # renovate: datasource=docker depName=ghcr.io/pulumi/pulumi-nodejs
-      image: ghcr.io/pulumi/pulumi-nodejs:3.257.0
+      image: ghcr.io/pulumi/pulumi-nodejs:3.254.0
       env:
         - name: GITHUB_TOKEN
           valueFrom:

--- a/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
+++ b/kubernetes/apps/pulumi/gulf-of-mexico/stack.yaml
@@ -107,7 +107,7 @@ spec:
   workspaceTemplate:
     spec:
       # renovate: datasource=docker depName=ghcr.io/pulumi/pulumi-nodejs
-      image: ghcr.io/pulumi/pulumi-nodejs:3.257.0
+      image: ghcr.io/pulumi/pulumi-nodejs:3.254.0
       env:
         - name: GITHUB_TOKEN
           valueFrom:

--- a/kubernetes/apps/pulumi/home-operations/stack.yaml
+++ b/kubernetes/apps/pulumi/home-operations/stack.yaml
@@ -108,7 +108,7 @@ spec:
   workspaceTemplate:
     spec:
       # renovate: datasource=docker depName=ghcr.io/pulumi/pulumi-nodejs
-      image: ghcr.io/pulumi/pulumi-nodejs:3.257.0
+      image: ghcr.io/pulumi/pulumi-nodejs:3.254.0
       env:
         - name: GITHUB_TOKEN
           valueFrom:

--- a/kubernetes/apps/pulumi/ocracoke/stack.yaml
+++ b/kubernetes/apps/pulumi/ocracoke/stack.yaml
@@ -107,7 +107,7 @@ spec:
   workspaceTemplate:
     spec:
       # renovate: datasource=docker depName=ghcr.io/pulumi/pulumi-nodejs
-      image: ghcr.io/pulumi/pulumi-nodejs:3.257.0
+      image: ghcr.io/pulumi/pulumi-nodejs:3.254.0
       env:
         - name: GITHUB_TOKEN
           valueFrom:

--- a/kubernetes/apps/pulumi/system/stack.yaml
+++ b/kubernetes/apps/pulumi/system/stack.yaml
@@ -102,7 +102,7 @@ spec:
   workspaceTemplate:
     spec:
       # renovate: datasource=docker depName=ghcr.io/pulumi/pulumi-nodejs
-      image: ghcr.io/pulumi/pulumi-nodejs:3.257.0
+      image: ghcr.io/pulumi/pulumi-nodejs:3.254.0
       env:
         - name: GITHUB_TOKEN
           valueFrom:

--- a/kubernetes/apps/pulumi/unifi-network/stack.yaml
+++ b/kubernetes/apps/pulumi/unifi-network/stack.yaml
@@ -106,7 +106,7 @@ spec:
   workspaceTemplate:
     spec:
       # renovate: datasource=docker depName=ghcr.io/pulumi/pulumi-nodejs
-      image: ghcr.io/pulumi/pulumi-nodejs:3.257.0
+      image: ghcr.io/pulumi/pulumi-nodejs:3.254.0
       env:
         - name: GITHUB_TOKEN
           valueFrom:

--- a/kubernetes/apps/pulumi/vault/stack.yaml
+++ b/kubernetes/apps/pulumi/vault/stack.yaml
@@ -108,7 +108,7 @@ spec:
   workspaceTemplate:
     spec:
       # renovate: datasource=docker depName=ghcr.io/pulumi/pulumi-nodejs
-      image: ghcr.io/pulumi/pulumi-nodejs:3.257.0
+      image: ghcr.io/pulumi/pulumi-nodejs:3.254.0
       env:
         - name: GITHUB_TOKEN
           valueFrom:


### PR DESCRIPTION
**Unblocks every Pulumi stack in the estate.** All of `system`, `backups`, `equestria`, `sgc`, `unifi-network`, `authentik` and `home-operations` are failing with:

```
operation error S3: PutObject ... StatusCode: 400
api error InvalidArgument: Invalid checksum provided
```

Nothing can be applied. This is also what stranded the authentik cutover mid-flight, with the SSO names released from SGC and not yet claimed by alpha-site.

## Cause established by experiment, not inference

Same `pulumi stack init`, from an identical throwaway pod in the `pulumi` namespace — same credentials, endpoint, region, path-style setting and backend URL. **Only the image changed:**

| image | result |
|---|---|
| `pulumi-nodejs:3.257.0` | `InvalidArgument: Invalid checksum provided` |
| `pulumi-nodejs:3.254.0` | `Created stack 'oldprobe'` ✓ |

So this reverts #794 across all ten pinned files.

## What was ruled out along the way

- **Not the server.** Minio is `RELEASE.2025-09-07T16-13-09Z` — new enough for modern checksums — and healthy.
- **Not the credentials or bucket.** The workspace Secret holds the same values as the OpenBao item a workstation uses (compared without printing them).
- **Not object size.** The failing write is a lock file of a few hundred bytes; a real 52 KB state imported fine from a workstation.
- **Not `AWS_REQUEST_CHECKSUM_CALCULATION=when_required`.** Tested in-cluster on 3.257.0 — failed identically. The usual SDK mitigation does not apply.
- **Not any commit in this repo.** Stacks last succeeded at *different* commits and now all fail at the same one — the signature of an environmental change, not a code change. In particular this is not the authentik migration, which only touched program content; the failure is in the engine's state write and happens before any program runs.

## The loose end this does not close

The identical 3.257.0 write **succeeds from a workstation** against the same Minio with the same credentials. So it's 3.257.0 *combined with something about the in-cluster path*, not 3.257.0 alone. Pinning back restores service; it doesn't explain that, and the real fix still wants finding before the pin can be lifted.

Per your call, no Renovate guard — so a future bump will re-break this unless the underlying issue is fixed first.

## Also included

Repairs a `description` string in `renovate.json5` that **I mangled in #835** into `"Sppostgegel Group"`. Cosmetic only — `description` is documentation and `groupName: "Spegel"` was untouched, so grouping behaviour never changed.

## Verification

- [x] `flate test all` — 351 passed, 2 skipped (both pre-existing missing-secret skips)
- [x] `renovate.json5` parses; 30 packageRules
- [x] Probe stacks and the `checksum-probe` bucket path cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)