### PR TITLE
fix(sgc): defuse the two stacks that break when the sgc stack is destroyed

### DIFF
--- a/components/store/bao.test.ts
+++ b/components/store/bao.test.ts
@@ -201,7 +201,10 @@ describe("resolveBaoPath", () => {
   it("routes the inventory families to their reserved _inventory paths, never shared/", () => {
     assert.equal(resolveBaoPath("Backup Plan").path, "clusters/_inventory/backup-plan");
     assert.equal(resolveBaoPath("Equestria Backup Plan").path, "clusters/_inventory/equestria-backup-plan");
-    assert.equal(resolveBaoPath("Stargate Command Backup Plan").path, "clusters/_inventory/stargate-command-backup-plan");
+    // A multi-word cluster title still slugs into one reserved path — this
+    // read `Stargate Command Backup Plan` until SGC's teardown; the rule it
+    // pins is the slug, not the cluster.
+    assert.equal(resolveBaoPath("Alpha Site Backup Plan").path, "clusters/_inventory/alpha-site-backup-plan");
     assert.equal(resolveBaoPath("Tailscale Export - home-operations").path, "clusters/_inventory/tailscale-export-home-operations");
     // A title merely containing the words is not the family.
     assert.equal(resolveBaoPath("Backup Plan Review Notes").path, "shared/backup-plan-review-notes");
@@ -269,7 +272,7 @@ describe("shapeTailscaleExports", () => {
 });
 
 describe("backupPlanKeys", () => {
-  const complete = ["backup-plan", "equestria-backup-plan", "stargate-command-backup-plan"];
+  const complete = ["backup-plan", "equestria-backup-plan"];
 
   it("selects the bare key and the -backup-plan suffixed keys, nothing else", () => {
     assert.deepEqual(backupPlanKeys(["authentik-outputs", "tailscale-export-ocracoke", ...complete]), complete);
@@ -278,12 +281,22 @@ describe("backupPlanKeys", () => {
   it("refuses an empty or torn inventory, naming what is missing", () => {
     // A smaller list here quietly shrinks what the directors back up — a
     // failure with no symptom until a restore is needed.
-    assert.throws(() => backupPlanKeys([]), /missing backup-plan, equestria-backup-plan, stargate-command-backup-plan/);
+    assert.throws(() => backupPlanKeys([]), /missing backup-plan, equestria-backup-plan/);
     assert.throws(() => backupPlanKeys(complete.filter(k => k !== "equestria-backup-plan")), /missing equestria-backup-plan/);
   });
 
   it("includes plans beyond the known set — a floor, not a ceiling", () => {
     assert.deepEqual(backupPlanKeys([...complete, "luna-backup-plan"]), [...complete, "luna-backup-plan"]);
+  });
+
+  it("does not demand a retired cluster's plan — SGC's key may be absent", () => {
+    // The teardown fuse: `pulumi destroy --stack sgc` removes
+    // `stargate-command-backup-plan` from the _inventory LIST. While it was
+    // in BACKUP_PLAN_KEYS that made this throw for every consumer, taking
+    // stacks/home, stacks/ocracoke and stacks/gulf-of-mexico down with it.
+    assert.doesNotThrow(() => backupPlanKeys(complete));
+    // …and while the key is still there (before the destroy), it is still read.
+    assert.deepEqual(backupPlanKeys([...complete, "stargate-command-backup-plan"]), [...complete, "stargate-command-backup-plan"]);
   });
 });
 

--- a/components/store/bao.ts
+++ b/components/store/bao.ts
@@ -76,8 +76,21 @@ const TAILSCALE_EXPORT_STACKS = ["gulf-of-mexico", "home-operations", "ocracoke"
  * The plans `BackupPlanOrchestrator.savePlan` produces today: `Backup Plan`
  * from stacks/backups, `<Cluster Title> Backup Plan` from each applications
  * stack. `getBackupPlans` refuses a partial set — see the override for why.
+ *
+ * `stargate-command-backup-plan` was listed here until SGC's teardown
+ * (docs/cluster-consolidation/22-decommission-sgc.md). `pulumi destroy
+ * --stack sgc` removes that `_inventory` key, and a listed-but-absent key is
+ * fatal, so leaving it here would have failed `getBackupPlans` for every
+ * consumer — the three `BackupPlanDirector`s in stacks/home, stacks/ocracoke
+ * and stacks/gulf-of-mexico, all at once, on a stack nobody touched.
+ *
+ * Removing an entry is the SAFE direction and must stay that way: the list is
+ * a floor, not a ceiling, so a producer that still writes its plan is still
+ * read whether or not it is named here. Adding an entry is the dangerous
+ * direction — it is a promise that the producing stack has already run its
+ * write (PLAN §G-8).
  */
-const BACKUP_PLAN_KEYS = ["backup-plan", "equestria-backup-plan", "stargate-command-backup-plan"];
+const BACKUP_PLAN_KEYS = ["backup-plan", "equestria-backup-plan"];
 
 /**
  * `baoStoreReadsEnabled` used to live here, gating whether reads went to

--- a/stacks/authentik/index.ts
+++ b/stacks/authentik/index.ts
@@ -1,7 +1,6 @@
 import { FullItem } from "@1password/connect";
 import { baoKvSecret, baoProvenance } from "@components/bao.ts";
 import { GlobalResources } from "@components/globals.ts";
-import { awaitOutput } from "@components/helpers.ts";
 import { OnePasswordItem, type OnePasswordItemSectionInput, PurposeEnum, TypeEnum } from "@dynamic/1password/OnePasswordItem.ts";
 import { Brand } from "@pulumi/authentik";
 import * as pulumi from "@pulumi/pulumi";
@@ -102,9 +101,9 @@ if (globals.baoDualWriteEnabled) {
       // `secrets` mount because that is the only KV mount consumers can read.
       data: pulumi.output({ groups, roles, flows, scopeMappings }),
       // Authentik object IDs (flows, groups, mappings) — identifiers, not
-    // credentials. Declared empty deliberately rather than omitted.
-    concealedFields: [],
-    customMetadata: baoProvenance({ source_title: "Authentik Outputs" }),
+      // credentials. Declared empty deliberately rather than omitted.
+      concealedFields: [],
+      customMetadata: baoProvenance({ source_title: "Authentik Outputs" }),
     },
     { provider: globals.baoProvider, parent: globals },
   );
@@ -112,15 +111,42 @@ if (globals.baoDualWriteEnabled) {
   pulumi.log.warn("BAO credentials absent — skipping the Authentik Outputs dual-write; consumers still read 1Password");
 }
 
-const clusterDefinition = await awaitOutput(globals.store.getCluster("Cluster: Stargate Command"));
+// The estate-wide tailnet brand.
+//
+// Its assets used to come from `getCluster("Cluster: Stargate Command")`.
+// `BaoStore.getCluster` THROWS on a title it cannot find, so the moment SGC's
+// cluster definition goes away (docs/cluster-consolidation/22-decommission-sgc.md
+// §4) this stack — the estate's SSO control plane, the one every other stack's
+// OIDC depends on — fails on every run, for a cluster it does not otherwise
+// touch. One cluster's teardown must not be able to take SSO down with it.
+//
+// The values below are the exact URLs the SGC definition carried, so the
+// rendered brand is byte-identical; this change is a decoupling, not a
+// restyle. They are literals rather than another cluster's definition because
+// this brand covers the TAILNET, not a cluster — there is no cluster whose
+// branding it should inherit. Alpha Site (where authentik now runs, and which
+// shares `authentikDomain: iris.driscoll.tech`) carries different
+// icon/favicon/background values, so pointing at it would have been a silent
+// rebrand smuggled in on a decommission. Restyling this brand is a one-line,
+// deliberate change to make here on its own.
+const TAILNET_BRAND_LOGO = "https://i.pinimg.com/originals/d6/1b/0f/d61b0fa0a759fd8baceedc9427246f7d.jpg";
+// The SGC definition set `favicon` to the same URL as `icon`; kept separate so
+// either can move without dragging the other.
+const TAILNET_BRAND_FAVICON = "https://i.pinimg.com/originals/d6/1b/0f/d61b0fa0a759fd8baceedc9427246f7d.jpg";
+const TAILNET_BRAND_BACKGROUND = "https://wallpapercave.com/wp/wp10853006.jpg";
+// Was `clusterDefinition.key`, i.e. the literal string "sgc". Kept as-is
+// because it renders in the login page's title; renaming it is a visible
+// change and belongs in its own commit, not in a teardown fuse fix.
+const TAILNET_BRAND_TITLE = "sgc";
+
 const _tailscaleBrand = new Brand(
   "tailscale",
   {
     domain: pulumi.interpolate`authentik.${globals.tailscaleDomain}`,
-    brandingLogo: clusterDefinition.icon,
-    brandingTitle: clusterDefinition.key,
-    brandingFavicon: clusterDefinition.favicon ?? "",
-    brandingDefaultFlowBackground: clusterDefinition.background ?? "/static/dist/assets/images/flow_background.jpg",
+    brandingLogo: TAILNET_BRAND_LOGO,
+    brandingTitle: TAILNET_BRAND_TITLE,
+    brandingFavicon: TAILNET_BRAND_FAVICON,
+    brandingDefaultFlowBackground: TAILNET_BRAND_BACKGROUND,
     flowAuthentication: authentikFlows.authenticationFlow.uuid,
     flowInvalidation: authentikFlows.providerLogoutFlow.uuid,
     flowUserSettings: authentikFlows.userSettingsFlow.uuid,


### PR DESCRIPTION
## Why

`pulumi destroy --stack sgc` is not safe to run today. Two independent fuses in
this repo fire on the destroy itself and take **four** stacks that nobody
touched down with it. Neither is recoverable by re-running the stack that
failed — the input they depend on is gone.

This PR removes both fuses. It changes no live infrastructure, no cluster
definition and nothing else SGC-related; `clusters/sgc.yaml`, the
`openbao-sgc-auth` block in `stacks/home`, and the `sgc` branch in
`stacks/applications` are all later steps with their own ordering.

> [!IMPORTANT]
> **Both changes must be merged and reconciled green BEFORE any SGC teardown
> runs.** They are a precondition of the destroy, not cleanup after it. Running
> `pulumi destroy --stack sgc` first means stacks/home, stacks/ocracoke,
> stacks/gulf-of-mexico and stacks/authentik all start failing, and the fix has
> to land under an outage instead of ahead of one.

## Fuse 1 — the backup-plan inventory throws for every consumer

`components/store/bao.ts` listed `stargate-command-backup-plan` in
`BACKUP_PLAN_KEYS`. `backupPlanKeys()` treats a **listed** key that is missing
from the `secrets/clusters/_inventory` LIST as fatal — deliberately, because a
silently smaller list quietly shrinks what the `BackupPlanDirector`s back up, a
failure with no symptom until someone needs a restore.

Destroying the `sgc` stack removes `clusters/_inventory/stargate-command-backup-plan`.
After that, `getBackupPlans()` throws for **every** consumer:

- `stacks/home/index.ts:22`
- `stacks/ocracoke/index.ts:16`
- `stacks/gulf-of-mexico/index.ts:15`

Three stacks, all failing on the next reconcile, none of which have anything to
do with SGC.

Removing an entry is the safe direction and the doc comment now says so
explicitly: the list is a **floor, not a ceiling**. A producer that still writes
its plan is still read whether or not it is named here — `stargate-command-backup-plan`
keeps being picked up right up until the destroy actually removes it. *Adding*
an entry is the dangerous direction, because that is a promise the producing
stack has already run its write (PLAN §G-8). That invariant is unchanged.

## Fuse 2 — `stacks/authentik` reads the SGC cluster definition

`stacks/authentik/index.ts` built the estate-wide **tailnet** authentik `Brand`
from `getCluster("Cluster: Stargate Command")`. `BaoStore.getCluster` throws on
a title it cannot find, so the moment `clusters/sgc.yaml` is deleted, the
estate's **SSO control stack** — the one every other stack's OIDC depends on —
fails on every run, over a cluster it does not otherwise touch.

The four branding inputs are now literals in the stack, so the brand no longer
depends on any cluster definition. This is a decoupling, not a restyle.

**Rendered brand, before → after (identical):**

| Field | Before (`Cluster: Stargate Command`) | After (literal) |
| --- | --- | --- |
| `brandingLogo` | `https://i.pinimg.com/originals/d6/1b/0f/d61b0fa0a759fd8baceedc9427246f7d.jpg` | same |
| `brandingFavicon` | `https://i.pinimg.com/originals/d6/1b/0f/d61b0fa0a759fd8baceedc9427246f7d.jpg` | same |
| `brandingDefaultFlowBackground` | `https://wallpapercave.com/wp/wp10853006.jpg` | same |
| `brandingTitle` | `clusterDefinition.key` → `"sgc"` | `"sgc"` |

No `Brand` field changes value, so `pulumi preview` should show no diff on this
resource beyond the loss of the `getCluster` read.

### Why not repoint at Alpha Site

Alpha Site is the obvious successor — authentik runs there now and
`clusters/alpha-site.yaml` declares the same `authentikDomain: iris.driscoll.tech`.
Its `icon`/`favicon`/`background` fields **are** populated, but with *different*
values:

- icon/favicon: `https://www.candyicons.com/style-image-examples/abstract-uYcg0JhhxK7bQ54KOtzsLX9U.png`
- background: `https://images.playground.com/43f58221d361456293f38739b6c69cea.jpeg`
- `key`: `alpha-site` (vs `sgc` for `brandingTitle`)

Adopting them would have been a visible rebrand of the tailnet login page
smuggled in on a decommission PR. It is also the wrong coupling in principle:
this brand covers the **tailnet**, not a cluster, so there is no cluster whose
branding it should inherit — which is exactly how it ended up wired to a cluster
that is being deleted.

`brandingTitle` therefore stays the literal string `"sgc"`, which is admittedly
a wart. It is commented as such. Restyling/renaming this brand is a one-line,
deliberate, visible change and belongs in its own commit.

## Tests

`components/store/bao.test.ts` updated to match, keeping the throw-on-missing
behaviour under test with the remaining keys, plus a new regression test that
pins the fuse itself: `backupPlanKeys` must **not** throw when
`stargate-command-backup-plan` is absent, and must still return it while it is
present.

The `resolveBaoPath("Stargate Command Backup Plan")` case became
`resolveBaoPath("Alpha Site Backup Plan")` — that assertion pins the
multi-word-title → single reserved `_inventory` slug rule, not the cluster, so
it keeps its meaning on a title that will still exist.

## Verification

- `npx tsx --test components/store/bao.test.ts` — **42 pass, 0 fail**
- `npx tsx --test components/store/clusters.test.ts components/store/refs.test.ts dynamic/1password/OnePasswordItem.test.ts scripts/op-to-bao/bao-paths.test.ts` — 41 pass, **1 pre-existing fail**: `scripts/op-to-bao/bao-paths.test.ts` cannot resolve `./mapping.ts`, which does not exist in the repo. Fails identically on `main`; untouched here.
- `mise run flate` (`flate test all …`) — **351 passed, 2 skipped** (the 2 skips are the usual missing-secret `GitRepository/vault` entries)
- `hk check` on the three changed files — **0 errors**. 7 warnings remain, all pre-existing and byte-identical to the same run against `main` (biome `noCommaOperator` in `bao.test.ts`, unused `log` import in `bao.ts`). Verified by stashing and re-running.
- `tsc --noEmit -p stacks/authentik/tsconfig.json` — the repo has a pile of pre-existing type errors (truenas client/types, `components/store/index.ts`, `clusters.test.ts`); **none** of them are in either changed source file.

One drive-by: a pre-existing mis-indented block in `stacks/authentik/index.ts`
(the `concealedFields`/`customMetadata` lines of the dual-write) is re-indented,
because biome flagged it as a hard error on any commit touching that file.

### Not verified

Nothing was run against live infrastructure — no `pulumi up`, `destroy`,
`refresh` or `preview`, and nothing in any cluster was touched. That the
authentik `Brand` shows a no-op diff is argued from the values above, not
observed from a preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
