### PR TITLE
chore(dns): drop the one-run adoption ids now the records are in state

### DIFF
--- a/stacks/home/index.ts
+++ b/stacks/home/index.ts
@@ -427,19 +427,9 @@ const _openbaoSgcAuth = new OpenBaoClusterAuth("openbao-sgc-auth", {
 });
 
 function clusterWideDns(globals: GlobalResources) {
-  // ONE-RUN ADOPTION IDS — delete all four `*ImportId` lines once this stack has gone green.
-  //
-  // These four names existed in UniFi and Cloudflare before Pulumi ever described them (they
-  // are not external-dns-managed and no other stack owns them), so plain creates fail with
-  // "Static DNS Record Already Exists" / Cloudflare 81054 and wedge the whole stack. The ids
-  // below adopt the live records instead. See components/StandardDns.ts for why they must not
-  // stay: the import id can never equal the state id, so every later run re-plans a replace.
-  // That now fails closed rather than deleting live DNS, but it will still wedge this stack.
   StandardDns.create(
     "spike-a",
     {
-      unifiImportId: "default:68f45bc5015fc104b3a3db19",
-      cloudflareImportId: "c2eddc69f9b07cd0e6a73c4d59b52189/9493f82e733d2901068732152f731dc1",
       type: "A",
       hostname: pulumi.interpolate`spike.${globals.searchDomain}`,
       ipAddress: `10.10.10.10`,
@@ -451,8 +441,6 @@ function clusterWideDns(globals: GlobalResources) {
   StandardDns.create(
     "spikespike-cname",
     {
-      unifiImportId: "default:68f45bc5015fc104b3a3db16",
-      cloudflareImportId: "c2eddc69f9b07cd0e6a73c4d59b52189/c0115e6662ca3070331f73d3c4b4171f",
       type: "CNAME",
       hostname: pulumi.interpolate`truenas.${globals.searchDomain}`,
       record: pulumi.interpolate`spike.${globals.searchDomain}`,
@@ -464,8 +452,6 @@ function clusterWideDns(globals: GlobalResources) {
   StandardDns.create(
     "discord-a",
     {
-      unifiImportId: "default:68f45bc5015fc104b3a3db12",
-      cloudflareImportId: "c2eddc69f9b07cd0e6a73c4d59b52189/631dcde6e22c40611cb29a0774ea975c",
       type: "A",
       hostname: pulumi.interpolate`discord.${globals.searchDomain}`,
       ipAddress: `10.10.0.1`,
@@ -477,8 +463,6 @@ function clusterWideDns(globals: GlobalResources) {
   StandardDns.create(
     "discord-cname",
     {
-      unifiImportId: "default:68f45bc5015fc104b3a3db1c",
-      cloudflareImportId: "c2eddc69f9b07cd0e6a73c4d59b52189/edde1ca9f6032cc7731d2896bf42a193",
       type: "CNAME",
       hostname: pulumi.interpolate`unifi.${globals.searchDomain}`,
       record: pulumi.interpolate`discord.${globals.searchDomain}`,


### PR DESCRIPTION
Required follow-up to #867 — **due now, not someday.**

## The adoption worked

All twelve `StandardDns` children are in state:

```
spike-a-unifi                id=68f45bc5015fc104b3a3db19            delete=None
spike-a-cloudflare           id=9493f82e733d2901068732152f731dc1    delete=None
spikespike-cname-unifi       id=68f45bc5015fc104b3a3db16            delete=None
spikespike-cname-cloudflare  id=c0115e6662ca3070331f73d3c4b4171f    delete=None
discord-a-unifi              id=68f45bc5015fc104b3a3db12            delete=None
discord-a-cloudflare         id=631dcde6e22c40611cb29a0774ea975c    delete=None
discord-cname-unifi          id=68f45bc5015fc104b3a3db1c            delete=None
discord-cname-cloudflare     id=edde1ca9f6032cc7731d2896bf42a193    delete=None
```

Correct bare ids, and **no `delete: true` twins** — that was the failure signature of the July 2026 incidents. All four names resolved correctly throughout, `truenas.driscoll.tech` included.

The `Static DNS Record Already Exists` and Cloudflare `81054` errors are gone from the run.

## Why this can't wait

With the records in state the ids have done their job. Leaving them is what wedges the stack: the import id can never equal the state id, so every subsequent run re-plans a replace. #867's guardrail makes that **fail closed** on "record already exists" rather than destroying live DNS — but failing closed is still failing.

Removing them restores the normal path: `import` undefined, `deleteBeforeReplace` back to `true` for ordinary replacements.

`components/StandardDns.ts` keeps the capability and the warning, so the next record needing adoption can use it the same way.

## Still failing, unrelated

The run now fails on a different error, which is step 4 (#852) doing its work:

```
HTTP Error '502 Bad Gateway' during 'DELETE /api/v3/outposts/instances/d7ccc692-…/'
```

That's `useEmbeddedOutpost` removing the per-host alpha-site `Outpost`. SGC's authentik is healthy (HTTP 200 on both names, two server pods), so this reads as transient and should clear on retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)