### PR TITLE
feat(dns): opt-in, transient import ids for StandardDns — adopt 4 records

### DIFF
--- a/components/StandardDns.ts
+++ b/components/StandardDns.ts
@@ -3,7 +3,7 @@ import type { GlobalResources } from "@components/globals.ts";
 import { type OnePasswordItemSectionInput, TypeEnum } from "@dynamic/1password/OnePasswordItem.ts";
 import type { GatusDefinition } from "@openapi/application-definition.js";
 import * as cloudflare from "@pulumi/cloudflare";
-import { all, ComponentResource, type ComponentResourceOptions, getStack, type Input, interpolate, mergeOptions, type Output, output } from "@pulumi/pulumi";
+import { all, ComponentResource, type ComponentResourceOptions, getStack, type Input, interpolate, log, mergeOptions, type Output, output } from "@pulumi/pulumi";
 import * as technitium from "@pulumi/technitium";
 import * as unifi from "@pulumiverse/unifi";
 import { addUptimeGatus } from "./helpers.ts";
@@ -21,6 +21,23 @@ export class StandardDns extends ComponentResource {
       ipAddress?: Input<string>;
       type: "A" | "CNAME";
       record?: Input<string>;
+      /**
+       * TRANSIENT adoption of a pre-existing UniFi record. Format is `<site>:<recordId>`,
+       * e.g. `default:68f45bc5015fc104b3a3db19`.
+       *
+       * Set this ONLY for the single run that adopts the record, then delete the line. It is
+       * not a permanent property: the provider stores the bare `<recordId>` in state, so this
+       * value can never equal the resource's own id and every later run re-plans a replace.
+       * See the block comment below for what that cost in July 2026.
+       */
+      unifiImportId?: string;
+      /**
+       * TRANSIENT adoption of a pre-existing Cloudflare record. Format is
+       * `<zoneId>/<recordId>`, e.g. `c2eddc…/9493f8…`.
+       *
+       * Same rule as `unifiImportId`: one run, then remove it.
+       */
+      cloudflareImportId?: string;
     },
     globals: GlobalResources,
     cro: ComponentResourceOptions,
@@ -55,7 +72,19 @@ export class StandardDns extends ComponentResource {
     //
     // A collision with an existing UniFi record is handled the same way as Cloudflare: reuse
     // the old Pulumi resource name so it becomes a replacement rather than a create.
-    const unifiId = undefined;
+    //
+    // ADOPTION IS NOW OPT-IN, PER CALL, AND MEANT TO BE TRANSIENT (`args.unifiImportId`).
+    // Two things make that safe enough to allow, and both matter:
+    //   1. It is never derived from a live lookup any more, so the silent
+    //      `undefined -> "default:<id>"` transition that caused the damage cannot happen on
+    //      its own. A human writes the id, for one run, on purpose.
+    //   2. `deleteBeforeReplace` is dropped for as long as an import id is set (see the
+    //      constructor). That is the mechanism that turned "a replace was planned" into
+    //      "the live record was destroyed first". Without it a mis-planned replace fails
+    //      closed on "record already exists" and leaves DNS untouched.
+    // Leaving the id in place after adoption does NOT wipe records, but it will wedge the
+    // stack on that error every run — which is the intended, loud failure mode.
+    const unifiId = args.unifiImportId;
     // Deliberately NOT adopting pre-existing Cloudflare records via `import`.
     //
     // The provider's import id is `<zoneId>/<recordId>` but the id it stores in state is the
@@ -68,7 +97,24 @@ export class StandardDns extends ComponentResource {
     // A collision with an existing Cloudflare record (error 81054) is instead handled by
     // reusing the old Pulumi resource name so it becomes a replacement rather than a create
     // — see the technitium record in `components/DockgeLxc.ts`.
-    const cloudflareId = undefined;
+    //
+    // As with UniFi above, adoption is now opt-in per call via `args.cloudflareImportId` and
+    // is meant to last exactly one run. The id mismatch described above is unchanged and
+    // unfixable from here — the guardrail is that `deleteBeforeReplace` is dropped while an
+    // import id is set, so the re-planned replace fails closed (error 81054, "record already
+    // exists") instead of destroying and recreating live DNS. Remove the id once the record
+    // is in state.
+    const cloudflareId = args.cloudflareImportId;
+    // Adoption ids are transient by design; say so on every run that carries one, so a
+    // leftover cannot sit quietly in the tree until the next replace surprises someone.
+    if (args.unifiImportId !== undefined || args.cloudflareImportId !== undefined) {
+      log.warn(
+        `StandardDns "${name}" is carrying an adoption import id (unifi=${args.unifiImportId ?? "-"}, cloudflare=${args.cloudflareImportId ?? "-"}). ` +
+          "These are ONE-RUN values: remove them once the records are in state. Left in place they re-plan a replace every update, " +
+          "which now fails closed rather than deleting live DNS — but it will wedge this stack.",
+      );
+    }
+
     return new StandardDns(
       name,
       {
@@ -116,7 +162,12 @@ export class StandardDns extends ComponentResource {
       {
         parent: this,
         provider: globals.unifiProvider,
-        deleteBeforeReplace: true,
+        // THE GUARDRAIL. `deleteBeforeReplace` is what converted a planned replace into a
+        // destroyed record in the 2026-07-28 incident. While an import id is set the import
+        // id can never match the state id, so a replace WILL be re-planned on the next run —
+        // without delete-first that plan fails on "record already exists" and live DNS is
+        // untouched. Once the id is removed the normal ordering comes back.
+        deleteBeforeReplace: args.unifiId === undefined,
         import: args.unifiId,
       },
     );
@@ -152,7 +203,9 @@ export class StandardDns extends ComponentResource {
       {
         parent: this,
         provider: globals.cloudflareProvider,
-        deleteBeforeReplace: true,
+        // Same guardrail as the UniFi record above — this is the option that turned the
+        // 2026-07-25 re-import loop into 56 wiped records, twice.
+        deleteBeforeReplace: args.cloudflareId === undefined,
         import: args.cloudflareId,
         // `zoneId` is replace-triggering, and the program supplies it as a secret while the
         // provider reads it back as plaintext. Keep it out of the diff so a `[secret] =>

--- a/stacks/home/index.ts
+++ b/stacks/home/index.ts
@@ -427,9 +427,19 @@ const _openbaoSgcAuth = new OpenBaoClusterAuth("openbao-sgc-auth", {
 });
 
 function clusterWideDns(globals: GlobalResources) {
+  // ONE-RUN ADOPTION IDS — delete all four `*ImportId` lines once this stack has gone green.
+  //
+  // These four names existed in UniFi and Cloudflare before Pulumi ever described them (they
+  // are not external-dns-managed and no other stack owns them), so plain creates fail with
+  // "Static DNS Record Already Exists" / Cloudflare 81054 and wedge the whole stack. The ids
+  // below adopt the live records instead. See components/StandardDns.ts for why they must not
+  // stay: the import id can never equal the state id, so every later run re-plans a replace.
+  // That now fails closed rather than deleting live DNS, but it will still wedge this stack.
   StandardDns.create(
     "spike-a",
     {
+      unifiImportId: "default:68f45bc5015fc104b3a3db19",
+      cloudflareImportId: "c2eddc69f9b07cd0e6a73c4d59b52189/9493f82e733d2901068732152f731dc1",
       type: "A",
       hostname: pulumi.interpolate`spike.${globals.searchDomain}`,
       ipAddress: `10.10.10.10`,
@@ -441,6 +451,8 @@ function clusterWideDns(globals: GlobalResources) {
   StandardDns.create(
     "spikespike-cname",
     {
+      unifiImportId: "default:68f45bc5015fc104b3a3db16",
+      cloudflareImportId: "c2eddc69f9b07cd0e6a73c4d59b52189/c0115e6662ca3070331f73d3c4b4171f",
       type: "CNAME",
       hostname: pulumi.interpolate`truenas.${globals.searchDomain}`,
       record: pulumi.interpolate`spike.${globals.searchDomain}`,
@@ -452,6 +464,8 @@ function clusterWideDns(globals: GlobalResources) {
   StandardDns.create(
     "discord-a",
     {
+      unifiImportId: "default:68f45bc5015fc104b3a3db12",
+      cloudflareImportId: "c2eddc69f9b07cd0e6a73c4d59b52189/631dcde6e22c40611cb29a0774ea975c",
       type: "A",
       hostname: pulumi.interpolate`discord.${globals.searchDomain}`,
       ipAddress: `10.10.0.1`,
@@ -463,6 +477,8 @@ function clusterWideDns(globals: GlobalResources) {
   StandardDns.create(
     "discord-cname",
     {
+      unifiImportId: "default:68f45bc5015fc104b3a3db1c",
+      cloudflareImportId: "c2eddc69f9b07cd0e6a73c4d59b52189/edde1ca9f6032cc7731d2896bf42a193",
       type: "CNAME",
       hostname: pulumi.interpolate`unifi.${globals.searchDomain}`,
       record: pulumi.interpolate`discord.${globals.searchDomain}`,


### PR DESCRIPTION
**Unblocks `stacks/home`, which has been wedged since `c87b3b43`** — and therefore unblocks the authentik cutover, whose claim half is a `stacks/home` run.

`spike`/`truenas`/`discord`/`unifi.driscoll.tech` existed in UniFi and Cloudflare before Pulumi described them, so the creates fail with `Static DNS Record Already Exists` and Cloudflare `81054`, failing the whole stack.

## I checked the cheaper fix first

`StandardDns.ts` prescribes *"reuse the old Pulumi resource name so it becomes a replacement rather than a create"*. That needs an old name to reuse. I searched `home-operations` (922 resources), `unifi-network` (44) and `system` (8) for all four hostnames and all eight live record ids — **zero matches**; only the `technitium` children are in state.

So this is **adoption**, which the component deliberately did not support, not a rename. Hence option 3.

## Why this isn't the thing that wiped DNS twice

The file records two incidents — 56 Cloudflare records wiped twice on 2026-07-25, nine UniFi records destroyed on 2026-07-28. Two changes separate this from that:

**1. Never derived from a live lookup.** The 2026-07-28 damage came from a `unifi.dns.getRecordsOutput` lookup that silently flipped `import: undefined` → `import: "default:<id>"` on the run *after* creation, planning a replace-by-import. That transition can no longer happen on its own — a human writes the id, once, deliberately.

**2. `deleteBeforeReplace` is dropped while an import id is set.** This is the load-bearing part. That option is what turned "a replace was planned" into "the live record was destroyed first" in *both* incidents. Without it, the replace that **will** be re-planned on the next run fails closed on "record already exists" and leaves DNS untouched.

The underlying mismatch is unchanged and unfixable from here — providers store a bare `<recordId>` while import needs `<site>:<recordId>` and `<zoneId>/<recordId>`. So a leftover id still wedges the stack every run. **It just no longer destroys anything.** `create()` also logs a warning on every run carrying one, so a leftover can't sit quietly.

## Follow-up required

The four ids in `stacks/home/index.ts` are **one-run values**, with a banner saying so. Once this stack goes green, delete the eight `*ImportId` lines. I'd expect that as a same-day follow-up PR, not a someday task.

## What to watch on the first run

- The four records adopt rather than create; **no delete** should appear in the plan for any of them
- `spike`/`truenas`/`discord`/`unifi.driscoll.tech` keep resolving throughout — `truenas` especially, since it's the Pulumi state backend's own endpoint
- The run also settles an open question for free: state claims four `technitium` records exist for these names but the API wasn't reachable to confirm, so if they're missing it'll surface here

## Verification

- [x] `tsc --noEmit` clean (one pre-existing `TS6307`)
- [x] `biome check` clean
- [ ] `pulumi preview` on `stacks/home` shows adoption with no deletes — **please confirm before applying**; note preview on this stack also invents phantom deletes for `StandardDns`/`TailnetKey`/`DeviceTags`, so read the four records specifically rather than the summary count

🤖 Generated with [Claude Code](https://claude.com/claude-code)