### PR TITLE
fix(alpha-site): put authentik back on staging names — disarm the conflict

### DIFF
--- a/docker/alpha-site/authentik/compose.yaml
+++ b/docker/alpha-site/authentik/compose.yaml
@@ -95,6 +95,19 @@ services:
       autoheal: true
       traefik.enable: true
 
+      # BACK ON STAGING HOSTNAMES — the cutover was rolled back (2026-08-16).
+      #
+      # #856 claimed the three vanity names here and merged, but never applied:
+      # the Pulumi state backend was broken estate-wide, so stacks/home could not
+      # run. SSO was restored by putting the names back on SGC
+      # (stargate-command-cluster#1832), which means BOTH sides claimed them —
+      # SGC serving them, and this file waiting to create StandardDns CNAMEs for
+      # them the moment Pulumi recovered. Two writers on live SSO DNS, armed and
+      # waiting on a Pulumi fix. This reverts that half.
+      #
+      # Re-apply #856 only as part of a real cutover window, after SGC has
+      # released the names again and retraction has been confirmed.
+      #
       # STAGING HOSTNAMES — deliberately NOT the production vanity aliases.
       #
       # Every `Host(...)` rule in this file is parsed by DockgeLxc's hostRegex
@@ -117,33 +130,16 @@ services:
       #
       # Issuer URLs do not change in this migration; only what answers behind
       # them does, which is why no app's OIDC config is touched.
-      # CUTOVER (step 5). These three are the estate's SSO names, released by
-      # stargate-command-cluster#1831 and confirmed retracted from cloudflare,
-      # technitium and unifi before this landed. Every cluster's outposts and
-      # Dockge hosts know authentik by one of them:
-      #   canterlot -> equestria, celestia, luna, skystar
-      #   iris      -> sgc, alpha-site
-      #   authentik -> the chart default, and AUTHENTIK_URL for every Pulumi stack
-      # Issuer URLs do not change; only what answers behind them does.
-      #
-      # authentik.${CLUSTER_DOMAIN} stays alongside them, so this host keeps a
-      # name of its own that is independent of the vanity set.
-      traefik.http.routers.authentik.rule: Host(`authentik.${searchDomain}`) || Host(`iris.${searchDomain}`) || Host(`canterlot.${searchDomain}`) || Host(`authentik.${CLUSTER_DOMAIN}`)
+      traefik.http.routers.authentik.rule: Host(`authentik.${CLUSTER_DOMAIN}`)
       traefik.http.routers.authentik.entrypoints: websecure
       traefik.http.routers.authentik.tls.certresolver: le
       traefik.http.routers.authentik.service: authentik
 
-      # STILL authentik-as, deliberately, even at cutover. `svc:authentik` on the
-      # tailnet is a SEPARATE name from the three public ones this step moves, and
-      # it is still owned by SGC. Claiming it here would collide on the service
-      # name — the failure mode that produces a Terminating service and a stuck
-      # finalizer in this estate.
-      #
-      # It does still need to move: DockgeLxc:700 hands `remote: true` hosts
-      # `authentik.<tailnet>` as their CLUSTER_AUTHENTIK_DOMAIN, and
-      # stacks/ocracoke is such a host — so its outpost keeps pointing at SGC
-      # until that name migrates. That is its own release-then-claim pair, on the
-      # same pattern as this one, and it must happen before SGC is scaled to zero.
+      # authentik-as, NOT authentik: `svc:authentik` already exists on the tailnet
+      # (and DockgeLxc:700 hands remote hosts `authentik.<tailnet>` as their
+      # CLUSTER_AUTHENTIK_DOMAIN). Claiming it here would both collide on the
+      # service name and silently repoint every remote Dockge host's outpost at
+      # this empty instance.
       traefik.http.routers.authentik-tailscale.rule: Host(`authentik-as.${tailscaleDomain}`)
       traefik.http.routers.authentik-tailscale.entrypoints: tailscale
       traefik.http.routers.authentik-tailscale.service: authentik
@@ -192,10 +188,8 @@ services:
 
 x-dockge:
   urls:
-    - https://authentik.${searchDomain}
-    - https://iris.${searchDomain}
-    - https://canterlot.${searchDomain}
     - https://authentik.${CLUSTER_DOMAIN}
+    - https://authentik-as.${tailscaleDomain}
 
 networks:
   dockge_default:

--- a/docker/alpha-site/authentik/definition.yaml
+++ b/docker/alpha-site/authentik/definition.yaml
@@ -17,8 +17,9 @@ spec:
   name: Authentik (Alpha Site)
   category: Infrastructure
   description: Authentik is an open-source identity provider focused on flexibility and security.
-  # The estate's primary SSO name — this host answers for it as of the cutover.
-  url: &url https://authentik.${searchDomain}
+  # Staging hostname — see compose.yaml's router comment for why this is not the
+  # production vanity alias. Flipped at cutover.
+  url: &url https://authentik.${CLUSTER_DOMAIN}
   icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/authentik.svg
   # NO `authentik:` block, and there never will be one. Authentik cannot be an
   # OAuth client of itself, and this host serves its own forwardAuth from the
@@ -41,35 +42,12 @@ spec:
     # single Pi on a single PoE switch (section 6, accepted), and "one alias did
     # not repoint" is a failure only a per-alias check can see.
     #
-    # 200, not 204. Verified against the live server: /-/health/live/ and
-    # /-/health/ready/ both answer 200. The 204 originally asserted here could
-    # never pass, and sat red while the endpoint was healthy.
-    - url: https://authentik.${searchDomain}/-/health/live/
-      method: GET
-      interval: 1m
-      conditions:
-        - "[STATUS] == 200"
-    # The two aliases now get their own checks, which they could not have while
-    # they still resolved to SGC — a check against them would have reported green
-    # for a server this stack had nothing to do with, and gone on passing straight
-    # through a failed cutover. They are load-bearing from here: every OIDC login
-    # and every outpost in the estate reaches this host by one of these three
-    # names, and "one alias did not repoint" is a failure only a per-alias check
-    # can see.
-    - url: https://canterlot.${searchDomain}/-/health/live/
-      method: GET
-      interval: 5m
-      conditions:
-        - "[STATUS] == 200"
-    - url: https://iris.${searchDomain}/-/health/live/
-      method: GET
-      interval: 5m
-      conditions:
-        - "[STATUS] == 200"
-    # Independent of the vanity set, so a DNS problem with those names is
-    # distinguishable from the server itself being down.
+    # 200, not 204. Verified against the live server after deploy:
+    # /-/health/live/ and /-/health/ready/ both answer 200. The 204 this
+    # originally asserted was wrong, so the check could never pass — it sat red
+    # from the moment the stack came up while the endpoint itself was healthy.
     - url: https://authentik.${CLUSTER_DOMAIN}/-/health/live/
       method: GET
-      interval: 5m
+      interval: 1m
       conditions:
         - "[STATUS] == 200"


### PR DESCRIPTION
**Time-sensitive — merge before the next successful `stacks/home` run.** #863 is already merged, so Pulumi is recovering.

## The armed conflict

#856 claimed `authentik`/`iris`/`canterlot.driscoll.tech` for alpha-site and merged — but **never applied**, because the Pulumi state backend was broken estate-wide.

SSO was then restored by putting those names back on SGC (stargate-command-cluster#1832). That left **both sides claiming them**:

- SGC's `HTTPRoute` — actually serving them now
- alpha-site's compose on `main` — waiting to create `StandardDns` CNAMEs pointing at `dockge-as` the moment Pulumi recovers

`DockgeLxc`'s `hostRegex` turns every `Host(...)` rule into infrastructure, so the next successful `stacks/home` run would have created those records against the ones SGC's external-dns publishes. Two writers on live SSO DNS — and `StandardDns` has wiped live records in this estate before.

## What this does

Reverts **the claim half only**. alpha-site goes back to `authentik.${CLUSTER_DOMAIN}` and `authentik-as.${tailscaleDomain}`, which nothing else owns, and keeps serving its restored copy there.

## What is deliberately NOT reverted

- **Step 4** (#852) — the embedded outpost stands
- **The restore** — alpha-site still holds a verified copy of the database
- **The plan's corrections from #856** — that `AUTHENTIK_URL` is a vanity name, so the DNS flip is itself the Pulumi repoint; and that the tailnet name is a separate third family that ocracoke depends on. Both are true and were the expensive part of that PR.

## Retry

Re-apply the claim as part of a real cutover window: re-sync the database, release the names from SGC, **confirm retraction across all three providers**, then claim. Plus the new gate this incident earned — confirm `stacks/home` can actually complete a run before releasing anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)