### PR TITLE
feat(alpha-site): authentik claims the SSO names — cutover, second attempt

### DIFF
--- a/docker/alpha-site/authentik/compose.yaml
+++ b/docker/alpha-site/authentik/compose.yaml
@@ -95,19 +95,6 @@ services:
       autoheal: true
       traefik.enable: true
 
-      # BACK ON STAGING HOSTNAMES — the cutover was rolled back (2026-08-16).
-      #
-      # #856 claimed the three vanity names here and merged, but never applied:
-      # the Pulumi state backend was broken estate-wide, so stacks/home could not
-      # run. SSO was restored by putting the names back on SGC
-      # (stargate-command-cluster#1832), which means BOTH sides claimed them —
-      # SGC serving them, and this file waiting to create StandardDns CNAMEs for
-      # them the moment Pulumi recovered. Two writers on live SSO DNS, armed and
-      # waiting on a Pulumi fix. This reverts that half.
-      #
-      # Re-apply #856 only as part of a real cutover window, after SGC has
-      # released the names again and retraction has been confirmed.
-      #
       # STAGING HOSTNAMES — deliberately NOT the production vanity aliases.
       #
       # Every `Host(...)` rule in this file is parsed by DockgeLxc's hostRegex
@@ -130,16 +117,39 @@ services:
       #
       # Issuer URLs do not change in this migration; only what answers behind
       # them does, which is why no app's OIDC config is touched.
-      traefik.http.routers.authentik.rule: Host(`authentik.${CLUSTER_DOMAIN}`)
+      # CUTOVER (step 5), SECOND ATTEMPT. The first (#856) merged but never
+      # applied — the Pulumi state backend was broken estate-wide, so this file
+      # sat claiming names SGC was serving, and #864 reverted it to disarm that.
+      # stacks/home has since completed a clean run, and the restore below was
+      # re-synced and verified minutes before this landed.
+      #
+      # These three are the estate's SSO names, released by
+      # stargate-command-cluster#1831 and confirmed retracted from cloudflare,
+      # technitium and unifi before this landed. Every cluster's outposts and
+      # Dockge hosts know authentik by one of them:
+      #   canterlot -> equestria, celestia, luna, skystar
+      #   iris      -> sgc, alpha-site
+      #   authentik -> the chart default, and AUTHENTIK_URL for every Pulumi stack
+      # Issuer URLs do not change; only what answers behind them does.
+      #
+      # authentik.${CLUSTER_DOMAIN} stays alongside them, so this host keeps a
+      # name of its own that is independent of the vanity set.
+      traefik.http.routers.authentik.rule: Host(`authentik.${searchDomain}`) || Host(`iris.${searchDomain}`) || Host(`canterlot.${searchDomain}`) || Host(`authentik.${CLUSTER_DOMAIN}`)
       traefik.http.routers.authentik.entrypoints: websecure
       traefik.http.routers.authentik.tls.certresolver: le
       traefik.http.routers.authentik.service: authentik
 
-      # authentik-as, NOT authentik: `svc:authentik` already exists on the tailnet
-      # (and DockgeLxc:700 hands remote hosts `authentik.<tailnet>` as their
-      # CLUSTER_AUTHENTIK_DOMAIN). Claiming it here would both collide on the
-      # service name and silently repoint every remote Dockge host's outpost at
-      # this empty instance.
+      # STILL authentik-as, deliberately, even at cutover. `svc:authentik` on the
+      # tailnet is a SEPARATE name from the three public ones this step moves, and
+      # it is still owned by SGC. Claiming it here would collide on the service
+      # name — the failure mode that produces a Terminating service and a stuck
+      # finalizer in this estate.
+      #
+      # It does still need to move: DockgeLxc:700 hands `remote: true` hosts
+      # `authentik.<tailnet>` as their CLUSTER_AUTHENTIK_DOMAIN, and
+      # stacks/ocracoke is such a host — so its outpost keeps pointing at SGC
+      # until that name migrates. That is its own release-then-claim pair, on the
+      # same pattern as this one, and it must happen before SGC is scaled to zero.
       traefik.http.routers.authentik-tailscale.rule: Host(`authentik-as.${tailscaleDomain}`)
       traefik.http.routers.authentik-tailscale.entrypoints: tailscale
       traefik.http.routers.authentik-tailscale.service: authentik
@@ -188,8 +198,10 @@ services:
 
 x-dockge:
   urls:
+    - https://authentik.${searchDomain}
+    - https://iris.${searchDomain}
+    - https://canterlot.${searchDomain}
     - https://authentik.${CLUSTER_DOMAIN}
-    - https://authentik-as.${tailscaleDomain}
 
 networks:
   dockge_default:

--- a/docker/alpha-site/authentik/definition.yaml
+++ b/docker/alpha-site/authentik/definition.yaml
@@ -17,9 +17,8 @@ spec:
   name: Authentik (Alpha Site)
   category: Infrastructure
   description: Authentik is an open-source identity provider focused on flexibility and security.
-  # Staging hostname — see compose.yaml's router comment for why this is not the
-  # production vanity alias. Flipped at cutover.
-  url: &url https://authentik.${CLUSTER_DOMAIN}
+  # The estate's primary SSO name — this host answers for it as of the cutover.
+  url: &url https://authentik.${searchDomain}
   icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/authentik.svg
   # NO `authentik:` block, and there never will be one. Authentik cannot be an
   # OAuth client of itself, and this host serves its own forwardAuth from the
@@ -42,12 +41,35 @@ spec:
     # single Pi on a single PoE switch (section 6, accepted), and "one alias did
     # not repoint" is a failure only a per-alias check can see.
     #
-    # 200, not 204. Verified against the live server after deploy:
-    # /-/health/live/ and /-/health/ready/ both answer 200. The 204 this
-    # originally asserted was wrong, so the check could never pass — it sat red
-    # from the moment the stack came up while the endpoint itself was healthy.
-    - url: https://authentik.${CLUSTER_DOMAIN}/-/health/live/
+    # 200, not 204. Verified against the live server: /-/health/live/ and
+    # /-/health/ready/ both answer 200. The 204 originally asserted here could
+    # never pass, and sat red while the endpoint was healthy.
+    - url: https://authentik.${searchDomain}/-/health/live/
       method: GET
       interval: 1m
+      conditions:
+        - "[STATUS] == 200"
+    # The two aliases now get their own checks, which they could not have while
+    # they still resolved to SGC — a check against them would have reported green
+    # for a server this stack had nothing to do with, and gone on passing straight
+    # through a failed cutover. They are load-bearing from here: every OIDC login
+    # and every outpost in the estate reaches this host by one of these three
+    # names, and "one alias did not repoint" is a failure only a per-alias check
+    # can see.
+    - url: https://canterlot.${searchDomain}/-/health/live/
+      method: GET
+      interval: 5m
+      conditions:
+        - "[STATUS] == 200"
+    - url: https://iris.${searchDomain}/-/health/live/
+      method: GET
+      interval: 5m
+      conditions:
+        - "[STATUS] == 200"
+    # Independent of the vanity set, so a DNS problem with those names is
+    # distinguishable from the server itself being down.
+    - url: https://authentik.${CLUSTER_DOMAIN}/-/health/live/
+      method: GET
+      interval: 5m
       conditions:
         - "[STATUS] == 200"


### PR DESCRIPTION
**Claim half. Merge only AFTER [stargate-command-cluster#1836](https://github.com/david-driscoll/stargate-command-cluster/pull/1836) has landed and its three names have been observed to retract from all three external-dns providers.**

Re-applies #856, which #864 reverted. That revert was a safety measure, not a correction: #856 merged but could never apply, because the Pulumi state backend was broken estate-wide. It left this file claiming three names SGC was actively serving — two writers on live SSO DNS, armed and waiting on a Pulumi fix.

## Both blocking conditions are cleared

**`stacks/home` completes a clean run.** Getting there took the Pulumi version pin (#863), the conflict disarm (#864), and adopting four pre-existing DNS records the stack couldn't create (#867/#868). Verified: state `succeeded`, and step 4's outpost migration completed — `alpha-site-alloy` now sits on the **embedded outpost** with the per-host `Outpost` gone.

**The restore is current.** Re-synced and verified against SGC minutes ago:

| gate | result |
|---|---|
| row counts | `users=12 groups=8 apps=128 tokens=8 flows=25 providers=78` — exact match |
| tables | 215 |
| ownership | all `authentik`, restored with `--role=authentik` |
| restore stderr | zero, with `--exit-on-error` |
| migrations on boot | none applied |
| bootstrap | no-op — counts unchanged after boot |
| media | 4 files re-copied |
| serving | HTTP 200 on the staging hostname |

The drift was real: the previous copy had `users=13 tokens=9`. That's why the re-sync mattered, and why it ran immediately before this rather than hours earlier.

## Deliberately unchanged

**`spec.name` keeps its `(Alpha Site)` suffix.** SGC still publishes an `ApplicationDefinition`, and Gatus **panics** on a duplicate `(name, group)` rather than skipping it — taking estate-wide monitoring down, as it did on 2026-08-13. The suffix comes off when SGC's definition goes.

**The tailnet router stays `authentik-as`.** `svc:authentik` is a separate name still owned by SGC, and `stacks/ocracoke` (`remote: true`) depends on it via `DockgeLxc.ts:700`. It needs its own release-then-claim pair **before SGC scales to zero**, or ocracoke's outpost points at a dead server.

## After merge

I'll run the post-checks: every outpost re-registers, `forwardAuth`-gated apps still authenticate, and a login round-trip per outpost type. `AUTHENTIK_URL` is `https://authentik.driscoll.tech` — a vanity name — so the DNS flip is itself the Pulumi repoint; no OpenBao edit needed.

## Rollback

Restore the three `hostnames` lines in SGC's HTTPRoute and revert this. SGC's database, PVC and CNPG role stay untouched throughout. The deadline is divergence: after the flip, every login and object write lands on alpha-site alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)