### PR TITLE
feat(tailscale-system): Taildrive 100Gi tailnet share, and collapse Kustomization sourceRefs onto flux-system

### DIFF
--- a/kubernetes/apps/cert-manager/cert-issuers/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-issuers/ks.yaml
@@ -23,7 +23,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -34,7 +34,7 @@ spec:
   timeout: 15m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   postBuild:

--- a/kubernetes/apps/cert-manager/trust-bundles/ks.yaml
+++ b/kubernetes/apps/cert-manager/trust-bundles/ks.yaml
@@ -25,7 +25,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   healthChecks:
     - apiVersion: trust.cert-manager.io/v1alpha1

--- a/kubernetes/apps/cert-manager/trust-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/trust-manager/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 15m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/cloudnative-pg/barman/ks.yaml
+++ b/kubernetes/apps/cloudnative-pg/barman/ks.yaml
@@ -28,7 +28,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/cloudnative-pg/operator/ks.yaml
+++ b/kubernetes/apps/cloudnative-pg/operator/ks.yaml
@@ -25,7 +25,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/coder/coder/ks.yaml
+++ b/kubernetes/apps/coder/coder/ks.yaml
@@ -27,7 +27,7 @@ spec:
       namespace: kube-system
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     # No failover/fast-node-eviction: it patches `defaultPodOptions`, which only

--- a/kubernetes/apps/database/neo4j/ks.yaml
+++ b/kubernetes/apps/database/neo4j/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/database/postgres/app/ks.yaml
+++ b/kubernetes/apps/database/postgres/app/ks.yaml
@@ -34,7 +34,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/database/postgres/backups/ks.yaml
+++ b/kubernetes/apps/database/postgres/backups/ks.yaml
@@ -34,7 +34,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/database/valkey/ks.yaml
+++ b/kubernetes/apps/database/valkey/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/books/audiobookshelf/ks.yaml
+++ b/kubernetes/apps/equestria/books/audiobookshelf/ks.yaml
@@ -27,7 +27,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/books/lazylibrarian/ks.yaml
+++ b/kubernetes/apps/equestria/books/lazylibrarian/ks.yaml
@@ -27,7 +27,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/books/openbooks/ks.yaml
+++ b/kubernetes/apps/equestria/books/openbooks/ks.yaml
@@ -27,7 +27,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/books/readarr-audio/ks.yaml
+++ b/kubernetes/apps/equestria/books/readarr-audio/ks.yaml
@@ -28,7 +28,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/books/readarr-ebook/ks.yaml
+++ b/kubernetes/apps/equestria/books/readarr-ebook/ks.yaml
@@ -28,7 +28,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/dns/technitium/ks.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/ks.yaml
@@ -28,7 +28,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/volsync

--- a/kubernetes/apps/equestria/downloads/autobrr/ks.yaml
+++ b/kubernetes/apps/equestria/downloads/autobrr/ks.yaml
@@ -33,7 +33,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/downloads/prowlarr/ks.yaml
+++ b/kubernetes/apps/equestria/downloads/prowlarr/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/downloads/qbittorrent/ks.yaml
+++ b/kubernetes/apps/equestria/downloads/qbittorrent/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/downloads/sabnzbd/ks.yaml
+++ b/kubernetes/apps/equestria/downloads/sabnzbd/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/games/habitica/ks.yaml
+++ b/kubernetes/apps/equestria/games/habitica/ks.yaml
@@ -27,7 +27,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/games/playerr/ks.yaml
+++ b/kubernetes/apps/equestria/games/playerr/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/games/questarr/ks.yaml
+++ b/kubernetes/apps/equestria/games/questarr/ks.yaml
@@ -31,7 +31,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/games/retrom/ks.yaml
+++ b/kubernetes/apps/equestria/games/retrom/ks.yaml
@@ -18,7 +18,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   wait: false
   interval: 30m

--- a/kubernetes/apps/equestria/games/romm/ks.yaml
+++ b/kubernetes/apps/equestria/games/romm/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/home/collabora/ks.yaml
+++ b/kubernetes/apps/equestria/home/collabora/ks.yaml
@@ -23,7 +23,7 @@ spec:
   dependsOn: []
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components: []
   postBuild:

--- a/kubernetes/apps/equestria/home/dynacat/ks.yaml
+++ b/kubernetes/apps/equestria/home/dynacat/ks.yaml
@@ -28,7 +28,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../kubernetes/components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/home/freshrss/ks.yaml
+++ b/kubernetes/apps/equestria/home/freshrss/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/home/immich/ks.yaml
+++ b/kubernetes/apps/equestria/home/immich/ks.yaml
@@ -31,7 +31,7 @@ spec:
       namespace: kube-system
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/home/karakeep/ks.yaml
+++ b/kubernetes/apps/equestria/home/karakeep/ks.yaml
@@ -25,7 +25,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/home/meilisearch/ks.yaml
+++ b/kubernetes/apps/equestria/home/meilisearch/ks.yaml
@@ -24,7 +24,7 @@ spec:
       namespace: kube-system
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/home/n8n/ks.yaml
+++ b/kubernetes/apps/equestria/home/n8n/ks.yaml
@@ -31,7 +31,7 @@ spec:
       namespace: kube-system
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/home/obsidian-sync/ks.yaml
+++ b/kubernetes/apps/equestria/home/obsidian-sync/ks.yaml
@@ -27,7 +27,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/home/outline/ks.yaml
+++ b/kubernetes/apps/equestria/home/outline/ks.yaml
@@ -23,7 +23,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/home/rustdesk/ks.yaml
+++ b/kubernetes/apps/equestria/home/rustdesk/ks.yaml
@@ -25,7 +25,7 @@ spec:
       namespace: volsync-system
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/volsync

--- a/kubernetes/apps/equestria/home/searxng/ks.yaml
+++ b/kubernetes/apps/equestria/home/searxng/ks.yaml
@@ -27,7 +27,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/home/super-productivity/ks.yaml
+++ b/kubernetes/apps/equestria/home/super-productivity/ks.yaml
@@ -22,7 +22,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/home/tandoor/ks.yaml
+++ b/kubernetes/apps/equestria/home/tandoor/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/home/tududi/ks.yaml
+++ b/kubernetes/apps/equestria/home/tududi/ks.yaml
@@ -28,7 +28,7 @@ spec:
       namespace: kube-system
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/home/windmill/ks.yaml
+++ b/kubernetes/apps/equestria/home/windmill/ks.yaml
@@ -27,7 +27,7 @@ spec:
       namespace: kube-system
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/idp/authentik-remote-cluster/ks.yaml
+++ b/kubernetes/apps/equestria/idp/authentik-remote-cluster/ks.yaml
@@ -22,5 +22,5 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system

--- a/kubernetes/apps/equestria/media/bazarr/ks.yaml
+++ b/kubernetes/apps/equestria/media/bazarr/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/media/emby/ks.yaml
+++ b/kubernetes/apps/equestria/media/emby/ks.yaml
@@ -28,7 +28,7 @@ spec:
   timeout: 1h
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/equestria/media/jellyfin/ks.yaml
@@ -28,7 +28,7 @@ spec:
   timeout: 1h
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/media/jellyseerr/ks.yaml
+++ b/kubernetes/apps/equestria/media/jellyseerr/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/media/kapowarr/ks.yaml
+++ b/kubernetes/apps/equestria/media/kapowarr/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/media/kometa/ks.yaml
+++ b/kubernetes/apps/equestria/media/kometa/ks.yaml
@@ -28,7 +28,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/volsync

--- a/kubernetes/apps/equestria/media/lidarr/ks.yaml
+++ b/kubernetes/apps/equestria/media/lidarr/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/media/mylar/ks.yaml
+++ b/kubernetes/apps/equestria/media/mylar/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/media/pinepods/ks.yaml
+++ b/kubernetes/apps/equestria/media/pinepods/ks.yaml
@@ -30,7 +30,7 @@ spec:
       namespace: kube-system
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/media/plex/ks.yaml
+++ b/kubernetes/apps/equestria/media/plex/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/media/pulsarr/ks.yaml
+++ b/kubernetes/apps/equestria/media/pulsarr/ks.yaml
@@ -31,7 +31,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/media/radarr/ks.yaml
+++ b/kubernetes/apps/equestria/media/radarr/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/media/seerr/ks.yaml
+++ b/kubernetes/apps/equestria/media/seerr/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/media/sonarr/ks.yaml
+++ b/kubernetes/apps/equestria/media/sonarr/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/media/stremio/ks.yaml
+++ b/kubernetes/apps/equestria/media/stremio/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/media/tautulli/ks.yaml
+++ b/kubernetes/apps/equestria/media/tautulli/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/media/tdarr/ks.yaml
+++ b/kubernetes/apps/equestria/media/tdarr/ks.yaml
@@ -24,7 +24,7 @@ spec:
   timeout: 1h
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/media/watchstate/ks.yaml
+++ b/kubernetes/apps/equestria/media/watchstate/ks.yaml
@@ -25,7 +25,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/pvr/dispatcharr/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/dispatcharr/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/pvr/ecm/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/ecm/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/pvr/ersatztv/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/ersatztv/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/pvr/game-thumbs/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/game-thumbs/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/pvr/identifiarr/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/identifiarr/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/pvr/iptv-sync/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/iptv-sync/ks.yaml
@@ -27,7 +27,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/tailscale

--- a/kubernetes/apps/equestria/pvr/kptv-fast/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/kptv-fast/ks.yaml
@@ -25,7 +25,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/pvr/strmgen/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/strmgen/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/pvr/teamarr/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/teamarr/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/pvr/xcproxy/ks.yaml
+++ b/kubernetes/apps/equestria/pvr/xcproxy/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/equestria/shared/secrets/ks.yaml
+++ b/kubernetes/apps/equestria/shared/secrets/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/equestria/shared/volumes/ks.yaml
+++ b/kubernetes/apps/equestria/shared/volumes/ks.yaml
@@ -27,7 +27,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/equestria/utils/librespeed/ks.yaml
+++ b/kubernetes/apps/equestria/utils/librespeed/ks.yaml
@@ -23,7 +23,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/equestria/utils/openspeedtest/ks.yaml
+++ b/kubernetes/apps/equestria/utils/openspeedtest/ks.yaml
@@ -23,7 +23,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/equestria/utils/whoami/ks.yaml
+++ b/kubernetes/apps/equestria/utils/whoami/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components: []
   postBuild:

--- a/kubernetes/apps/github-actions/1password/syndicates/ks.yaml
+++ b/kubernetes/apps/github-actions/1password/syndicates/ks.yaml
@@ -15,7 +15,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/github-actions/controller/ks.yaml
+++ b/kubernetes/apps/github-actions/controller/ks.yaml
@@ -18,7 +18,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   wait: true
   interval: 30m

--- a/kubernetes/apps/github-actions/repositories/ks.yaml
+++ b/kubernetes/apps/github-actions/repositories/ks.yaml
@@ -14,7 +14,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   wait: true
   interval: 30m

--- a/kubernetes/apps/github-actions/runners/david-driscoll/ks.yaml
+++ b/kubernetes/apps/github-actions/runners/david-driscoll/ks.yaml
@@ -19,7 +19,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   wait: true
   interval: 30m

--- a/kubernetes/apps/github-actions/runners/littles-tech-release/ks.yaml
+++ b/kubernetes/apps/github-actions/runners/littles-tech-release/ks.yaml
@@ -19,7 +19,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   wait: true
   interval: 30m

--- a/kubernetes/apps/github-actions/runners/littles-tech/ks.yaml
+++ b/kubernetes/apps/github-actions/runners/littles-tech/ks.yaml
@@ -19,7 +19,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   wait: true
   interval: 30m

--- a/kubernetes/apps/github-actions/runners/vault/ks.yaml
+++ b/kubernetes/apps/github-actions/runners/vault/ks.yaml
@@ -19,7 +19,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   wait: true
   interval: 30m

--- a/kubernetes/apps/kube-system/1password/ks.yaml
+++ b/kubernetes/apps/kube-system/1password/ks.yaml
@@ -20,7 +20,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -23,7 +23,7 @@ spec:
   timeout: 15m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   postBuild:

--- a/kubernetes/apps/kube-system/coredns/ks.yaml
+++ b/kubernetes/apps/kube-system/coredns/ks.yaml
@@ -21,7 +21,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   postBuild:

--- a/kubernetes/apps/kube-system/descheduler/ks.yaml
+++ b/kubernetes/apps/kube-system/descheduler/ks.yaml
@@ -19,7 +19,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   postBuild:

--- a/kubernetes/apps/kube-system/etcd/ks.yaml
+++ b/kubernetes/apps/kube-system/etcd/ks.yaml
@@ -17,7 +17,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   timeout: 5m

--- a/kubernetes/apps/kube-system/external-secrets/app/ks.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/app/ks.yaml
@@ -22,5 +22,5 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system

--- a/kubernetes/apps/kube-system/external-secrets/reloader/ks.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/reloader/ks.yaml
@@ -20,7 +20,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   dependsOn:
     - name: external-secrets

--- a/kubernetes/apps/kube-system/external-secrets/stores/ks.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/ks.yaml
@@ -20,7 +20,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   dependsOn:
     - name: external-secrets

--- a/kubernetes/apps/kube-system/features/amd/ks.yaml
+++ b/kubernetes/apps/kube-system/features/amd/ks.yaml
@@ -20,5 +20,5 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system

--- a/kubernetes/apps/kube-system/features/intel-gpu/ks.yaml
+++ b/kubernetes/apps/kube-system/features/intel-gpu/ks.yaml
@@ -27,7 +27,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   postBuild:

--- a/kubernetes/apps/kube-system/features/intel/ks.yaml
+++ b/kubernetes/apps/kube-system/features/intel/ks.yaml
@@ -20,5 +20,5 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system

--- a/kubernetes/apps/kube-system/features/node-feature-discovery/ks.yaml
+++ b/kubernetes/apps/kube-system/features/node-feature-discovery/ks.yaml
@@ -20,7 +20,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/kube-system/features/nvidia/ks.yaml
+++ b/kubernetes/apps/kube-system/features/nvidia/ks.yaml
@@ -20,5 +20,5 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system

--- a/kubernetes/apps/kube-system/headlamp/ks.yaml
+++ b/kubernetes/apps/kube-system/headlamp/ks.yaml
@@ -20,7 +20,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   dependsOn:
     - name: external-secrets

--- a/kubernetes/apps/kube-system/metrics-server/ks.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/ks.yaml
@@ -19,7 +19,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   postBuild:

--- a/kubernetes/apps/kube-system/multus/ks.yaml
+++ b/kubernetes/apps/kube-system/multus/ks.yaml
@@ -22,7 +22,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/kube-system/openbao-replica/ks.yaml
+++ b/kubernetes/apps/kube-system/openbao-replica/ks.yaml
@@ -51,7 +51,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/kube-system/openbao/ks.yaml
+++ b/kubernetes/apps/kube-system/openbao/ks.yaml
@@ -73,7 +73,7 @@ spec:
   timeout: 15m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../components/postgres

--- a/kubernetes/apps/kube-system/reflector/ks.yaml
+++ b/kubernetes/apps/kube-system/reflector/ks.yaml
@@ -19,7 +19,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   postBuild:

--- a/kubernetes/apps/kube-system/registry/ks.yaml
+++ b/kubernetes/apps/kube-system/registry/ks.yaml
@@ -23,7 +23,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   components:

--- a/kubernetes/apps/kube-system/reloader/ks.yaml
+++ b/kubernetes/apps/kube-system/reloader/ks.yaml
@@ -21,7 +21,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   postBuild:

--- a/kubernetes/apps/kube-system/secrets/docker-hub-auth/ks.yaml
+++ b/kubernetes/apps/kube-system/secrets/docker-hub-auth/ks.yaml
@@ -20,7 +20,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   dependsOn:
     - name: external-secrets

--- a/kubernetes/apps/kube-system/secrets/github-auth/ks.yaml
+++ b/kubernetes/apps/kube-system/secrets/github-auth/ks.yaml
@@ -19,7 +19,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   dependsOn:
     - name: external-secrets

--- a/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
@@ -28,7 +28,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   postBuild:

--- a/kubernetes/apps/kube-system/snapshot-crds/ks.yaml
+++ b/kubernetes/apps/kube-system/snapshot-crds/ks.yaml
@@ -31,7 +31,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/kube-system/spegel/ks.yaml
+++ b/kubernetes/apps/kube-system/spegel/ks.yaml
@@ -21,7 +21,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   postBuild:

--- a/kubernetes/apps/kube-system/vsc-retention/ks.yaml
+++ b/kubernetes/apps/kube-system/vsc-retention/ks.yaml
@@ -22,7 +22,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   postBuild:

--- a/kubernetes/apps/longhorn-system/longhorn/ks.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/ks.yaml
@@ -20,7 +20,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/longhorn-system/storageclass/ks.yaml
+++ b/kubernetes/apps/longhorn-system/storageclass/ks.yaml
@@ -23,7 +23,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/network/certificates/ks.yaml
+++ b/kubernetes/apps/network/certificates/ks.yaml
@@ -28,7 +28,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   healthChecks:
     - apiVersion: cert-manager.io/v1

--- a/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/network/crowdsec-ui/ks.yaml
+++ b/kubernetes/apps/network/crowdsec-ui/ks.yaml
@@ -32,7 +32,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/network/crowdsec/ks.yaml
+++ b/kubernetes/apps/network/crowdsec/ks.yaml
@@ -50,7 +50,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/network/external-dns/cloudflare/ks.yaml
+++ b/kubernetes/apps/network/external-dns/cloudflare/ks.yaml
@@ -26,5 +26,5 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system

--- a/kubernetes/apps/network/external-dns/records/ks.yaml
+++ b/kubernetes/apps/network/external-dns/records/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/network/external-dns/technitium/ks.yaml
+++ b/kubernetes/apps/network/external-dns/technitium/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/network/external-dns/unifi/ks.yaml
+++ b/kubernetes/apps/network/external-dns/unifi/ks.yaml
@@ -25,7 +25,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   postBuild:

--- a/kubernetes/apps/network/k8s-gateway/ks.yaml
+++ b/kubernetes/apps/network/k8s-gateway/ks.yaml
@@ -23,7 +23,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/network/secrets/ks.yaml
+++ b/kubernetes/apps/network/secrets/ks.yaml
@@ -32,5 +32,5 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system

--- a/kubernetes/apps/network/traefik-crds/ks.yaml
+++ b/kubernetes/apps/network/traefik-crds/ks.yaml
@@ -29,7 +29,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/network/traefik/ks.yaml
+++ b/kubernetes/apps/network/traefik/ks.yaml
@@ -28,7 +28,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/nfs-system/csi-driver-nfs/ks.yaml
+++ b/kubernetes/apps/nfs-system/csi-driver-nfs/ks.yaml
@@ -25,7 +25,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/observability/alertmanager/ks.yaml
+++ b/kubernetes/apps/observability/alertmanager/ks.yaml
@@ -27,7 +27,7 @@ spec:
   deletionPolicy: Orphan
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   wait: false
   interval: 24h

--- a/kubernetes/apps/observability/alloy/ks.yaml
+++ b/kubernetes/apps/observability/alloy/ks.yaml
@@ -25,5 +25,5 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system

--- a/kubernetes/apps/observability/blackbox-exporter/ks.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/ks.yaml
@@ -22,7 +22,7 @@ spec:
   retryInterval: 2m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   timeout: 5m

--- a/kubernetes/apps/observability/crds/ks.yaml
+++ b/kubernetes/apps/observability/crds/ks.yaml
@@ -24,7 +24,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/observability/grafana-operator/ks.yaml
+++ b/kubernetes/apps/observability/grafana-operator/ks.yaml
@@ -27,7 +27,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -27,7 +27,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/observability/intel-gpu-exporter/ks.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/observability/loki/ks.yaml
+++ b/kubernetes/apps/observability/loki/ks.yaml
@@ -24,7 +24,7 @@ spec:
   timeout: 20m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   path: ./kubernetes/apps/observability/loki
   dependsOn:

--- a/kubernetes/apps/observability/priority-class/ks.yaml
+++ b/kubernetes/apps/observability/priority-class/ks.yaml
@@ -25,7 +25,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/observability/prometheus/ks.yaml
+++ b/kubernetes/apps/observability/prometheus/ks.yaml
@@ -27,7 +27,7 @@ spec:
   deletionPolicy: Orphan
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   wait: false
   interval: 24h

--- a/kubernetes/apps/observability/silences/ks.yaml
+++ b/kubernetes/apps/observability/silences/ks.yaml
@@ -33,7 +33,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/observability/smartctl-exporter/ks.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/observability/speedtest-exporter/ks.yaml
+++ b/kubernetes/apps/observability/speedtest-exporter/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/observability/tempo/ks.yaml
+++ b/kubernetes/apps/observability/tempo/ks.yaml
@@ -25,5 +25,5 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system

--- a/kubernetes/apps/observability/thanos/ks.yaml
+++ b/kubernetes/apps/observability/thanos/ks.yaml
@@ -18,7 +18,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   dependsOn:
     - name: volsync

--- a/kubernetes/apps/observability/unpoller/ks.yaml
+++ b/kubernetes/apps/observability/unpoller/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/openebs-system/openebs/ks.yaml
+++ b/kubernetes/apps/openebs-system/openebs/ks.yaml
@@ -25,7 +25,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/pulumi/applications/ks.yaml
+++ b/kubernetes/apps/pulumi/applications/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 20m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/pulumi/authentik/ks.yaml
+++ b/kubernetes/apps/pulumi/authentik/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 20m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/pulumi/backups/ks.yaml
+++ b/kubernetes/apps/pulumi/backups/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 20m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/pulumi/gulf-of-mexico/ks.yaml
+++ b/kubernetes/apps/pulumi/gulf-of-mexico/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 20m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/pulumi/history-pruner/ks.yaml
+++ b/kubernetes/apps/pulumi/history-pruner/ks.yaml
@@ -27,7 +27,7 @@ spec:
   components: []
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/pulumi/home-operations/ks.yaml
+++ b/kubernetes/apps/pulumi/home-operations/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 20m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/pulumi/kubeproxies/ks.yaml
+++ b/kubernetes/apps/pulumi/kubeproxies/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 5m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/pulumi/lock-canceller/ks.yaml
+++ b/kubernetes/apps/pulumi/lock-canceller/ks.yaml
@@ -27,7 +27,7 @@ spec:
   components: []
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/pulumi/npm-cache-prune/ks.yaml
+++ b/kubernetes/apps/pulumi/npm-cache-prune/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 5m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/pulumi/ocracoke/ks.yaml
+++ b/kubernetes/apps/pulumi/ocracoke/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 20m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/pulumi/pulumi-operator/ks.yaml
+++ b/kubernetes/apps/pulumi/pulumi-operator/ks.yaml
@@ -27,7 +27,7 @@ spec:
   components: []
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/pulumi/secrets/gitrepository.yaml
+++ b/kubernetes/apps/pulumi/secrets/gitrepository.yaml
@@ -1,5 +1,38 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/gitrepository-source-v1.json
+# DO NOT fold this into flux-system/flux-system, and do not rename it.
+#
+# Every other Kustomization in this repo now uses sourceRef flux-system; the
+# eight Pulumi Stacks cannot, and it is not a permissions problem -- the
+# operator's ClusterRole already has cluster-wide get/list/watch on
+# gitrepositories. Two things in pulumi-kubernetes-operator block it, both
+# still true on master as of v2.9.0 (the latest release):
+#
+#   1. FluxSourceReference (operator/api/pulumi/shared/stack_types.go) has
+#      exactly three fields -- apiVersion, kind, name. There is no namespace
+#      field to set, and the CRD's structural schema prunes unknown keys, so a
+#      hand-added `namespace:` is silently dropped rather than rejected.
+#   2. stack_controller.go resolves the source with
+#      `client.ObjectKey{Name: fluxSource.SourceRef.Name, Namespace: request.Namespace}`
+#      -- hardcoded to the Stack's OWN namespace.
+#
+# The quieter of the two is the watch path: enqueueStacksForSourceFunc lists
+# candidate Stacks with `client.InNamespace(src.GetNamespace())`, so even a
+# lookup that somehow resolved cross-namespace would stop waking these Stacks
+# on new commits. They would go stale on the requeue timer instead of failing
+# loudly, which is the worst possible way for this to break.
+#
+# That leaves exactly one route to reusing flux-system/flux-system: move the
+# Stacks into the flux-system namespace, since the lookup follows the Stack.
+# Rejected on blast radius and on security -- it would relocate 9 Stacks, 13
+# ServiceAccounts and 16 Kustomizations, and would park pulumi-operator-passphrase,
+# -github and -bao-approle next to the controllers that run the whole cluster.
+# (Dropping fluxSource for spec.projectRepo would also remove the duplicate, at
+# the cost of Flux artifact caching and the webhook-driven resync. Also declined.)
+#
+# So this object stays, in this namespace, under this name. It is a genuinely
+# separate GitRepository from flux-system/flux-system that happens to track the
+# same URL and branch. One extra 10m fetch is the whole cost.
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:

--- a/kubernetes/apps/pulumi/secrets/ks.yaml
+++ b/kubernetes/apps/pulumi/secrets/ks.yaml
@@ -24,7 +24,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   # Required for openbao-approle.sops.yaml. The components/common patch adds
   # decryption to the parent `pulumi` Kustomization but not to this child, so

--- a/kubernetes/apps/pulumi/system/ks.yaml
+++ b/kubernetes/apps/pulumi/system/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 20m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/pulumi/unifi-network/ks.yaml
+++ b/kubernetes/apps/pulumi/unifi-network/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 20m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/pulumi/update-pruner/ks.yaml
+++ b/kubernetes/apps/pulumi/update-pruner/ks.yaml
@@ -27,7 +27,7 @@ spec:
   components: []
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/pulumi/vault/ks.yaml
+++ b/kubernetes/apps/pulumi/vault/ks.yaml
@@ -26,7 +26,7 @@ spec:
   timeout: 20m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/system-upgrade/tuppr/ks.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/ks.yaml
@@ -24,5 +24,5 @@ spec:
       NAMESPACE: *namespace
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system

--- a/kubernetes/apps/system-upgrade/upgrades/ks.yaml
+++ b/kubernetes/apps/system-upgrade/upgrades/ks.yaml
@@ -27,5 +27,5 @@ spec:
       NAMESPACE: *namespace
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system

--- a/kubernetes/apps/tailscale-system/golink/ks.yaml
+++ b/kubernetes/apps/tailscale-system/golink/ks.yaml
@@ -24,7 +24,7 @@ spec:
       namespace: volsync-system
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/tailscale-system/iam/ks.yaml
+++ b/kubernetes/apps/tailscale-system/iam/ks.yaml
@@ -25,7 +25,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/tailscale-system/idp/ks.yaml
+++ b/kubernetes/apps/tailscale-system/idp/ks.yaml
@@ -25,7 +25,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
     - ../../../components/failover/fast-node-eviction

--- a/kubernetes/apps/tailscale-system/kustomization.yaml
+++ b/kubernetes/apps/tailscale-system/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - ./golink/ks.yaml
   - ./idp/ks.yaml
   - ./iam/ks.yaml
+  - ./taildrive/ks.yaml

--- a/kubernetes/apps/tailscale-system/operator/ks.yaml
+++ b/kubernetes/apps/tailscale-system/operator/ks.yaml
@@ -25,7 +25,7 @@ spec:
       namespace: kube-system
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/tailscale-system/resources/ks.yaml
+++ b/kubernetes/apps/tailscale-system/resources/ks.yaml
@@ -25,7 +25,7 @@ spec:
       namespace: kube-system
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/tailscale-system/services/ks.yaml
+++ b/kubernetes/apps/tailscale-system/services/ks.yaml
@@ -23,7 +23,7 @@ spec:
       namespace: tailscale-system
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   postBuild:
     substitute:

--- a/kubernetes/apps/tailscale-system/taildrive/helmrelease.yaml
+++ b/kubernetes/apps/tailscale-system/taildrive/helmrelease.yaml
@@ -32,73 +32,143 @@ spec:
     fullnameOverride: *app
     controllers:
       app:
-        initContainers:
-          sysctler:
-            image:
-              repository: tailscale/tailscale
-              tag: v1.102.2@sha256:321ce041508c19079b57a28b6666c8d81ab0b08accc0a2585b3ab663d557ac24
-            command:
-              - /bin/sh
-              - '-c'
-            args:
-              - >-
-                sysctl -w net.ipv4.ip_forward=1 && if sysctl
-                net.ipv6.conf.all.forwarding; then sysctl -w
-                net.ipv6.conf.all.forwarding=1; fi
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
-            securityContext:
-              privileged: true
+        annotations:
+          reloader.stakater.com/auto: "true"
+        # The PVC is RWO and Longhorn-backed, so two replicas could never both
+        # mount it -- and two tailscaled processes sharing one state dir would
+        # fight over the node key regardless. Recreate, not RollingUpdate.
+        strategy: Recreate
         containers:
           app:
             image:
-              repository: ghcr.io/tailscale/tailscale
+              repository: tailscale/tailscale
               tag: v1.102.2@sha256:321ce041508c19079b57a28b6666c8d81ab0b08accc0a2585b3ab663d557ac24
-            command:
-              - /bin/sh
-              - '-c'
-            args:
-              - >-
-              - tailscale up --hostname=${APP}
-                tailscale drive share media /media
-                tailscale drive share backup /backup
-                tailscale drive share opencloud /opencloud
-                tailscale drive share taildrive /taildrive
+            # NOTE: no `command:`/`args:` override. The image's entrypoint is
+            # containerboot, and containerboot is what actually starts
+            # tailscaled and runs `tailscale up`. Overriding the entrypoint with
+            # `/bin/sh -c 'tailscale up ...'` -- the previous shape of this file
+            # -- left no daemon for the CLI to talk to.
             env:
-              TS_AUTHKEY:
+              TS_HOSTNAME: *app
+              TS_STATE_DIR: &state /var/lib/tailscale
+              # containerboot stores state in a kube Secret when it detects
+              # Kubernetes; we keep it on the volsync PVC instead so the node
+              # identity AND the Taildrive share list (both live in tailscaled
+              # prefs) survive a restart and are covered by the nightly backup.
+              TS_KUBE_SECRET: ""
+              # Taildrive is served out of tailscaled's own peerapi, so there is
+              # nothing here that needs a TUN device, NET_ADMIN, or a privileged
+              # container. Userspace keeps this pod unprivileged.
+              TS_USERSPACE: "true"
+              TS_AUTH_ONCE: "true"
+              TS_ACCEPT_DNS: "false"
+              TS_ENABLE_HEALTH_CHECK: "true"
+              # Load-bearing. Every drive grant in stacks/unifi-network/acl-manager.ts
+              # targets tag:shared-drive, and the `drive:share` + `drive:access`
+              # nodeAttrs are granted only to tag:shared-drive and autogroup:admin.
+              # A node registered under the shared tag:apps authkey has no
+              # Taildrive capability at all and `drive share` fails silently.
+              TS_EXTRA_ARGS: --advertise-tags=tag:shared-drive
+              # OAuth rather than the shared `tailscale-authkey` Secret: that
+              # Secret is hand-applied, untracked by Flux, and pre-tagged
+              # tag:apps, so it cannot register this node under tag:shared-drive.
+              # tag:operator owns tag:shared-drive (acl-manager.ts setTagOwner),
+              # so the operator's OAuth client can mint the key, and OAuth
+              # clients do not expire the way a 90-day authkey does.
+              TS_CLIENT_ID:
                 valueFrom:
                   secretKeyRef:
-                    name: tailscale-authkey
-                    key: authkey
+                    name: tailscale-oauth
+                    key: username
+              TS_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: tailscale-oauth
+                    key: credential
+            # containerboot has no env var for Taildrive -- `drive share` is a
+            # LocalAPI call, so it has to be made against a running tailscaled.
+            # postStart runs concurrently with the entrypoint and the container
+            # is not marked Running until it returns, so retrying the real
+            # command until it succeeds is both the wait and the assertion.
+            # It is idempotent: re-running it on every restart just re-asserts
+            # a share that is already in prefs.
+            lifecycle:
+              postStart:
+                exec:
+                  command:
+                    - /bin/sh
+                    - -c
+                    - |
+                      n=0
+                      until tailscale drive share shared /shared; do
+                        n=$((n + 1))
+                        if [ "$n" -ge 60 ]; then
+                          echo "taildrive: tailscaled never came up; giving up after 2m" >&2
+                          exit 1
+                        fi
+                        sleep 2
+                      done
+                      tailscale drive list
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &health 9002
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probe
+              # postStart already gates Running on tailscaled being reachable.
+              startup:
+                enabled: false
             securityContext:
-              privileged: true
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
 
     defaultPodOptions:
       securityContext:
-        runAsUser: 568
-        runAsGroup: 568
-        fsGroupChangePolicy: OnRootMismatch
+        # tailscaled writes its state dir and creates /var/run/tailscale itself.
+        # Root without any capability is what the technitium tailscale container
+        # already does here; VOLSYNC_PUID/PGID in ks.yaml are pinned to 0 to
+        # match, so the restic mover can read what this pod writes.
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        seccompProfile:
+          type: RuntimeDefault
+
+    service:
+      # ClusterIP only, for the containerboot health endpoint. Taildrive itself
+      # is reached over the tailnet at 100.100.100.100:8080 by each peer, never
+      # through a cluster Service -- which is why this app has no tailscale
+      # Ingress component.
+      app:
+        controller: app
+        type: ClusterIP
+        ports:
+          health:
+            port: *health
 
     persistence:
       data:
-        existingClaim: ${APP}
+        existingClaim: *app
         globalMounts:
-          - path: /taildrive
-      nfs-media:
-        type: nfs
-        server: ${SPIKE_IP}
-        path: /mnt/stash/media
-        globalMounts:
-          - path: /media
-      nfs-backup:
-        type: nfs
-        server: ${SPIKE_IP}
-        path: /mnt/stash/backup
-        globalMounts:
-          - path: /backup
-      nfs-opencloud:
-        type: nfs
-        server: ${SPIKE_IP}
-        path: /mnt/stash/data/opencloud
-        globalMounts:
-          - path: /opencloud
+          # Both subPaths are load-bearing. Mounting the volume root at /shared
+          # would put the tailscale state dir -- node key, machine key -- inside
+          # the directory served over WebDAV to every peer with a drive grant.
+          - path: /shared
+            subPath: shared
+          - path: *state
+            subPath: .tailscale-state

--- a/kubernetes/apps/tailscale-system/taildrive/ks.yaml
+++ b/kubernetes/apps/tailscale-system/taildrive/ks.yaml
@@ -15,6 +15,11 @@ spec:
       app.kubernetes.io/name: *app
       driscoll.dev/name: *app
   dependsOn:
+    # Not for the operator's CRDs -- this app uses none of them. It is for the
+    # `tailscale-oauth` Secret, which operator/tailscale.yaml's ExternalSecret
+    # produces and which this app reads for TS_CLIENT_ID / TS_CLIENT_SECRET.
+    - name: tailscale-operator
+      namespace: tailscale-system
     - name: volsync
       namespace: volsync-system
   path: ./kubernetes/apps/tailscale-system/taildrive
@@ -25,13 +30,25 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   components:
-    - ../../../components/tailscale
+    # NOTE: components/tailscale is deliberately absent. That component renders
+    # a tailscale-operator Ingress pointing at Service ${APP} port `http`.
+    # Taildrive is not an HTTP app and is not reached through the cluster at
+    # all -- peers talk to it over the tailnet at 100.100.100.100:8080 -- so
+    # that Ingress had no backend and would never go Ready.
     - ../../../components/volsync
   postBuild:
     substitute:
       APP: *app
       NAMESPACE: *namespace
-      VOLSYNC_CAPACITY: 50Gi
+      VOLSYNC_CAPACITY: 100Gi
+      # Pinned rather than inherited: the component's defaults are asymmetric
+      # (source 2Gi, destination 8Gi), and a 100Gi restic repo wants more index
+      # cache than the 2Gi source default would give it.
+      VOLSYNC_CACHE_CAPACITY: 10Gi
+      # tailscaled runs as root in this pod, so files landing in the share are
+      # root-owned. The restic mover has to match or it cannot read them.
+      VOLSYNC_PUID: "0"
+      VOLSYNC_PGID: "0"

--- a/kubernetes/apps/volsync-system/restore-cleanup/ks.yaml
+++ b/kubernetes/apps/volsync-system/restore-cleanup/ks.yaml
@@ -22,7 +22,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   postBuild:

--- a/kubernetes/apps/volsync-system/volsync/ks.yaml
+++ b/kubernetes/apps/volsync-system/volsync/ks.yaml
@@ -22,7 +22,7 @@ spec:
   timeout: 10m
   sourceRef:
     kind: GitRepository
-    name: home-operations
+    name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
   postBuild:


### PR DESCRIPTION
Two related changes: getting `tailscale-system/taildrive` to actually deploy, and the sourceRef cleanup that surfaced while validating it.

## 1. Taildrive

`taildrive/ks.yaml` was never listed in the namespace kustomization, so Flux never created the Kustomization — confirmed against the cluster, there is no `taildrive` Kustomization in `tailscale-system`. That alone meant none of the file's other problems had ever had a chance to fail. Registering it exposed five more:

| Problem | Fix |
| --- | --- |
| `command: [/bin/sh, -c]` bypassed `containerboot`, so `tailscaled` never started and `tailscale up` had no daemon to talk to | Removed the entrypoint override |
| `args` was malformed — `- >-` produced an empty first arg, then folded four commands into one string with no separators | Gone with the override |
| Registered under `tag:apps`, which has **no** Taildrive capability | Register under `tag:shared-drive` |
| `components/tailscale` renders an Ingress at Service `${APP}` port `http`, which Taildrive has neither of — `wait: true` would hang on it | Component dropped |
| `runAsUser: 568`; `tailscaled` needs root | Root, unprivileged |

**On the tag.** Every drive grant in `stacks/unifi-network/acl-manager.ts` targets `tag:shared-drive`, and the `drive:share`/`drive:access` nodeAttrs reach only that tag and `autogroup:admin`. The shared `tailscale-authkey` Secret is pre-tagged `tag:apps`, so it could never have worked. Since `tag:operator` owns `tag:shared-drive`, the operator's existing OAuth client can register the node via `TS_CLIENT_ID`/`TS_CLIENT_SECRET` + `--advertise-tags` — no new Secret, and OAuth clients don't expire like a 90-day authkey. This also drops the last consumer of `tailscale-authkey`, which is hand-applied and untracked by Flux.

**On the share.** `containerboot` has no Taildrive env var — `drive share` is a LocalAPI call, so it needs a live `tailscaled`. A `postStart` hook retries the real command, which is both the wait and the assertion. Userspace networking means no TUN, no `NET_ADMIN`, no privileged container, and the `sysctl` init container is gone.

Share is `shared` (matching the existing `shared-drive-access` grant, so no ACL change) on a 100Gi volsync PVC. Mounted by **subPath** — mounting the volume root would have put the tailscale state dir, node key and machine key included, inside the directory served over WebDAV to every peer with a drive grant.

## 2. sourceRef migration

Validating the above surfaced that `flate` couldn't see working-tree changes, because the child Kustomizations referenced the `home-operations` GitRepository and flate resolves that by cloning remote `main`. Both GitRepositories track the same URL and branch and were on the same commit; `flux-system` reconciles at 1m instead of 1h and has no `ignore` patterns, so the switch is content-identical.

**167 Kustomizations move. Two categories deliberately don't** — `home-operations` names three different objects here, and a textual sweep would conflate them:

- **8 Pulumi `Stack` `fluxSource.sourceRef`** — no namespace field, so they resolve against the Stack's own namespace (`pulumi/home-operations`, a separate GitRepository). Renaming these would break every Pulumi stack.
- **4 `dependsOn: {name: home-operations, namespace: pulumi}`** — a Kustomization dependency, not a source.

I researched whether Pulumi could follow. It can't, and it isn't RBAC — the operator's ClusterRole already has cluster-wide `get/list/watch` on `gitrepositories`. `FluxSourceReference` has exactly `apiVersion`/`kind`/`name`, and the CRD's structural schema silently **prunes** a hand-added `namespace`. `stack_controller.go` resolves with `Namespace: request.Namespace`. Quietest of all, `enqueueStacksForSourceFunc` lists candidates with `client.InNamespace(src.GetNamespace())` — so a cross-namespace reference would stop waking the Stacks on new commits rather than erroring. Still true on `master`, and v2.9.0 is the latest release. `pulumi/secrets/gitrepository.yaml` now records this so the inconsistency isn't "fixed" later into a silent-staleness bug.

## Verification

- `hk check` green across all 7 steps (`flate`, `yamllint`, `typos`, `detect-private-key`, `newlines`, `trailing-whitespace`, `check-case-conflict`).
- flate reports **351 passed / 2 skipped and a byte-identical object set** against a pristine HEAD worktree — the migration introduces zero rendering delta.
- Taildrive values render clean against app-template 5.1.0 with schema validation; volsync renders a 100Gi PVC with `runAsUser: 0` movers.
- Confirmed against the live cluster that all 148 consumers come from `cluster-apps` — one cluster, no external repo consumes the old source.

## Follow-ups (not in this PR)

- `flux-system/home-operations` now has **zero** consumers. Its definition and Receiver entry are left in place on purpose so the old source stays resolvable through rollout; removal is a clean second commit once this reconciles. `pulumi/home-operations` must stay either way.
- Worth a glance before merge: the drive grants in `acl-manager.ts` are Pulumi-applied state I couldn't verify from the repo. If they aren't live, the postStart hook crash-loops the pod with a visible `drive share` failure rather than failing silently.
- First deploy creates a lingering 100Gi `taildrive-dst-dest` PVC on top of the 100Gi source, per `components/volsync/AGENTS.md`. ~200Gi against 5TB free, but it's a larger instance of the pattern that doc calls the 2026-07 storage incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)