### PR TITLE
feat(mise): migrate the cluster repos' taskfiles into mise tasks

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -9,6 +9,16 @@ kubectl = "1.36.3"
 "github:cloudnative-pg/cloudnative-pg" = { version = "v1.30.0", bin = "kubectl-cnpg" }
 powershell-core = "7.6.5"
 1password-cli = "2.39.0"
+# Talos tooling for the `talos:*` tasks under .config/mise/tasks/talos/, ported
+# from equestria-cluster alongside the talos/ tree in 9cd47c0a.
+#
+# `talosctl` MUST stay in step with talos/talenv.yaml's talosVersion. That is
+# not a convention, it is enforced: `mise run talos:validate-config` compares
+# the two and refuses to validate a machine config with a mismatched schema.
+# Renovate bumps talenv.yaml from the ghcr.io/siderolabs/installer tag; this
+# line has to move with it.
+talosctl = "1.13.8"
+talhelper = "3.1.16"
 yq = "4.53.3"
 jq = "1.8.2"
 task = "3.52.0"
@@ -142,6 +152,27 @@ BAO_AUTH_METHOD = "approle"
 BAO_ROLE_ID = "ref+sops://{{config_root}}/.config/bao-approle.sops.yaml#/role_id"
 BAO_SECRET_ID = "ref+sops://{{config_root}}/.config/bao-approle.sops.yaml#/secret_id"
 SOPS_AGE_KEY_FILE = "{{config_root}}/age.key"
+
+# Where talhelper writes the generated admin talosconfig, and where every
+# `talos:*` task expects to find it. Set globally so an ad-hoc `talosctl` in
+# this repo targets equestria too, matching what equestria-cluster's Taskfile
+# did with its `env:` block.
+#
+# This path does not exist until `mise run talos:genconfig` has run —
+# talos/clusterconfig/.gitignore excludes the generated files, including this
+# one. Pointing an env var at a missing file is inert; talosctl only complains
+# when you actually use it.
+#
+# NOT pointed at the tracked talos/talosconfig: that one carries
+# `endpoints: []`, so every command through it would need an explicit
+# `--endpoints`.
+#
+# Note what is deliberately NOT set here: KUBECONFIG. equestria-cluster's
+# Taskfile pinned it to a repo-local ./kubeconfig; this repo carries no such
+# file, and setting it to a missing path would break every kubectl invocation
+# for anyone using their own. The migrated kubectl/flux tasks therefore follow
+# the ambient context — check `kubectl config current-context` first.
+TALOSCONFIG = "{{config_root}}/talos/clusterconfig/talosconfig"
 
 # UNIFI_HOST = "unifi.driscoll.tech"
 # UNIFI_USERNAME = "op://Eris/unifipoller/username"

--- a/.config/mise/tasks/flux/delete-kustomization
+++ b/.config/mise/tasks/flux/delete-kustomization
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#MISE description="Force-delete a stuck Flux Kustomization by stripping its finalizer, then re-reconcile cluster-apps"
+#USAGE arg "<namespace>" help="Namespace of the Kustomization"
+#USAGE arg "<name>" help="Name of the Kustomization"
+#
+# Ported from equestria-cluster/.taskfiles/flux/Taskfile.yaml (`flux:delete-kustomization`).
+#
+# For a Kustomization wedged in Terminating: removing the finalizer is what lets
+# the delete complete, and `flux delete` on its own will not do it.
+#
+# `cluster-apps` is the parent that owns ./kubernetes/apps in this repo
+# (kubernetes/flux/cluster/ks.yaml), so reconciling it is what re-creates the
+# child if it should still exist. That name is unchanged from the source repo.
+#
+# Follows the AMBIENT kubeconfig/context.
+# shellcheck disable=SC2154  # usage_namespace / usage_name are injected by
+#                            mise from the #USAGE headers above; shellcheck
+#                            cannot see where they are assigned.
+set -Eeuo pipefail
+
+printf 'Removing finalizer from Kustomization %s/%s\n' "${usage_namespace}" "${usage_name}"
+kubectl -n "${usage_namespace}" patch kustomization "${usage_name}" \
+  --type=json -p='[{"op": "remove", "path": "/metadata/finalizers"}]'
+flux -n "${usage_namespace}" delete kustomization "${usage_name}" --silent
+
+printf 'Reconciling cluster-apps to apply changes\n'
+flux -n flux-system reconcile kustomization cluster-apps

--- a/.config/mise/tasks/flux/reconcile
+++ b/.config/mise/tasks/flux/reconcile
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#MISE description="Force Flux to pull the three GitRepositories and re-reconcile the root"
+#
+# Ported from equestria-cluster/Taskfile.yaml (the root `reconcile` task).
+#
+# All three sources named here exist in this repo's Flux tree:
+#   flux-system     — kubernetes/flux/cluster/ks.yaml (the root, this repo)
+#   home-operations — kubernetes/apps/flux-system/repositories/home-operations.yaml
+#   vault           — kubernetes/apps/flux-system/repositories/vault.yaml
+#
+# Follows the AMBIENT kubeconfig/context: equestria-cluster's Taskfile pinned
+# KUBECONFIG to a repo-local file and this repo carries no such file, so check
+# `kubectl config current-context` first.
+set -Eeuo pipefail
+
+flux --namespace flux-system reconcile source git flux-system
+flux --namespace flux-system reconcile source git home-operations
+flux --namespace flux-system reconcile source git vault
+flux --namespace flux-system reconcile kustomization flux-system --with-source

--- a/.config/mise/tasks/k8s/cleanup-pods
+++ b/.config/mise/tasks/k8s/cleanup-pods
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#MISE description="Delete Failed and Succeeded pods across all namespaces"
+#
+# Ported from equestria-cluster/.taskfiles/k8s/Taskfile.yaml (`kubernetes:cleanup-pods`).
+#
+# PORTED AS-IS, INCLUDING THE MISMATCH. The original description said
+# "Failed/Pending/Succeeded" but its matrix only ever listed Failed and
+# Succeeded — and correctly so: a Pending pod is one the scheduler has not
+# placed yet, and deleting those in bulk would fight the scheduler rather than
+# clean up after it. The description here matches the code.
+#
+# Follows the AMBIENT kubeconfig/context.
+set -Eeuo pipefail
+
+for phase in Failed Succeeded; do
+  kubectl delete pods --field-selector "status.phase=${phase}" -A --ignore-not-found=true
+done

--- a/.config/mise/tasks/k8s/restart-flux
+++ b/.config/mise/tasks/k8s/restart-flux
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#MISE description="Roll every Deployment, StatefulSet and DaemonSet in flux-system"
+#
+# Ported from equestria-cluster/.taskfiles/k8s/Taskfile.yaml (`kubernetes:restart-flux`).
+# Follows the AMBIENT kubeconfig/context.
+set -Eeuo pipefail
+
+kubectl rollout restart deployment,statefulset,daemonset -n flux-system

--- a/.config/mise/tasks/k8s/restart-kube
+++ b/.config/mise/tasks/k8s/restart-kube
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#MISE description="Roll every Deployment, StatefulSet and DaemonSet in kube-system"
+#
+# Ported from equestria-cluster/.taskfiles/k8s/Taskfile.yaml (`kubernetes:restart-kube`).
+# Follows the AMBIENT kubeconfig/context.
+set -Eeuo pipefail
+
+kubectl rollout restart deployment,statefulset,daemonset -n kube-system

--- a/.config/mise/tasks/talos/add-node
+++ b/.config/mise/tasks/talos/add-node
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#MISE description="Add a node that is still in maintenance mode (applies config over the insecure API)"
+#MISE dir="{{config_root}}/talos"
+#MISE depends=["talos:genconfig"]
+#USAGE arg "<ip>" help="Maintenance-mode node IP, as it appears in talos/talconfig.yaml"
+#USAGE flag "--mode <mode>" default="auto" help="talosctl apply-config --mode (auto|no-reboot|reboot|staged|try)"
+#
+# Ported from equestria-cluster/.taskfiles/talos/Taskfile.yaml (`talos:add-node`).
+#
+# The only difference from talos:apply-node is `--insecure`: a node in
+# maintenance mode has no machine config yet, so it has no client certificate to
+# authenticate against and the normal path cannot reach it.
+# shellcheck disable=SC2154  # usage_ip / usage_mode are injected by mise from
+#                            the #USAGE headers above; shellcheck cannot see
+#                            where they are assigned.
+set -Eeuo pipefail
+
+talhelper gencommand apply --node "${usage_ip}" --extra-flags "--insecure --mode=${usage_mode}" | bash

--- a/.config/mise/tasks/talos/apply
+++ b/.config/mise/tasks/talos/apply
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#MISE description="Apply the rendered Talos config to every node"
+#MISE dir="{{config_root}}/talos"
+#MISE depends=["talos:genconfig"]
+#USAGE flag "--mode <mode>" default="auto" help="talosctl apply-config --mode (auto|no-reboot|reboot|staged|try)"
+#
+# Ported from equestria-cluster/.taskfiles/talos/Taskfile.yaml (`talos:apply`).
+# go-task's `MODE=…` variable becomes a `--mode` flag; `mise run talos:apply
+# --mode reboot` replaces `task talos:apply MODE=reboot`.
+# shellcheck disable=SC2154  # usage_mode is injected by mise from the #USAGE
+#                            header above; shellcheck cannot see where it is
+#                            assigned.
+set -Eeuo pipefail
+
+talhelper gencommand apply --extra-flags "--mode=${usage_mode}" | bash

--- a/.config/mise/tasks/talos/apply-node
+++ b/.config/mise/tasks/talos/apply-node
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#MISE description="Apply the rendered Talos config to one node"
+#MISE dir="{{config_root}}/talos"
+#MISE depends=["talos:genconfig"]
+#USAGE arg "<ip>" help="Node IP address, as it appears in talos/talconfig.yaml"
+#USAGE flag "--mode <mode>" default="auto" help="talosctl apply-config --mode (auto|no-reboot|reboot|staged|try)"
+#
+# Ported from equestria-cluster/.taskfiles/talos/Taskfile.yaml (`talos:apply-node`).
+#
+#   mise run talos:apply-node 10.10.206.10
+#   mise run talos:apply-node 10.10.206.10 --mode reboot
+# shellcheck disable=SC2154  # usage_ip / usage_mode are injected by mise from
+#                            the #USAGE headers above; shellcheck cannot see
+#                            where they are assigned.
+# shellcheck disable=SC2016  # the backticks below are prose emphasis in an
+#                            operator-facing message, not a command
+#                            substitution -- the single quotes are intentional.
+set -Eeuo pipefail
+
+# The original's `talosctl --nodes {{.IP}} get machineconfig` precondition, kept
+# because it is the one that distinguishes "wrong IP" from "node in maintenance
+# mode" — the latter needs talos:add-node (--insecure), not this task, and
+# without the check that surfaces as a bare certificate error.
+talosctl --nodes "${usage_ip}" get machineconfig >/dev/null || {
+  printf 'talos:apply-node: %s did not answer an authenticated Talos API call.\n' "${usage_ip}" >&2
+  printf 'talos:apply-node: a node still in maintenance mode needs `mise run talos:add-node %s`.\n' "${usage_ip}" >&2
+  exit 1
+}
+
+talhelper gencommand apply --node "${usage_ip}" --extra-flags "--mode=${usage_mode}" | bash

--- a/.config/mise/tasks/talos/backup-etcd
+++ b/.config/mise/tasks/talos/backup-etcd
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#MISE description="Take an etcd snapshot from a control-plane node before a major upgrade"
+#MISE dir="{{config_root}}/talos"
+#
+# Ported from equestria-cluster/.taskfiles/talos/Taskfile.yaml (`talos:backup-etcd`).
+#
+# The snapshot lands in talos/ as etcd-pre-upgrade-<timestamp>.db. The repo root
+# .gitignore already carries `*.db*`, so it cannot be committed by accident —
+# but it also is not backed up anywhere. Move it somewhere durable if it matters.
+#
+# Uses kubectl to find a control-plane node, so it follows the AMBIENT
+# kubeconfig/context.
+set -Eeuo pipefail
+
+cp_node_ip="$(kubectl get nodes -l node-role.kubernetes.io/control-plane \
+  -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')"
+
+[[ -n "${cp_node_ip}" ]] || {
+  printf 'talos:backup-etcd: no control-plane node returned — wrong kubeconfig context?\n' >&2
+  exit 1
+}
+
+snapshot="etcd-pre-upgrade-$(date +%Y%m%d-%H%M%S).db"
+printf 'Backing up etcd from %s into talos/%s\n' "${cp_node_ip}" "${snapshot}"
+talosctl -n "${cp_node_ip}" etcd snapshot "${snapshot}"
+printf 'Backup completed successfully\n'

--- a/.config/mise/tasks/talos/genconfig
+++ b/.config/mise/tasks/talos/genconfig
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#MISE description="Render Talos machine configs into talos/clusterconfig with talhelper"
+#MISE dir="{{config_root}}/talos"
+#
+# Ported from equestria-cluster/.taskfiles/talos/Taskfile.yaml (`talos:generate-config`).
+# Renamed to `genconfig` to match the talhelper subcommand it wraps — every
+# other task in this namespace is named after its talhelper verb.
+#
+# This is the root of the namespace: every task that needs a rendered machine
+# config or a working talosconfig `depends` on it, which is what replaces
+# go-task's `deps: [generate-config]`.
+#
+# Outputs land in talos/clusterconfig/, which is gitignored per node (see
+# talos/clusterconfig/.gitignore) — including the generated `talosconfig` that
+# $TALOSCONFIG points at.
+set -Eeuo pipefail
+
+# go-task expressed these as `preconditions:`; mise has no equivalent, so they
+# are inline. The `which talhelper / talosctl` checks the original carried are
+# dropped on purpose — both are pinned in .config/mise.toml [tools], so mise
+# installs them before the task body ever runs.
+[[ -f talconfig.yaml ]] || {
+  printf 'talos:genconfig: talos/talconfig.yaml is missing.\n' >&2
+  exit 1
+}
+
+[[ -f "${MISE_CONFIG_ROOT}/.sops.yaml" ]] || {
+  printf 'talos:genconfig: .sops.yaml is missing at the repo root.\n' >&2
+  exit 1
+}
+
+# talsecret.sops.yaml is SOPS-encrypted, so genconfig cannot decrypt it without
+# the age key. Absent, sops fails with a generic "no matching keys" that names
+# neither the file nor the variable — worth catching by name.
+[[ -f "${SOPS_AGE_KEY_FILE}" ]] || {
+  printf 'talos:genconfig: no age key at %s (SOPS_AGE_KEY_FILE).\n' "${SOPS_AGE_KEY_FILE}" >&2
+  printf 'talos:genconfig: it is gitignored, so a fresh clone or a git worktree will not have it.\n' >&2
+  exit 1
+}
+
+talhelper genconfig

--- a/.config/mise/tasks/talos/preflight-upgrade
+++ b/.config/mise/tasks/talos/preflight-upgrade
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#MISE description="Read-only gate to run before a Talos or Kubernetes minor upgrade"
+#MISE dir="{{config_root}}/talos"
+#
+# Ported from equestria-cluster/.taskfiles/talos/Taskfile.yaml (`talos:preflight-upgrade`).
+#
+# Read-only: it inspects and exits non-zero, it never changes anything. Run it
+# before talos:upgrade / talos:upgrade-k8s.
+#
+# Deliberately NOT wired as a `depends` of those tasks. It gates on live cluster
+# state (nodes Ready, VolSync quiet), so making it a hard dependency would mean
+# a mid-upgrade retry of a single node could not run while the cluster is —
+# correctly — still settling.
+#
+# The original's `echo "\nSection"` printed a literal backslash-n under bash,
+# whose builtin echo does not interpret escapes without -e. Uses printf here.
+#
+# Uses kubectl, so it follows the AMBIENT kubeconfig/context — this repo does
+# not pin KUBECONFIG the way equestria-cluster's Taskfile did.
+set -Eeuo pipefail
+
+printf 'Target versions from talenv.yaml\n'
+printf '  Talos:      %s\n' "$(yq '.talosVersion' ./talenv.yaml)"
+printf '  Kubernetes: %s\n' "$(yq '.kubernetesVersion' ./talenv.yaml)"
+
+printf '\nClient tooling versions\n'
+kubectl version --client
+talosctl version --client
+
+printf '\nCluster node status\n'
+kubectl get nodes -o wide
+not_ready_count="$(kubectl get nodes --no-headers | awk '$2 != "Ready" { print $1 }' | wc -l | tr -d ' ')"
+if [[ "${not_ready_count}" != "0" ]]; then
+  printf 'One or more nodes are not Ready. Aborting preflight.\n' >&2
+  exit 1
+fi
+
+control_plane_nodes="$(kubectl get nodes -l node-role.kubernetes.io/control-plane -o json \
+  | jq -r '[.items[].status.addresses[] | select(.type == "InternalIP") | .address] | join(",")')"
+all_nodes="$(kubectl get nodes -o json \
+  | jq -r '[.items[].status.addresses[] | select(.type == "InternalIP") | .address] | unique | join(",")')"
+init_node="${control_plane_nodes%%,*}"
+
+printf '\nTalos API health\n'
+for node in ${all_nodes//,/ }; do
+  printf '  checking Talos API on %s via endpoint %s\n' "${node}" "${init_node}"
+  talosctl --nodes "${node}" --endpoints "${init_node}" get machinestatus >/dev/null
+done
+
+printf '\nChecking VolSync synchronization state\n'
+if kubectl get crd replicationsources.volsync.backube >/dev/null 2>&1; then
+  unsynced="$(kubectl get replicationsources.volsync.backube -A -o json \
+    | jq -r '.items[]? | select(any(.status.conditions[]?; .type == "Synchronizing" and .status == "True")) | "\(.metadata.namespace)/\(.metadata.name)"')"
+  if [[ -n "${unsynced}" ]]; then
+    printf 'ReplicationSource objects still synchronizing:\n%s\n' "${unsynced}" >&2
+    exit 1
+  fi
+else
+  printf 'ReplicationSource CRD not found; skipping VolSync gate.\n'
+fi
+
+printf '\nPreflight checks passed.\n'

--- a/.config/mise/tasks/talos/reboot
+++ b/.config/mise/tasks/talos/reboot
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#MISE description="Roll a reboot through the control-plane nodes, one at a time"
+#MISE dir="{{config_root}}/talos"
+#MISE depends=["talos:genconfig"]
+#
+# Ported from equestria-cluster/.taskfiles/talos/Taskfile.yaml (`talos:reboot`).
+#
+# PORTED AS-IS, INCLUDING THE MISMATCH. The original is described as "reboot the
+# cluster without downtime" but its node selector is
+# `-l node-role.kubernetes.io/control-plane`, so workers are never touched. The
+# description here says what the code does rather than what the old one claimed;
+# widening the selector would change what a destructive task does, which is a
+# decision for a separate change, not a mechanical port.
+#
+# The unused `MODE` var the original declared is dropped — nothing in the body
+# ever read it.
+#
+# Uses kubectl, so it follows the AMBIENT kubeconfig/context. Unlike the source
+# repo this one does not pin KUBECONFIG to a repo-local file; check
+# `kubectl config current-context` before running.
+set -Eeuo pipefail
+
+nodes="$(kubectl get nodes -l node-role.kubernetes.io/control-plane \
+  -o jsonpath='{range .items[*]}{.status.addresses[?(@.type=="InternalIP")].address}{" "}{end}')"
+
+[[ -n "${nodes// /}" ]] || {
+  printf 'talos:reboot: no control-plane nodes returned — wrong kubeconfig context?\n' >&2
+  exit 1
+}
+
+for node in ${nodes}; do
+  printf 'Rebooting %s\n' "${node}"
+  talosctl reboot -n "${node}" --wait
+  sleep 10
+done

--- a/.config/mise/tasks/talos/reset
+++ b/.config/mise/tasks/talos/reset
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#MISE description="DESTRUCTIVE: wipe every node and return the cluster to maintenance mode"
+#MISE dir="{{config_root}}/talos"
+#MISE depends=["talos:genconfig"]
+#MISE confirm="This DESTROYS the cluster and resets every node to maintenance mode. Continue?"
+#
+# Ported from equestria-cluster/.taskfiles/talos/Taskfile.yaml (`talos:reset`).
+# go-task's `prompt:` becomes mise's `confirm=`.
+#
+# STATE and EPHEMERAL are both wiped, so this takes etcd with it. There is no
+# undo and no partial form — `talos:reset-node` is the one-node version.
+set -Eeuo pipefail
+
+talhelper gencommand reset \
+  --extra-flags="--reboot --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL --graceful=false --wait=false" | bash

--- a/.config/mise/tasks/talos/reset-node
+++ b/.config/mise/tasks/talos/reset-node
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#MISE description="DESTRUCTIVE: wipe one node and return it to maintenance mode"
+#MISE dir="{{config_root}}/talos"
+#MISE depends=["talos:genconfig"]
+#MISE confirm="This wipes the node's STATE and EPHEMERAL partitions. Continue?"
+#USAGE arg "<ip>" help="Node IP address, as it appears in talos/talconfig.yaml"
+#
+# Ported from equestria-cluster/.taskfiles/talos/Taskfile.yaml (`talos:reset-node`).
+#
+# `--graceful=false` skips the etcd leave, so on a control-plane node the member
+# has to be removed from etcd separately. Bring the node back with
+# `mise run talos:add-node <ip>`.
+# shellcheck disable=SC2154  # usage_ip is injected by mise from the #USAGE
+#                            header above; shellcheck cannot see where it is
+#                            assigned.
+set -Eeuo pipefail
+
+talhelper gencommand reset --node "${usage_ip}" \
+  --extra-flags="--reboot --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL --graceful=false --wait=false" | bash

--- a/.config/mise/tasks/talos/rotate-ca
+++ b/.config/mise/tasks/talos/rotate-ca
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#MISE description="Rotate the Talos API CA — the only way to revoke a leaked talosconfig"
+#MISE dir="{{config_root}}/talos"
+#USAGE arg "<ip>" help="Control-plane IP, as it appears in talos/talconfig.yaml"
+#
+# Not a port. Neither source repo had this task; it was written for the
+# 2026-08-17 incident in which talos/talosconfig — an os:admin client
+# certificate and its unencrypted private key — was committed to a public repo.
+#
+# Talos has no CRL. A leaked client certificate cannot be revoked, and issuing
+# a replacement admin cert leaves the leaked one valid until it expires.
+# Rotating the CA is the only thing that invalidates it.
+#
+# Read docs/runbooks/talos-ca-rotation.md first — in particular the talsecret
+# step, which no upstream doc covers and which this task cannot do for you.
+#
+# No `#MISE confirm=`: that prompts BEFORE the task runs, which would ask for
+# consent before showing the dry run. The gate here is deliberately after it.
+# shellcheck disable=SC2154  # usage_ip is injected by mise from the #USAGE
+#                            header above; shellcheck cannot see the assignment.
+set -euo pipefail
+
+node="${usage_ip}"
+
+echo "==> Dry run against ${node}. Nothing changes yet."
+echo
+talosctl -n "$node" rotate-ca --dry-run=true --talos=true --kubernetes=false
+
+cat <<'WARN'
+
+────────────────────────────────────────────────────────────────────────
+Read the plan above before continuing.
+
+Scoped to --kubernetes=false. A leaked talosconfig is a Talos-API
+credential; the Kubernetes CA is a separate rotation with its own blast
+radius. Widen it only if a kubeconfig leaked too.
+
+After this completes you MUST:
+  1. talosctl config merge ./talosconfig   &&  rm ./talosconfig
+  2. Write the new CA into talos/talsecret.sops.yaml (sops, in place)
+
+Step 2 is not optional and not in the upstream docs. talhelper renders
+machine configs from talsecret, and `rotate-ca` cannot update it
+(siderolabs/talos#12816 — --with-secrets is proposed, unimplemented).
+Leave it stale and the next `mise run talos:genconfig` renders the OLD
+CA straight back, undoing this.
+
+Anyone holding a talosconfig you have not recorded loses access now.
+────────────────────────────────────────────────────────────────────────
+
+WARN
+
+read -r -p "Type 'rotate' to proceed, anything else to abort: " reply
+if [[ "$reply" != "rotate" ]]; then
+  echo "Aborted. Nothing was changed."
+  exit 1
+fi
+
+echo "==> Rotating."
+talosctl -n "$node" rotate-ca --dry-run=false --talos=true --kubernetes=false
+
+cat <<'NEXT'
+
+==> The command finished. It is NOT remediated until you have:
+
+  1. talosctl config merge ./talosconfig   &&  rm ./talosconfig
+  2. Updated certs.os.{crt,key} in talos/talsecret.sops.yaml
+  3. Confirmed `mise run talos:genconfig` now renders the NEW CA
+  4. Proven the old credential is dead:
+       talosctl --talosconfig ./old-talosconfig -n <node> version   # must FAIL
+
+Step 4 is the gate — not this command exiting zero.
+See docs/runbooks/talos-ca-rotation.md.
+NEXT

--- a/.config/mise/tasks/talos/rotate-ca
+++ b/.config/mise/tasks/talos/rotate-ca
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Rotate the Talos API CA — the only way to revoke a leaked talosconfig"
 #MISE dir="{{config_root}}/talos"
+#MISE depends=["talos:validate-config"]
 #USAGE arg "<ip>" help="Control-plane IP, as it appears in talos/talconfig.yaml"
 #
 # Not a port. Neither source repo had this task; it was written for the
@@ -13,6 +14,15 @@
 #
 # Read docs/runbooks/talos-ca-rotation.md first — in particular the talsecret
 # step, which no upstream doc covers and which this task cannot do for you.
+#
+# `depends` is talos:validate-config, not talos:genconfig. Both gate on a
+# renderable config and a talosctl matching talenv.yaml, which is worth having
+# before touching the cluster's trust root. But note validate-config itself
+# depends on genconfig, so this DOES render ./clusterconfig/*.yaml as a side
+# effect — from the CURRENT talsecret, i.e. with the OLD CA. Those files are
+# stale the moment the rotation succeeds. That is called out again in the
+# closing output, because freshly-written configs sitting there right after a
+# rotation are exactly what would tempt someone into applying them.
 #
 # No `#MISE confirm=`: that prompts BEFORE the task runs, which would ask for
 # consent before showing the dry run. The gate here is deliberately after it.
@@ -70,5 +80,10 @@ cat <<'NEXT'
        talosctl --talosconfig ./old-talosconfig -n <node> version   # must FAIL
 
 Step 4 is the gate — not this command exiting zero.
+
+./clusterconfig/*.yaml was rendered by the validate-config dependency
+BEFORE the rotation, so it carries the OLD CA. Do not apply it. It
+becomes correct once step 2 lands and you re-run talos:genconfig.
+
 See docs/runbooks/talos-ca-rotation.md.
 NEXT

--- a/.config/mise/tasks/talos/upgrade
+++ b/.config/mise/tasks/talos/upgrade
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#MISE description="Upgrade Talos on every node to talenv.yaml's talosVersion"
+#MISE dir="{{config_root}}/talos"
+#MISE depends=["talos:validate-config"]
+#
+# Ported from equestria-cluster/.taskfiles/talos/Taskfile.yaml (`talos:upgrade`).
+#
+# Depends on validate-config, not genconfig: an upgrade is the one operation
+# where a config the running Talos version would reject takes the node down
+# rather than erroring in the terminal.
+#
+# Run `mise run talos:preflight-upgrade` first for a minor-version bump.
+set -Eeuo pipefail
+
+talhelper gencommand upgrade --extra-flags "--timeout=20m --wait" | bash

--- a/.config/mise/tasks/talos/upgrade-k8s
+++ b/.config/mise/tasks/talos/upgrade-k8s
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#MISE description="Upgrade Kubernetes to talenv.yaml's kubernetesVersion"
+#MISE dir="{{config_root}}/talos"
+#MISE depends=["talos:validate-config"]
+#
+# Ported from equestria-cluster/.taskfiles/talos/Taskfile.yaml (`talos:upgrade-k8s`).
+#
+# The target version is read from talenv.yaml rather than passed in, so this
+# task always converges on what the repo declares. To step through an
+# intermediate release (Kubernetes does not support skipping a minor), use
+# `mise run talos:upgrade-k8s-to <version>`.
+set -Eeuo pipefail
+
+kubernetes_version="$(yq '.kubernetesVersion' ./talenv.yaml)"
+
+talhelper gencommand upgrade-k8s --extra-flags "--to '${kubernetes_version}'" | bash

--- a/.config/mise/tasks/talos/upgrade-k8s-to
+++ b/.config/mise/tasks/talos/upgrade-k8s-to
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#MISE description="Upgrade Kubernetes to an explicit intermediate version, without editing talenv.yaml"
+#MISE dir="{{config_root}}/talos"
+#MISE depends=["talos:validate-config"]
+#USAGE arg "<version>" help="Kubernetes version to step to, e.g. v1.35.4"
+#
+# Ported from equestria-cluster/.taskfiles/talos/Taskfile.yaml (`talos:upgrade-k8s-to`).
+#
+# Exists because Kubernetes refuses to skip a minor version. Going v1.34 -> v1.36
+# means running this once for v1.35.x and only then `talos:upgrade-k8s`.
+#
+# The version is handed over as a SECOND --env-file that shadows talenv.yaml's
+# kubernetesVersion, so talenv.yaml itself is never edited and never left
+# holding an intermediate value if the run is interrupted.
+# shellcheck disable=SC2154  # usage_version is injected by mise from the
+#                            #USAGE header above; shellcheck cannot see where
+#                            it is assigned.
+set -Eeuo pipefail
+
+tmpfile="$(mktemp)"
+trap 'rm -f "${tmpfile}"' EXIT
+printf 'kubernetesVersion: %s\n' "${usage_version}" > "${tmpfile}"
+
+talhelper gencommand upgrade-k8s --env-file talenv.yaml --env-file "${tmpfile}" | bash

--- a/.config/mise/tasks/talos/upgrade-node
+++ b/.config/mise/tasks/talos/upgrade-node
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#MISE description="Upgrade Talos on one node to talenv.yaml's talosVersion"
+#MISE dir="{{config_root}}/talos"
+#MISE depends=["talos:genconfig"]
+#USAGE arg "<ip>" help="Node IP address, as it appears in talos/talconfig.yaml"
+#
+# Ported from equestria-cluster/.taskfiles/talos/Taskfile.yaml (`talos:upgrade-node`).
+#
+# Only `genconfig`, matching the original: the whole point of the per-node task
+# is to retry or resume a single node after `talos:upgrade` has already run its
+# validation once.
+# shellcheck disable=SC2154  # usage_ip is injected by mise from the #USAGE
+#                            header above; shellcheck cannot see where it is
+#                            assigned.
+set -Eeuo pipefail
+
+talosctl --nodes "${usage_ip}" get machineconfig >/dev/null || {
+  printf 'talos:upgrade-node: %s did not answer an authenticated Talos API call.\n' "${usage_ip}" >&2
+  exit 1
+}
+
+talhelper gencommand upgrade --node "${usage_ip}" --extra-flags "--timeout=10m" | bash

--- a/.config/mise/tasks/talos/validate-config
+++ b/.config/mise/tasks/talos/validate-config
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#MISE description="Validate the rendered Talos machine configs, and that talosctl matches talenv.yaml"
+#MISE dir="{{config_root}}/talos"
+#MISE depends=["talos:genconfig"]
+#
+# Ported from equestria-cluster/.taskfiles/talos/Taskfile.yaml (`talos:validate-config`).
+#
+# CHANGED FROM THE ORIGINAL, deliberately. The source version resolved the
+# talosctl to test with as `mise exec talosctl@${expected} -- talosctl version`
+# and then compared that to ${expected} — which mise satisfies by installing
+# exactly the version asked for, so the comparison could never fail. It was a
+# tautology dressed as a drift check.
+#
+# This version compares the talosctl PINNED IN .config/mise.toml against
+# talenv.yaml's talosVersion, which is the drift that actually bites: bump
+# talenv without bumping [tools] and you validate next release's config with
+# last release's schema.
+# shellcheck disable=SC2016  # the backticks below are prose emphasis in an
+#                            operator-facing message, not a command
+#                            substitution -- the single quotes are intentional.
+set -Eeuo pipefail
+
+expected_talos_version="$(yq '.talosVersion' ./talenv.yaml)"
+talosctl_version="$(talosctl version --client | awk '/Tag:/ {print $2}')"
+
+if [[ "${talosctl_version}" != "${expected_talos_version}" ]]; then
+  printf 'talos:validate-config: talosctl is %s but talos/talenv.yaml asks for %s.\n' \
+    "${talosctl_version}" "${expected_talos_version}" >&2
+  printf 'talos:validate-config: bump `talosctl` in .config/mise.toml [tools] to match, then `mise install`.\n' >&2
+  exit 1
+fi
+
+shopt -s nullglob
+configs=(./clusterconfig/*.yaml)
+if ((${#configs[@]} == 0)); then
+  # genconfig ran (it is a dependency) yet produced nothing — that is a
+  # talconfig problem, not a missing-file problem, so say so rather than
+  # reporting a vacuous pass.
+  printf 'talos:validate-config: no ./clusterconfig/*.yaml after genconfig.\n' >&2
+  exit 1
+fi
+
+for cfg in "${configs[@]}"; do
+  printf 'Validating %s\n' "${cfg}"
+  talosctl validate --mode metal --strict --config "${cfg}"
+done
+
+printf 'Talos config validation passed.\n'


### PR DESCRIPTION
`stargate-command-cluster` and `equestria-cluster` are being archived. Their
go-task setups are **byte-identical** — `diff -r` between the two `.taskfiles/`
trees reports nothing, and the two root `Taskfile.yaml` files match as well — so
this migrates **one** copy, from `equestria-cluster`, the cluster that survives.

## Inventory

24 source tasks. 19 migrated, 1 deferred, 4 skipped. Every SGC task was also an
equestria task, so nothing was dropped for being SGC-scoped; the whole SGC set is
the duplicate half of the identical pair.

### `talos:*` — the priority set, all pointed at this repo's `talos/`

| Source task | What it does | Verdict | Lands as |
| --- | --- | --- | --- |
| `talos:generate-config` | `talhelper genconfig` | **MIGRATE** | `talos:genconfig` — renamed to match the talhelper verb, like every other task here |
| `talos:validate-config` | Validate rendered configs + talosctl version gate | **MIGRATE** (rewritten, see below) | `talos:validate-config` |
| `talos:apply` | Apply config to all nodes | **MIGRATE** | `talos:apply [--mode]` |
| `talos:apply-node` | Apply config to one node | **MIGRATE** | `talos:apply-node <ip> [--mode]` |
| `talos:add-node` | Apply over the insecure API to a maintenance-mode node | **MIGRATE** | `talos:add-node <ip> [--mode]` |
| `talos:upgrade` | Upgrade Talos, all nodes | **MIGRATE** | `talos:upgrade` |
| `talos:upgrade-node` | Upgrade Talos, one node | **MIGRATE** | `talos:upgrade-node <ip>` |
| `talos:upgrade-k8s` | Upgrade Kubernetes to `talenv.yaml`'s version | **MIGRATE** | `talos:upgrade-k8s` |
| `talos:upgrade-k8s-to` | Step to an explicit intermediate Kubernetes version | **MIGRATE** | `talos:upgrade-k8s-to <version>` |
| `talos:reboot` | Rolling reboot of control planes | **MIGRATE** (as-is, see below) | `talos:reboot` |
| `talos:reset` | Wipe every node back to maintenance mode | **MIGRATE** | `talos:reset` (gated by `confirm`) |
| `talos:reset-node` | Wipe one node back to maintenance mode | **MIGRATE** | `talos:reset-node <ip>` (gated by `confirm`) |
| `talos:preflight-upgrade` | Read-only gate: versions, node Ready, Talos API, VolSync quiet | **MIGRATE** | `talos:preflight-upgrade` |
| `talos:backup-etcd` | etcd snapshot from a control-plane node | **MIGRATE** | `talos:backup-etcd` |

### `flux:*` and `k8s:*`

| Source task | What it does | Verdict | Lands as |
| --- | --- | --- | --- |
| root `reconcile` | Reconcile the three GitRepositories + the root Kustomization | **MIGRATE** | `flux:reconcile` — all three sources (`flux-system`, `home-operations`, `vault`) exist in this repo's Flux tree, verified |
| `flux:delete-kustomization` | Strip a stuck Kustomization's finalizer, then re-reconcile `cluster-apps` | **MIGRATE** | `flux:delete-kustomization <namespace> <name>` — `cluster-apps` exists here (`kubernetes/flux/cluster/ks.yaml`) |
| `kubernetes:cleanup-pods` | Delete Failed/Succeeded pods cluster-wide | **MIGRATE** (as-is, see below) | `k8s:cleanup-pods` |
| `kubernetes:restart-flux` | Roll everything in `flux-system` | **MIGRATE** | `k8s:restart-flux` |
| `kubernetes:restart-kube` | Roll everything in `kube-system` | **MIGRATE** | `k8s:restart-kube` |

### Not migrated

| Source task | Verdict | Why |
| --- | --- | --- |
| `bootstrap:talos` | **DEFERRED** | Carries the `talhelper gensecret` step (commented out in the source, but integral to a real bootstrap). Talos secret/cert generation is being handled separately under its own security requirements, so it is deliberately out of this PR. |
| `bootstrap:apps` | **SKIP** | Its whole body is `bash scripts/bootstrap-apps.sh`, and neither that script nor its `scripts/lib/common.sh` dependency exists here. It also wants `helmfile` and `kustomize`, which are not pinned in this repo. Porting a cluster-bootstrap script is a separate, reviewable change — a task pointing at a missing script is worse than no task. |
| `kubernetes:cleanup-resource` | **SKIP** | Same reason: its body is `bash scripts/cleanup-resource.sh`, which does not exist here. ~50 lines, self-contained, destructive — easy to port in a follow-up if it is wanted. |
| root `default: task --list` | **SKIP** | `mise tasks` already is this. |
| the entire `stargate-command-cluster` set | **SKIP — duplicate** | Byte-identical to equestria's. `diff -r` between the two `.taskfiles/` trees produces no output. |

## Shape of the migration

Nested file tasks under `.config/mise/tasks/{talos,flux,k8s}/`, which mise turns
into `talos:`, `flux:` and `k8s:` namespaces — so `task talos:apply` becomes
`mise run talos:apply`. File tasks rather than `[tasks.*]` in `mise.toml` because
that is already the split in this repo (`mise.toml` holds one-liners,
`.config/mise/tasks/` holds anything with a shebang), and it puts every one of
these under shellcheck, which hk runs.

Translation table:

| go-task | mise |
| --- | --- |
| `deps: [generate-config]` | `#MISE depends=["talos:genconfig"]` |
| `prompt: …` | `#MISE confirm="…"` |
| `requires: vars: [IP]` + `{{.IP}}` | `#USAGE arg "<ip>"` + `${usage_ip}` |
| `vars: MODE: '{{.MODE \| default "auto"}}'` | `#USAGE flag "--mode <mode>" default="auto"` |
| `dir: '{{.TALOS_DIR}}'` | `#MISE dir="{{config_root}}/talos"` |

So `task talos:apply-node IP=10.10.206.10 MODE=reboot` is now
`mise run talos:apply-node 10.10.206.10 --mode reboot`.

Most `preconditions:` are **dropped rather than translated**. They were
`which talhelper talosctl yq` checks, and every one of those tools is pinned in
`[tools]`, so mise installs them before a task body ever runs. The preconditions
that carried real information are kept inline: age key present (`genconfig`), and
"this node answers an authenticated Talos API call" (`apply-node`, `upgrade-node`),
which is the check that distinguishes a wrong IP from a node still in maintenance
mode — the latter needs `talos:add-node`, and without the check that surfaces as a
bare certificate error.

## Three deliberate deviations from the source

1. **`talos:validate-config`'s version gate is rewritten.** The original resolved
   talosctl as `mise exec talosctl@${expected} -- talosctl version` and then
   compared the result to `${expected}` — which mise satisfies by installing
   exactly the version requested, so the comparison could never fail. It was a
   tautology dressed as a drift check. It now compares the talosctl pinned in
   `.config/mise.toml` against `talos/talenv.yaml`, which is the drift that
   actually bites.

2. **`talos:reboot` is ported as-is, including its mismatch.** It is described as
   "reboot the cluster without downtime" but its selector is
   `-l node-role.kubernetes.io/control-plane`, so workers are never touched. The
   description now says what the code does; widening the selector would change
   what a destructive task does and is a decision for a separate change. The
   discrepancy is documented in the file. Its unused `MODE` var is dropped.

3. **`k8s:cleanup-pods` likewise.** Described as "Failed/Pending/Succeeded", but
   the matrix only ever listed Failed and Succeeded — correctly so, since a
   Pending pod is one the scheduler has not placed yet. Description corrected to
   match the code.

## `.config/mise.toml` changes

- `talosctl = "1.13.8"` and `talhelper = "3.1.16"` added to `[tools]`. talosctl
  must track `talenv.yaml`'s `talosVersion` (currently `v1.13.8`, verified to
  match) — Renovate bumps `talenv.yaml` from the installer tag, and this line has
  to move with it. `talos:validate-config` now enforces the pairing.
- `TALOSCONFIG` added to `[env]`, pointing at the talhelper-generated
  `talos/clusterconfig/talosconfig` rather than the tracked `talos/talosconfig`
  (which has `endpoints: []`, so every command through it would need an explicit
  `--endpoints`). The path does not exist until `talos:genconfig` runs; that is
  inert.

## Gaps a reviewer should know about

- **`KUBECONFIG` is deliberately not set.** The source Taskfile pinned it to a
  repo-local `./kubeconfig`; this repo carries no such file, and setting the var
  to a missing path would break every `kubectl` invocation for anyone using their
  own config. All eight migrated tasks that shell out to `kubectl`/`flux`
  therefore follow the **ambient** context, and each file says so in a comment.
  Check `kubectl config current-context` before running them. If a repo-local
  kubeconfig is wanted, that is a follow-up.
- **`age.key` is gitignored**, so `talos:genconfig` cannot run in a fresh clone or
  a git worktree until it is placed. The task now fails by name rather than
  through a generic sops "no matching keys".
- **`.sops.yaml` has no `talos/` creation rule.** Decryption of the existing
  `talos/talsecret.sops.yaml` works regardless (the age key is what matters), so
  nothing in this PR is affected — but any future task or command that *encrypts*
  a file under `talos/` will not match a rule. Relevant to whoever picks up the
  deferred `gensecret` work.
- **Two scripts would need porting** for the two SKIPped tasks:
  `scripts/bootstrap-apps.sh` (+ `scripts/lib/common.sh`) and
  `scripts/cleanup-resource.sh`.

## :rotating_light: Unrelated finding, flagged not fixed

`talos/talosconfig` was committed **in plaintext** in 9cd47c0a and contains the
cluster's **admin ed25519 private key** (the `key:` field, base64-encoded PEM).
`talos/clusterconfig/.gitignore` correctly ignores the generated `talosconfig`,
but this second copy at `talos/talosconfig` is tracked. It slipped past hk's
`detect-private-key` step because the PEM is base64-wrapped rather than raw.

Not touched here — it needs credential rotation, not a `git rm`, and Talos cert
rotation is exactly the work being handled separately. Raising it because nobody
else is looking at that file.

## Verification

- `mise tasks` lists all 19 (14 `talos:`, 2 `flux:`, 3 `k8s:`).
- `mise run <task> --help` renders the correct `usage` spec for every task that
  takes arguments; `mise tasks info --json` confirms `depends` and `dir` parsed
  from the headers.
- `#MISE confirm=` verified to abort rather than run when there is no tty, so
  `talos:reset` / `talos:reset-node` cannot fire unattended.
- `talosctl version --client` → `v1.13.8`, matching `talenv.yaml` — the
  `validate-config` gate passes.
- `shellcheck` clean on all 19 (two per-file `disable=` directives, each with a
  justification, matching the convention `vals-run` already uses).
- `hk check` exits 0 over all 20 changed files.
- **Nothing was executed against a cluster.** No task that mutates anything was
  run, so the task *bodies* are verified to parse and lint but not to work
  end-to-end against equestria.

---

# Follow-up: the repo-local kubeconfig (commit `6c89b050`)

The original migration deliberately dropped equestria-cluster's
`KUBECONFIG: '{{.ROOT_DIR}}/kubeconfig'`, leaving the eight kubectl/flux tasks
on the ambient config. That was right about the bare path and wrong about the
conclusion — it left no repo-local option and no way to create one. This
follow-up adds both, without taking the ambient config away.

## What changed

| File | Change |
| --- | --- |
| `.config/mise/tasks/talos/kubeconfig` | **new** — `talos:kubeconfig`, generates the repo-local `./kubeconfig` |
| `.config/mise/tasks/k8s/require-kubeconfig` | **new**, hidden — the guard, a `depends` of all eight kubectl/flux tasks |
| `.config/mise.toml` | `KUBECONFIG` set in `[env]`, as a two-entry list |
| 8 task files | `#MISE depends=["k8s:require-kubeconfig"]`, and the now-inaccurate "AMBIENT kubeconfig" comments rewritten |
| `.gitignore` | one negation line — see the trap below |

### `talos:kubeconfig`

Lifted out of the source repo's `bootstrap:talos`, where it was the last of four
lines:

```
until talhelper gencommand kubeconfig --extra-flags="{{.ROOT_DIR}} --force" | bash; do sleep 10; done
```

- **`depends=["talos:genconfig"]`.** The command talhelper emits is
  `talosctl kubeconfig --talosconfig=./clusterconfig/talosconfig <dir> --force --nodes=<cp-ip>`,
  so it reads `talos/clusterconfig/talosconfig` — which only `genconfig` writes
  and which is gitignored. Without the dependency a fresh clone or a git
  worktree gets a talosconfig-not-found error instead of just rendering the
  config it needs. Every sibling that touches the Talos API takes the same
  dependency.
- **talhelper over hand-rolled talosctl**, matching the source: the
  control-plane node comes from `talconfig.yaml`, so it stays correct when nodes
  are added or renumbered.
- **Idempotent.** `--force` overwrites rather than merging or refusing, so
  re-running converges instead of accumulating stale entries. Read-only against
  the cluster, safe to re-run.
- The source's unbounded `until … sleep 10` is kept but **bounded** at 30
  attempts / 10s. Unbounded is right for a bootstrap waiting on a cluster that
  does not exist yet, and wrong for something run by hand — it would hang
  silently forever against an unreachable cluster.

## :rotating_light: The ambient-kubeconfig question, answered

`[env]` applies to **everything** run under mise in this repo, so this needed
deciding before committing rather than after. **The change does not break
ambient kubectl** — but only because the value is a *list*, not the single path
the source repo used.

**Set:**

```toml
KUBECONFIG = "{{config_root}}/kubeconfig:{{env.HOME}}/.kube/config"
```

**The bare path was rejected on evidence, not taste.** A single missing path
does *not* make kubectl fall back to `~/.kube/config` — that fallback only
happens when `KUBECONFIG` is **unset**. Tested against kubectl 1.34:

```console
$ KUBECONFIG=/tmp/definitely-missing kubectl config current-context
error: current-context is not set                      # exit 1

$ KUBECONFIG=/tmp/definitely-missing flux get sources git
✗ failed to get server groups: Get "http://localhost:8080/api": dial tcp [::1]:8080: connect: connection refused
```

So the source's convention, copied literally, would have broken every ad-hoc
`kubectl`, every `kubectl --context admin@sgc`, and both migrated namespaces for
anyone who has not run `talos:kubeconfig` — a bigger regression than the
convenience it buys.

**Why the list is safe.** All four properties verified, not assumed:

1. **Missing list entries are silently skipped.** With the repo-local file
   absent — the state of every fresh clone, and of this worktree right now —
   behaviour is identical to today.
   ```console
   $ KUBECONFIG=/tmp/definitely-missing:$HOME/.kube/config kubectl config current-context
   admin@equestria                                       # exit 0
   ```
2. **Ambient contexts stay listed and stay selectable.** `admin@sgc` and both
   `*-operator.opossum-yo.ts.net` contexts survive the merge, so
   `kubectl --context admin@sgc` — the pattern `.claude/skills/k8s` documents and
   mandates — keeps working:
   ```console
   $ mise exec -- kubectl config get-contexts -o name
   admin@equestria
   admin@sgc
   equestria-operator.opossum-yo.ts.net
   sgc-operator.opossum-yo.ts.net
   ```
3. **The one collision is a no-op.** Merging is by name, first file wins, and the
   only name both files can define is `admin@equestria`. talosctl generates it
   against `talconfig.yaml`'s `endpoint: https://10.10.206.201:6443` — the exact
   server `~/.kube/config` already has for that context. So precedence resolves
   to an identical entry.
4. **Nothing else in the repo reads it.** Every Pulumi `kubernetes.Provider` is
   handed an explicit `kubeconfig:` string built from a stored cluster definition
   (`stacks/applications/kubernetes.ts`, `components/openbao/clusterAuth.ts`) —
   the env var is never consulted. No GitHub Actions workflow runs `kubectl`.

**One real behaviour change, stated plainly.** Once the repo-local file exists,
`kubectl config` **writes** (`use-context`, `set-context`) land in the first
list entry rather than in `~/.kube/config`, so switching context inside this
repo becomes repo-scoped. It never edits `~/.kube/config`. While the repo-local
file is absent the writes go to the ambient file exactly as they do today —
verified that kubectl does *not* create the missing first entry:

```console
$ KUBECONFIG=/tmp/nonexistent:./ambient-copy kubectl config use-context admin@sgc
Switched to context "admin@sgc".
$ ls /tmp/nonexistent          # still absent; the write landed in ambient-copy
```

The `KUBECONFIG unset` precondition in `docs/cluster-consolidation/03` and `/04`
is unaffected: that gate means "no live cluster reachable", and unset already
resolves to `~/.kube/config` today. The list is functionally the same starting
point.

## The guard

`k8s:require-kubeconfig`, hidden (`#MISE hide=true`, confirmed it stays out of
`mise tasks` while remaining runnable), wired as a `depends` on all eight tasks.
It is the mise equivalent of the source Taskfile's
`preconditions: - test -f {{.KUBECONFIG}}`.

**It deliberately does not copy that test.** Checking for
`${MISE_CONFIG_ROOT}/kubeconfig` would hard-fail every task for anyone driving
them from their own `~/.kube/config` — which is the status quo and has to keep
working. The question worth asking is "is there a usable context at all", so it
runs `kubectl config current-context`: local-only, no API call, no timeout
against a down cluster.

```console
$ KUBECONFIG=/tmp/missing-a:/tmp/missing-b bash .config/mise/tasks/k8s/require-kubeconfig
No kubeconfig context is set — every kubectl/flux task here would fall back to
localhost:8080 and fail with a connection-refused error that names nothing.

KUBECONFIG=/tmp/missing-a:/tmp/missing-b

Fix it with either:
  mise run talos:kubeconfig   # fetch the repo-local one from the Talos API
  kubectl config use-context <name>   # if you already have one of your own
```

Verified with a throwaway task pair that a failing `depends` **aborts before the
dependent body runs** (exit 1, body never printed) — otherwise the guard would
be decoration.

## :rotating_light: Trap caught: `.gitignore` swallowed the new task

The bare `kubeconfig` pattern added in #892 matches **at any depth**, so it also
matched `.config/mise/tasks/talos/kubeconfig` — the task that *creates* the
ignored file. `git add -A` skipped it with no error and it would simply have
been missing from the commit.

```console
$ git check-ignore -v .config/mise/tasks/talos/kubeconfig
.gitignore:52:kubeconfig	.config/mise/tasks/talos/kubeconfig
```

Fixed with one negation line (not a duplicate rule); the root `kubeconfig` and
`talos/clusterconfig/talosconfig` stay ignored, both re-checked.

## Verification

- `git check-ignore -v kubeconfig` → still ignored by `.gitignore:52`; the new
  task file is now tracked, mode `100755`.
- `mise tasks` lists `talos:kubeconfig`; `k8s:require-kubeconfig` correctly
  hidden.
- `mise run talos:kubeconfig --help` renders (`Depends on: talos:genconfig`), and
  `--help` was confirmed to short-circuit *before* dependencies or the body run.
- `mise env` renders `KUBECONFIG` with `{{env.HOME}}` expanded;
  `mise exec -- kubectl config current-context` → `admin@equestria`, unchanged.
- `shellcheck` clean on both new tasks and all eight modified ones.
- `hk check` exits 0 over all 12 changed files.
- **Nothing was executed against a cluster.** `talos:kubeconfig` was never run —
  its body is verified to parse and lint, not to work end to end. Whether the
  generated file's context and server match `~/.kube/config` is inferred from
  `talconfig.yaml`'s `endpoint` and `clusterName`, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
