### PR TITLE
feat(authentik): re-home the iris brand onto equestria before SGC's stack is destroyed

### DIFF
--- a/stacks/applications/index.ts
+++ b/stacks/applications/index.ts
@@ -30,6 +30,46 @@ if (clusterDefinition.key === "sgc" || clusterDefinition.key === "equestria") {
   );
 }
 
+// `iris.driscoll.tech`, re-homed onto equestria's instance.
+//
+// This brand used to be the SGC one: `clusters/sgc.yaml` carries
+// `authentikDomain: iris.driscoll.tech`, so the block above built it from the
+// `sgc` instance. Destroying that stack
+// (docs/cluster-consolidation/22-decommission-sgc.md) would take the brand with
+// it and drop a live login surface to authentik's default — `iris` is not an SGC
+// app, it is one of the estate's three public SSO names and it answers from
+// alpha-site today. Keeping the brand alive means giving it an owner that
+// survives, and equestria's instance is the one that does.
+//
+// The asset URLs are the exact values `clusters/sgc.yaml` carried, as literals:
+// the definition is deleted later in the same teardown, and this brand must not
+// acquire a dependency on it. So this is a re-home, not a restyle — the rendered
+// brand is byte-identical to what is live now. Alpha Site declares the same
+// `authentikDomain` but different imagery, and is `type: dockge` so it has no
+// applications instance of its own; adopting its assets would have been a
+// visible change nobody asked for.
+//
+// ORDERING: authentik keys brands by domain, so this cannot coexist with the
+// `sgc` instance's copy. It must land AFTER `pulumi destroy --stack sgc`, or
+// equestria's run fails on a duplicate domain. Between the two, `iris` renders
+// authentik's default brand.
+if (clusterDefinition.key === "equestria") {
+  const _irisBrand = new authentik.Brand(
+    "iris",
+    {
+      domain: "iris.driscoll.tech",
+      brandingLogo: "https://i.pinimg.com/originals/d6/1b/0f/d61b0fa0a759fd8baceedc9427246f7d.jpg",
+      brandingTitle: "Stargate Command",
+      brandingFavicon: "https://i.pinimg.com/originals/d6/1b/0f/d61b0fa0a759fd8baceedc9427246f7d.jpg",
+      brandingDefaultFlowBackground: "https://wallpapercave.com/wp/wp10853006.jpg",
+      flowAuthentication: outputs.flows.authenticationFlow,
+      flowInvalidation: outputs.flows.providerLogoutFlow,
+      flowUserSettings: outputs.flows.userSettingsFlow,
+    },
+    { deleteBeforeReplace: true },
+  );
+}
+
 switch (clusterDefinition.type) {
   case "kubernetes":
     await kubernetesApplications(globals, outputs, clusterDefinition);


### PR DESCRIPTION
> **Merge order matters: this must land AFTER `pulumi destroy --stack sgc`.** See *Ordering* below.

## Why

`iris.driscoll.tech` is one of the estate's three public SSO names and answers from alpha-site today. Its authentik `Brand`, though, is still built by the **`sgc`** instance of `stacks/applications` — because `clusters/sgc.yaml` is what carries `authentikDomain: iris.driscoll.tech`, and [index.ts:16](stacks/applications/index.ts:16) brands only `sgc` and `equestria`.

So destroying the `sgc` stack takes the brand with it and drops a live login surface to authentik's default. That has nothing to do with the SGC apps actually being retired, and [piece 22](docs/cluster-consolidation/22-decommission-sgc.md)'s risk table used to describe this resource as "live-but-unused". It is live and used.

Keeping it means giving it an owner that survives the teardown. That is equestria's instance.

## What this is not

**Not a restyle.** The asset URLs are exactly what `clusters/sgc.yaml` carries today, so the rendered brand is byte-identical:

| | value |
|---|---|
| logo + favicon | `…/d61b0fa0a759fd8baceedc9427246f7d.jpg` |
| background | `…/wp10853006.jpg` |
| title | `Stargate Command` |

They are **literals, not a cluster-definition read**. `clusters/sgc.yaml` is deleted later in the same teardown, and a brand that outlives it must not depend on it — the same decoupling #875 made for the tailnet brand, for the same reason.

Alpha Site declares the same `authentikDomain: iris.driscoll.tech` but different imagery, and being `type: dockge` it has no applications instance of its own. Adopting its assets would have been a visible change nobody asked for.

## Ordering

authentik keys brands by **domain**, so this cannot coexist with the `sgc` instance's copy. Sequence:

1. `pulumi destroy --stack sgc` — deletes the old brand; `iris` renders authentik's default in the interim
2. Merge this; equestria's next run recreates it

Merging this **first** means equestria's stack fails on a duplicate domain — the same claim-before-release shape that has bitten this migration twice already, once on the SSO names and once on the cluster-wide DNS records.

## Verification

- [x] `hk check` — all steps pass, including biome
- [x] No new type diagnostics in the changed file
- [ ] Not previewed — `vals-run` cannot resolve credentials in this environment (`.config/bao-approle.sops.yaml` does not decrypt with either local age key), so the byte-identical claim is argued from the values above rather than observed from a diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
