### PR TITLE
fix(talos): point the SGC control planes at equestria's VIP, not SGC's

### DIFF
--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -264,8 +264,7 @@ nodes:
           grow: false
           minSize: 1TB
           maxSize: 1TB
-    nodeLabels: &nodeLabels
-      node.longhorn.io/create-default-disk: 'config'
+    nodeLabels: *nodeLabels
     nodeAnnotations: &nodeAnnotations
       node.longhorn.io/default-disks-config: |
         {
@@ -307,7 +306,14 @@ nodes:
             gateway: "10.10.0.1"
         mtu: 1500
         vip:
-          ip: "10.10.209.201"
+          # 10.10.206.201, not SGC's old 10.10.209.201. These three join
+          # equestria, whose endpoint is https://10.10.206.201:6443 — a control
+          # plane advertising a different VIP forms its own election for an
+          # address nothing routes to, and additionalApiServerCertSans does not
+          # cover .209.201, so anything reaching the API that way fails TLS.
+          # Viable as a shared VIP because every node here is /16 inside
+          # 10.10.0.0/16 behind gateway 10.10.0.1 — one broadcast domain.
+          ip: "10.10.206.201"
   - hostname: "othalla"
     ipAddress: "10.10.209.11"
     installDisk: "/dev/nvme0n1"
@@ -329,7 +335,14 @@ nodes:
             gateway: "10.10.0.1"
         mtu: 1500
         vip:
-          ip: "10.10.209.201"
+          # 10.10.206.201, not SGC's old 10.10.209.201. These three join
+          # equestria, whose endpoint is https://10.10.206.201:6443 — a control
+          # plane advertising a different VIP forms its own election for an
+          # address nothing routes to, and additionalApiServerCertSans does not
+          # cover .209.201, so anything reaching the API that way fails TLS.
+          # Viable as a shared VIP because every node here is /16 inside
+          # 10.10.0.0/16 behind gateway 10.10.0.1 — one broadcast domain.
+          ip: "10.10.206.201"
   - hostname: "pegasus"
     ipAddress: "10.10.209.12"
     installDisk: "/dev/nvme0n1"
@@ -351,7 +364,14 @@ nodes:
             gateway: "10.10.0.1"
         mtu: 1500
         vip:
-          ip: "10.10.209.201"
+          # 10.10.206.201, not SGC's old 10.10.209.201. These three join
+          # equestria, whose endpoint is https://10.10.206.201:6443 — a control
+          # plane advertising a different VIP forms its own election for an
+          # address nothing routes to, and additionalApiServerCertSans does not
+          # cover .209.201, so anything reaching the API that way fails TLS.
+          # Viable as a shared VIP because every node here is /16 inside
+          # 10.10.0.0/16 behind gateway 10.10.0.1 — one broadcast domain.
+          ip: "10.10.206.201"
 # Global patches
 patches:
   - "@./patches/global/machine-files.yaml"


### PR DESCRIPTION
**Blocks the config adoption.** Not applied to any node — see the note at the end on ordering.

## The defect

The migration added SGC's three nodes to equestria's talconfig as control planes (piece 18, encoded). Their VIP is wrong:

| node | cp | ip | vip |
|---|---|---|---|
| hard-hat, fluttershy, kerfuffle | ✓ | `10.10.206.x` | `10.10.206.201` |
| milky-way, othalla, pegasus | ✓ | `10.10.209.x` | **`10.10.209.201`** ← SGC's own API VIP |

Six control planes, two VIPs, one cluster whose endpoint is `https://10.10.206.201:6443`.

1. Talos VIP is an **elected shared address** among the nodes configured with it. The SGC three would run their own election for an address that isn't the endpoint and that nothing routes to.
2. `additionalApiServerCertSans` lists `10.10.206.201` and **not** `.209.201` — anything reaching the API that way fails TLS.
3. It carries SGC's VIP into the surviving cluster, the exact reference [piece 22 §1](docs/cluster-consolidation/22-decommission-sgc.md) exists to retire.

Nothing about the addressing had to change: every node is `/16` inside `10.10.0.0/16` behind gateway `10.10.0.1`, so one shared VIP is viable.

## Also: the duplicate anchor is not cosmetic

`&nodeLabels` was defined twice. **PyYAML refuses the file outright** — `found duplicate anchor 'nodeLabels'`. Go's `yaml.v3` tolerates redefinition, which is why talhelper never complained, but any strict parser in the chain would choke.

Both bodies were byte-identical, so deduping is behaviour-preserving — and I verified rather than assumed: parsed both revisions and diffed the fully-resolved structures. **Identical apart from the VIPs.**

While here — my earlier "4× `&intel`" concern was a bad regex on my part. Those are distinct anchors (`&intel_un1290_user_volumes`, `&amd_minifm_schematic`), not duplicates.

## Ordering

Deliberately not applied. Machine configs want regenerating **after** the CA rotation (#893), so rotation touches three nodes' worth of config instead of six.

## Verification

- [x] Resolved-config diff proves only the VIPs changed
- [x] File now parses under a strict YAML parser; it did not before
- [x] `hk check` passes
- [ ] Not applied to any node — deliberate

🤖 Generated with [Claude Code](https://claude.com/claude-code)