### PR TITLE
fix(sgc): unwedge the home stack, and stop the drop rules churning HA entities

### DIFF
--- a/components/constants.ts
+++ b/components/constants.ts
@@ -29,10 +29,17 @@ const dnsServers = {
     use: false,
     internal: true,
   },
+  // SGC was decommissioned and its three nodes wiped on 2026-08-17 (see
+  // docs/cluster-consolidation/22-decommission-sgc.md); this resolver no longer
+  // answers. `use` feeds dns.internalIps in stacks/unifi-network/local-dns.ts,
+  // so while it was true every IoT and Home DHCP lease still handed clients a
+  // dead nameserver in slot 4. Commit 2244059a dropped it from the Talos global
+  // nameservers but not from this path. Kept rather than deleted so the address
+  // stays on record if the entry is ever revived.
   "Stargate Command": {
     ips: ["10.10.209.202"],
-    uptime: true,
-    use: true,
+    uptime: false,
+    use: false,
     internal: true,
   },
   Quad9: {

--- a/stacks/home/index.ts
+++ b/stacks/home/index.ts
@@ -10,7 +10,6 @@ import * as minio from "@pulumi/minio";
 import * as pulumi from "@pulumi/pulumi";
 import { DockgeLxc, getDockageProperties } from "../../components/DockgeLxc.ts";
 import { GlobalResources } from "../../components/globals.ts";
-import { OpenBaoClusterAuth } from "../../components/openbao/clusterAuth.ts";
 import { OpenBaoOidc } from "../../components/openbao/oidc.ts";
 import { ProxmoxBackupServerLxc } from "../../components/ProxmoxBackupServerLxc.ts";
 import { getProxmoxProperties, ProxmoxHost } from "../../components/ProxmoxHost.ts";
@@ -409,22 +408,24 @@ export const celestia = {
 // the HelmRelease config or an env var — see components/openbao/oidc.ts.
 const _openbaoOidc = new OpenBaoOidc("openbao-oidc", { globals });
 
-// Phase 7: SGC's ESO gets its own kubernetes auth mount. One OpenBao serves
-// the estate, but one `kubernetes` mount pins a single API server and rejects
-// every other cluster's ServiceAccount tokens — so it is one mount per
-// cluster. equestria's equivalent still belongs to the bootstrap script and
-// would need `pulumi import` to adopt; see components/openbao/clusterAuth.ts.
+// No OpenBaoClusterAuth here any more. This held `openbao-sgc-auth`, the
+// per-cluster kubernetes auth mount for SGC's ESO — one mount per cluster,
+// because a single `kubernetes` mount pins one API server and rejects every
+// other cluster's ServiceAccount tokens.
 //
-// The API server is addressed by IP on purpose: a *.driscoll.tech name
-// resolves through split-horizon DNS, which would put Technitium in the login
-// path for every SGC secret read. 10.10.209.201 is in the API server cert's
-// SANs and reachable from an openbao pod — both verified before this landed.
-const _openbaoSgcAuth = new OpenBaoClusterAuth("openbao-sgc-auth", {
-  globals,
-  clusterKey: "sgc",
-  clusterTitle: "Cluster: Stargate Command",
-  kubernetesHost: "https://10.10.209.201:6443",
-});
+// SGC was decommissioned and its nodes wiped on 2026-08-17, which took
+// https://10.10.209.201:6443 with it. The resource then failed every refresh
+// with `configured Kubernetes cluster is unreachable`, wedging this whole
+// stack at UpdateFailed — removing it is step 2 of Phase 2 in
+// docs/cluster-consolidation/22-decommission-sgc.md.
+//
+// equestria's equivalent is deliberately absent too: it still belongs to the
+// bootstrap script and would need `pulumi import` to adopt. See
+// components/openbao/clusterAuth.ts.
+//
+// Still outstanding from Phase 2: the `kubernetes-sgc` mount and the `eso-sgc`
+// policy/role are `retainOnDelete`, so Pulumi never reaches them — they need
+// hand-deletion (step 4).
 
 function clusterWideDns(globals: GlobalResources) {
   StandardDns.create(

--- a/stacks/unifi-network/tailscale-drop-firewall-rule.ts
+++ b/stacks/unifi-network/tailscale-drop-firewall-rule.ts
@@ -14,7 +14,10 @@ import type { components } from "../../types/tailscale.ts";
  * A single AT&T endpoint IP for one device, together with every source port Tailscale currently
  * advertises for it. Tailscale reports several concurrent STUN endpoints per device, and the NAT
  * mapping behind them rotates every few minutes — so the ports are grouped under the IP rather than
- * spread across one resource each. Only the IP is identity; the ports are payload.
+ * spread across one resource each.
+ *
+ * Neither field is identity any more: the device is. See {@link createTailscaleAttDropFirewallRule}
+ * for why the IP had to stop naming the resource.
  */
 interface DropTarget {
   ip: string;
@@ -47,6 +50,20 @@ function boundName(name: string): string {
   return `${name.slice(0, MAX_LOGICAL_NAME - digest.length - 1)}-${digest}`;
 }
 
+/**
+ * Block the AT&T-side endpoints Tailscale would otherwise use for direct paths, so those devices
+ * fall back to the peer relays.
+ *
+ * One rule per device per IP family — deliberately NOT one per endpoint IP. AT&T rotates these
+ * addresses whenever the delegated prefix or the NAT mapping changes. While the IP was part of the
+ * resource name, every rotation replaced the FirewallPolicy, UniFi minted a fresh rule id, and Home
+ * Assistant's UniFi integration registered a switch entity against the new id while stranding the
+ * old one as `unavailable` forever. 712 of those had piled up by 2026-08-17, which pushed the
+ * HomeKit bridge past the 150-accessory HAP limit and took the whole bridge offline in Apple Home.
+ *
+ * Keying on the device makes an address rotation an in-place update of a stable rule: the `ips` list
+ * and the port group change, the rule id does not, and Home Assistant keeps one entity per rule.
+ */
 export function createTailscaleAttDropFirewallRule(globals: GlobalResources) {
   const matcher = new CIDRMatcher([Tailscale.subnets.home]);
   const devices = pulumi.output(getTailscaleClient(globals)).apply(async client => {
@@ -112,98 +129,104 @@ export function createTailscaleAttDropFirewallRule(globals: GlobalResources) {
       pulumi.log.info("No peer relays found, skipping firewall rule creation", globals);
       return;
     }
+    /**
+     * Union the ports observed across one device's endpoints.
+     *
+     * Ports were previously tracked per endpoint IP. Now that a device's addresses share a single
+     * rule, they share a single port group too, so a device's AT&T endpoints are all blocked on the
+     * union of the ports any of them was seen using. These are BLOCK rules aimed at one device's own
+     * ISP endpoints, so widening the set only drops more of what the rule exists to drop.
+     */
+    const unionPorts = (targets: DropTarget[]) => [...new Set(targets.flatMap(t => t.ports))].sort((a, b) => a - b).map(String);
+
     for (const { device, ipv4IpsToDrop, ipv6IpsToDrop } of devices) {
       if (ipv4IpsToDrop.length > 0) {
-        for (const { ip, ports } of ipv4IpsToDrop) {
-          const name = `att-tailscale-drop-ipv4-${device.hostname}-${ip.replace(/\./g, "-")}`;
-          const portGroup = new firewall.FirewallGroup(
-            boundName(`${name}-ports`),
-            {
-              type: "port-group",
-              members: ports.map(String),
-            },
-            {
-              provider: globals.unifiFirewallProvider,
-            },
-          );
+        const name = `att-tailscale-drop-ipv4-${device.hostname}`;
+        const portGroup = new firewall.FirewallGroup(
+          boundName(`${name}-ports`),
+          {
+            type: "port-group",
+            members: unionPorts(ipv4IpsToDrop),
+          },
+          {
+            provider: globals.unifiFirewallProvider,
+          },
+        );
 
-          const _firewallRule = new firewall.FirewallPolicy(
-            boundName(name),
-            {
-              enabled: true,
+        const _firewallRule = new firewall.FirewallPolicy(
+          boundName(name),
+          {
+            enabled: true,
 
-              action: "BLOCK", // REJECT ?
-              connectionStateType: "ALL",
-              protocol: "all",
-              ipVersion: "IPV4",
+            action: "BLOCK", // REJECT ?
+            connectionStateType: "ALL",
+            protocol: "all",
+            ipVersion: "IPV4",
 
-              source: {
-                zoneId: externalZone.id,
-                ips: [ip],
-                portGroupId: portGroup.id,
-                portMatchingType: "OBJECT",
-              },
-              destination: {
-                zoneId: internalZone.id,
-                ips: peerRelays,
-                matchOppositeIps: true,
-              },
-              schedule: {
-                mode: "ALWAYS",
-              },
+            source: {
+              zoneId: externalZone.id,
+              ips: ipv4IpsToDrop.map(t => t.ip),
+              portGroupId: portGroup.id,
+              portMatchingType: "OBJECT",
             },
-            {
-              provider: globals.unifiFirewallProvider,
-              deleteBeforeReplace: true,
+            destination: {
+              zoneId: internalZone.id,
+              ips: peerRelays,
+              matchOppositeIps: true,
             },
-          );
-        }
+            schedule: {
+              mode: "ALWAYS",
+            },
+          },
+          {
+            provider: globals.unifiFirewallProvider,
+            deleteBeforeReplace: true,
+          },
+        );
       }
 
       if (ipv6IpsToDrop.length > 0) {
-        for (const { ip, ports } of ipv6IpsToDrop) {
-          const name = `att-tailscale-drop-ipv6-${device.hostname}-${ip.replace(/:/g, "-")}`;
-          const portGroup = new firewall.FirewallGroup(
-            boundName(`${name}-ports`),
-            {
-              type: "port-group",
-              members: ports.map(String),
-            },
-            {
-              provider: globals.unifiFirewallProvider,
-            },
-          );
+        const name = `att-tailscale-drop-ipv6-${device.hostname}`;
+        const portGroup = new firewall.FirewallGroup(
+          boundName(`${name}-ports`),
+          {
+            type: "port-group",
+            members: unionPorts(ipv6IpsToDrop),
+          },
+          {
+            provider: globals.unifiFirewallProvider,
+          },
+        );
 
-          const _firewallRule = new firewall.FirewallPolicy(
-            boundName(name),
-            {
-              enabled: true,
+        const _firewallRule = new firewall.FirewallPolicy(
+          boundName(name),
+          {
+            enabled: true,
 
-              action: "BLOCK", // REJECT ?
-              connectionStateType: "ALL",
-              protocol: "all",
-              ipVersion: "IPV6",
+            action: "BLOCK", // REJECT ?
+            connectionStateType: "ALL",
+            protocol: "all",
+            ipVersion: "IPV6",
 
-              source: {
-                zoneId: externalZone.id,
-                ips: [ip],
-                portGroupId: portGroup.id,
-                portMatchingType: "OBJECT",
-              },
-              destination: {
-                zoneId: internalZone.id,
-                // TODO: peer-relays that have ipv6?
-              },
-              schedule: {
-                mode: "ALWAYS",
-              },
+            source: {
+              zoneId: externalZone.id,
+              ips: ipv6IpsToDrop.map(t => t.ip),
+              portGroupId: portGroup.id,
+              portMatchingType: "OBJECT",
             },
-            {
-              provider: globals.unifiFirewallProvider,
-              deleteBeforeReplace: true,
+            destination: {
+              zoneId: internalZone.id,
+              // TODO: peer-relays that have ipv6?
             },
-          );
-        }
+            schedule: {
+              mode: "ALWAYS",
+            },
+          },
+          {
+            provider: globals.unifiFirewallProvider,
+            deleteBeforeReplace: true,
+          },
+        );
       }
     }
   });


### PR DESCRIPTION
Two independent fixes, both fallout from the SGC decommission on 2026-08-17.

## 1. `home` stack is wedged — `openbao-sgc-auth`

`stacks/home` has been `UpdateFailed` through **six consecutive runs since 16:07**. Nothing deploys from it until this lands.

```
configured Kubernetes cluster is unreachable: Get
"https://sgc-kubeproxy.opossum-yo.ts.net/openapi/v2?timeout=32s":
dial tcp 10.196.162.7:443: i/o timeout
error: failed to read resource state due to unreachable cluster
```

`OpenBaoClusterAuth("openbao-sgc-auth")` pointed at `https://10.10.209.201:6443`, which stopped existing when the nodes were wiped. This is **Phase 2 step 2** of `docs/cluster-consolidation/22-decommission-sgc.md`; the `pulumi destroy --stack sgc` that step gates on has already run.

A tombstone comment is left in place, because equestria's equivalent is *also* deliberately absent (it belongs to the bootstrap script and would need `pulumi import` to adopt) and the next reader will wonder.

## 2. Dead resolver still in every DHCP lease — `constants.ts`

The `"Stargate Command"` `dnsServers` entry was still `use: true`. `use` feeds `dns.internalIps`, which `stacks/unifi-network/local-dns.ts` puts into UniFi's four DHCP DNS slots — so every **IoT and Home** client was still being handed `10.10.209.202` in slot 4. Commit `2244059a` removed it from the Talos global nameservers but not from this path.

`uptime: false` also drops it from the `StandardDns` Gatus fan-out, which short-circuits on that flag. Both consumers verified by reading them, not assumed. **Phase 2 step 6.**

Set to `false` rather than deleted, so the address stays on record.

## 3. Drop rules churned a new HA entity per address rotation — `tailscale-drop-firewall-rule.ts`

This is the root cause of today's HomeKit outage.

One `FirewallPolicy` + `FirewallGroup` per **(device, endpoint IP)**, with the IP baked into the resource name. Every AT&T address rotation replaced the rule, UniFi minted a fresh rule id, HA's UniFi integration registered a switch entity against the new id, and the previous generation was stranded `unavailable` forever. **712 had accumulated.**

The HomeKit bridge filter is exclude-only with empty include lists — which HA reads as *include everything not excluded* — so all 712 were bridged, putting it at **1593 accessories against HAP's hard limit of 150**. iOS drops a bridge that far over the cap wholesale, which is why nothing in the house responded from any Apple device.

Now keyed on **(device, IP family)**. An address rotation becomes an in-place update of a stable rule: the `ips` list and port group change, the rule id does not, and HA keeps one entity per rule.

### ⚠️ Review notes

- **Semantics widen slightly.** Ports are now unioned across a device's endpoints rather than tracked per endpoint. These are BLOCK rules aimed at one device's own ISP endpoints, so the widening only ever drops more of what the rule exists to drop — but it is a real change.
- **The rename replaces every `att-tailscale-drop-*` rule once.** With `deleteBeforeReplace: true` there is a brief window with those blocks absent.
- **`home` deploy guidance, per piece 22 and prior incidents:** targeted `--target` refresh only (a full refresh hard-errors on the UniFi read-404), and judge from `pulumi stack history`, **never** from `preview`, which invents phantom deletes on this stack.
- Step 6 wants `up` on `home`, `gulf-of-mexico` **and** `ocracoke`.

## Deliberately not included

Remaining Phase 2 items, left as their own deliberate steps: the `kubernetes-sgc` mount and `eso-sgc` policy/role (step 4 — `retainOnDelete`, so Pulumi never reaches them and they need hand-deletion), `clusters/sgc.yaml` (step 3), the Tailscale ACL surface (step 5, strictly ordered), and `sgc-kubeproxy` (step 7, which the plan schedules late on purpose). `cnpg-sgc-backups` (step 9) is the point of no return for SGC's data and wants an explicit decision.

## Verification

- `biome check` clean on all three files; hk pre-commit hooks green.
- `tsc --noEmit` reports **10 errors, identical with and without these changes** — all pre-existing (`components/helpers.ts` TS6307, `components/store/*`, `components/truenas/*`). None introduced here.
- Not deployed. No `pulumi up` or `preview` has been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
