### PR TITLE
feat(alpha-site): drop the "(Alpha Site)" suffix from authentik's display name

### DIFF
--- a/docker/alpha-site/authentik/definition.yaml
+++ b/docker/alpha-site/authentik/definition.yaml
@@ -5,16 +5,22 @@ kind: ApplicationDefinition
 metadata:
   name: authentik
 spec:
-  # "(Alpha Site)", not bare "Authentik", and this is load-bearing while SGC is
-  # still live. addGatusInstances builds each endpoint's Gatus name from
-  # spec.name, and Gatus enforces global uniqueness on (name, group) across the
-  # whole merged config from every cluster — it PANICS on a duplicate rather than
-  # skipping it, which takes down monitoring for the entire estate, not just this
-  # endpoint. That exact failure happened on 2026-08-13 staging tsidp; see
-  # docs/cluster-consolidation/27-migration-churn-failure-modes.md. SGC's copy
-  # publishes ("Authentik ", "Applications"), so this must not be able to collide.
-  # Rename to plain "Authentik" only once SGC's definition is gone.
-  name: Authentik (Alpha Site)
+  # Plain "Authentik" — the suffix is retired, along with SGC's copy.
+  #
+  # This carried "(Alpha Site)" because addGatusInstances builds each endpoint's
+  # Gatus name from spec.name, and Gatus enforces uniqueness on (name, group)
+  # across the merged config from every cluster — it PANICS on a duplicate rather
+  # than skipping it, taking down monitoring for the whole estate. That happened
+  # on 2026-08-13 staging tsidp; see
+  # docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  #
+  # Two things retire it. SGC's authentik ApplicationDefinition is gone with the
+  # `sgc` applications stack, so the ("Authentik ", "Applications") entry it
+  # published no longer exists. And the collision was narrower than this comment
+  # used to claim: verified against the live merged config, SGC's entry sat in
+  # group "Applications" while this one sits in "Infrastructure" (from `category`
+  # below), so the two never shared a key even before the teardown.
+  name: Authentik
   category: Infrastructure
   description: Authentik is an open-source identity provider focused on flexibility and security.
   # The estate's primary SSO name — this host answers for it as of the cutover.


### PR DESCRIPTION
> **Merge order: land this AFTER `pulumi destroy --stack sgc`.** Same queue as #879. The reason is weaker than it looks — see *What I found* — but the downside is estate-wide monitoring, so it waits.

## Why the suffix existed

`addGatusInstances` derives each endpoint's Gatus name from `spec.name`. Gatus enforces uniqueness on `(name, group)` across the merged config from **every** cluster, and it **panics** on a duplicate rather than skipping it — taking estate-wide monitoring down, as it did on 2026-08-13 while staging tsidp ([piece 27](docs/cluster-consolidation/27-migration-churn-failure-modes.md)). While SGC published its own `Authentik`, the distinct name was the guard.

SGC's `ApplicationDefinition` goes with the `sgc` applications stack, so that entry stops existing and the guard has nothing left to protect.

## What I found, and it corrects the old comment

The comment being replaced asserted that SGC's copy publishes `("Authentik ", "Applications")` and that this one "must not be able to collide." Read off the **live merged Gatus config** on `dockge-as`:

| source | name | group |
|---|---|---|
| `uptime-cluster-apps-sgc.yaml:34` | `"Authentik "` | `Applications` |
| `uptime-proxmox-host-alpha-site.yaml:42` | `"Authentik (Alpha Site) "` | `Infrastructure` |

The groups differ — `Infrastructure` comes from this file's own `category`. So the two **never shared a key**, even with both live, and the rename would very likely have been safe at any point. The suffix was guarding against a collision that could not happen.

I have still queued this behind the destroy rather than acting on that. The upside is a cosmetic name; the downside if I've misread Gatus's key semantics is every check in the estate going dark. Not a trade worth taking when waiting costs nothing — but the evidence is here if you'd rather land it early.

## Scope

One file, one field, plus the comment rewritten to record the above. No other reference to `Authentik (Alpha Site)` exists in the tree.

## Verification

- [x] `hk check` — all steps pass including yamllint
- [x] Live Gatus config read directly for the name/group evidence above
- [ ] Not observed post-rename — that needs the destroy to land first

🤖 Generated with [Claude Code](https://claude.com/claude-code)
