### PR TITLE
feat(alpha-site): authentik takes the tailnet name too

### DIFF
--- a/docker/alpha-site/authentik/compose.yaml
+++ b/docker/alpha-site/authentik/compose.yaml
@@ -203,6 +203,7 @@ x-dockge:
     - https://iris.${searchDomain}
     - https://canterlot.${searchDomain}
     - https://authentik.${CLUSTER_DOMAIN}
+    - https://authentik.${tailscaleDomain}
 
 networks:
   dockge_default:

--- a/docker/alpha-site/authentik/compose.yaml
+++ b/docker/alpha-site/authentik/compose.yaml
@@ -139,18 +139,19 @@ services:
       traefik.http.routers.authentik.tls.certresolver: le
       traefik.http.routers.authentik.service: authentik
 
-      # STILL authentik-as, deliberately, even at cutover. `svc:authentik` on the
-      # tailnet is a SEPARATE name from the three public ones this step moves, and
-      # it is still owned by SGC. Claiming it here would collide on the service
-      # name — the failure mode that produces a Terminating service and a stuck
-      # finalizer in this estate.
+      # The tailnet name moves here too. DockgeLxc's hostRegex turns this rule
+      # into the whole chain automatically (components/DockgeLxc.ts:1078-1118):
+      # a tailscale.Service `svc:authentik`, a `tailscale serve --service=svc:authentik
+      # --https=443 127.0.0.1:8443` on this host so it actually backs the VIP, and a
+      # monitor.addService entry. Dropping the old rule likewise runs
+      # `tailscale serve clear svc:authentik-as`.
       #
-      # It does still need to move: DockgeLxc:700 hands `remote: true` hosts
-      # `authentik.<tailnet>` as their CLUSTER_AUTHENTIK_DOMAIN, and
-      # stacks/ocracoke is such a host — so its outpost keeps pointing at SGC
-      # until that name migrates. That is its own release-then-claim pair, on the
-      # same pattern as this one, and it must happen before SGC is scaled to zero.
-      traefik.http.routers.authentik-tailscale.rule: Host(`authentik-as.${tailscaleDomain}`)
+      # This is the name remote Dockge hosts use, NOT a public vanity alias:
+      # DockgeLxc.ts:700 hands `remote: true` hosts `authentik.${tailscaleDomain}` as
+      # their CLUSTER_AUTHENTIK_DOMAIN. skystar (stacks/ocracoke) is such a host — its
+      # outpost dials https://authentik.opossum-yo.ts.net and is serving through it
+      # today — so this has to land before SGC is scaled to zero.
+      traefik.http.routers.authentik-tailscale.rule: Host(`authentik.${tailscaleDomain}`)
       traefik.http.routers.authentik-tailscale.entrypoints: tailscale
       traefik.http.routers.authentik-tailscale.service: authentik
 


### PR DESCRIPTION
**The last name still pointing at SGC.** Required before the cluster can be scaled down.

## One rule, whole chain — automatically

`DockgeLxc`'s `hostRegex` ([`components/DockgeLxc.ts:1078-1118`](https://github.com/david-driscoll/home-operations/blob/main/components/DockgeLxc.ts#L1078)) turns a tailnet `Host(...)` rule into all three pieces:

1. `new tailscale.Service({ name: "svc:authentik", ports: ["tcp:443"], tags: [dockge, apps] })`
2. a `remote.Command` on this host: `tailscale serve --service=svc:authentik --yes --https=443 127.0.0.1:8443` — so the host actually **backs** the VIP, pointed at Traefik's tailscale entrypoint
3. `monitor.addService("svc:authentik")`

Dropping the old rule runs the matching `tailscale serve clear svc:authentik-as`. No admin-console step.

## Why this is separate from the vanity names

It doesn't travel with them. `DockgeLxc.ts:700` hands `remote: true` hosts `authentik.${tailscaleDomain}` — **not** a public alias — as their `CLUSTER_AUTHENTIK_DOMAIN`. `stacks/ocracoke` (skystar) is such a host:

```
AUTHENTIK_HOST=https://authentik.opossum-yo.ts.net
```

and it is serving through it right now — a `backrest.skystar.driscoll.tech` request got a 302 through that outpost minutes ago. **So this must land before SGC is scaled to zero**, or skystar's outpost points at a dead server.

## Nothing owns it today

Checked before writing this: `svc:authentik` is owned by no code — not `stacks/home` (which owns `svc:authentik-as`), not `ocracoke`, not `gulf-of-mexico`, and no SGC or equestria manifest. It's unmanaged, so this claim is a plain create rather than the release-then-claim pair the public names needed.

## After merge, worth watching

- `authentik.opossum-yo.ts.net` resolves to the alpha-site-backed VIP rather than `100.106.100.188`
- skystar's outpost keeps serving across the change
- `svc:authentik-as` is cleared and `authentik-as.opossum-yo.ts.net` stops resolving

If the create collides with the existing unmanaged VIP, expect it to **fail closed** on the Pulumi run rather than break anything — the same shape as the DNS "already exists" case, and #867's adoption pattern is available if it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)