### PR TITLE
fix(talos): drop Stargate Command's dead resolver from the global nameservers

### DIFF
--- a/talos/clusterconfig/.gitignore
+++ b/talos/clusterconfig/.gitignore
@@ -15,3 +15,6 @@ equestria-fluttershy.yaml
 equestria-kerfuffle.yaml
 equestria-hard-hat.yaml
 equestria-pinkie-pie.yaml
+equestria-milky-way.yaml
+equestria-othalla.yaml
+equestria-pegasus.yaml

--- a/talos/patches/global/machine-network.yaml
+++ b/talos/patches/global/machine-network.yaml
@@ -6,4 +6,8 @@ machine:
       - 149.112.112.112
       - 10.10.10.9
       - 10.10.0.1
-      - 10.10.209.202
+      # 10.10.209.202 — Stargate Command's Technitium — removed 2026-08-17.
+      # SGC was decommissioned and its nodes wiped, so this stopped answering
+      # entirely; it was the fifth entry behind four live resolvers, which is
+      # why nothing visibly broke. The remaining four were each verified to
+      # resolve an internal name before this was dropped.


### PR DESCRIPTION
`10.10.209.202` was SGC's Technitium. SGC is decommissioned and its three nodes are wiped, so that address no longer answers.

Verified rather than assumed — each configured resolver tested against an internal name:

```
9.9.9.9         alive
149.112.112.112 alive
10.10.10.9      alive
10.10.0.1       alive
10.10.209.202   times out
```

It sat **fifth, behind four live resolvers**, which is why nothing visibly broke and why it went unnoticed. `machine-network.yaml` is a global patch, so every node carries it — including the three original control planes, not just the newly joined ones.

Removal only; no replacement needed, since the remaining four all resolve.

## Applied

Being rolled out with `talosctl apply-config` across all nodes as part of the SGC→equestria control-plane migration — the two remaining wiped nodes get it on their initial join, the four existing nodes as a no-reboot config change.

## Verification

- [x] Regenerated configs carry exactly four nameservers, with no other diff
- [x] Each surviving resolver confirmed to answer an internal name

🤖 Generated with [Claude Code](https://claude.com/claude-code)