### PR TITLE
fix(taildrive): run as nobody so Taildrive will actually serve the share

### DIFF
--- a/kubernetes/apps/tailscale-system/taildrive/helmrelease.yaml
+++ b/kubernetes/apps/tailscale-system/taildrive/helmrelease.yaml
@@ -38,6 +38,41 @@ spec:
         # mount it -- and two tailscaled processes sharing one state dir would
         # fight over the node key regardless. Recreate, not RollingUpdate.
         strategy: Recreate
+        initContainers:
+          # fsGroup alone is not enough. It sets GROUP ownership and adds group
+          # write, but never changes the uid -- so the state dir stays owned by
+          # root, and tailscaled's `chmod` on it fails with EPERM for nobody.
+          # The failure is quiet and badly downstream-shifted: tailscaled falls
+          # back to an in-memory store, never logs in, never receives a netmap,
+          # and the drive share PUT then 403s with "taildrive sharing not
+          # enabled ... add drive:share to nodeAttrs" -- which reads exactly
+          # like an ACL problem and is not one.
+          #
+          # Same shape as tsidp's fix-permissions init container. Only the state
+          # dir is walked: /shared is already setgid + group-writable from
+          # fsGroup, which is all the file server needs, and -R over a 100Gi
+          # share would be a real cost on every restart.
+          fix-permissions:
+            image:
+              repository: busybox
+              tag: 1.38.0@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616
+            command:
+              - /bin/sh
+              - -c
+              - |
+                chown -R 65534:65534 /var/lib/tailscale
+                chown 65534:65534 /shared
+            securityContext:
+              # Must be explicit: the pod sets runAsNonRoot: true, and the
+              # kubelet rejects a container that inherits it while asking for
+              # uid 0.
+              runAsNonRoot: false
+              runAsUser: 0
+              runAsGroup: 0
+              capabilities:
+                add:
+                  - CHOWN
+                  - FOWNER
         containers:
           app:
             image:
@@ -139,13 +174,30 @@ spec:
 
     defaultPodOptions:
       securityContext:
-        # tailscaled writes its state dir and creates /var/run/tailscale itself.
-        # Root without any capability is what the technitium tailscale container
-        # already does here; VOLSYNC_PUID/PGID in ks.yaml are pinned to 0 to
-        # match, so the restic mover can read what this pod writes.
-        runAsNonRoot: false
-        runAsUser: 0
-        runAsGroup: 0
+        # 65534/nobody, and both halves of that are load-bearing.
+        #
+        # NON-ROOT, because Taildrive refuses to serve as root. tailscaled runs
+        # the file server as the share's owning UNIX account (Share.As), and
+        # drive/driveimpl/remote_impl.go tries sudo, then su, then falls back to
+        # running it in-process behind assertNotRoot() -- which hard-fails on
+        # uid 0. This pod has no sudo in the image and no CAP_SETUID/CAP_SETGID
+        # to su with, so the fallback is the only reachable branch and it must
+        # not be root. Running as nobody puts us on that branch cleanly
+        # ("starting taildrive file server as ourselves") with no capabilities.
+        #
+        # 65534 SPECIFICALLY, because assertNotRoot() calls user.Current(),
+        # which resolves uid -> name out of /etc/passwd. The estate's usual 568
+        # has no passwd entry in this image, so it would not fail open -- it
+        # would fail differently, with "failed to find current user". nobody is
+        # the only non-system account the image actually defines.
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        # Makes the volume group-owned by 65534 so tailscaled can write its
+        # state dir and clients can write the share. VOLSYNC_PUID/PGID in
+        # ks.yaml match, so the restic mover reads what this pod writes.
+        fsGroup: 65534
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
 
@@ -162,6 +214,15 @@ spec:
             port: *health
 
     persistence:
+      # containerboot puts the real socket at /tmp/tailscaled.sock and symlinks
+      # it to /run/tailscale/tailscaled.sock so the CLI finds it on its default
+      # path. /run in this image is root-owned 0755, so as nobody we cannot
+      # create that directory -- and without it the postStart hook's `tailscale`
+      # invocation has no socket to talk to. An emptyDir supplies a writable one.
+      run-tailscale:
+        type: emptyDir
+        globalMounts:
+          - path: /run/tailscale
       data:
         existingClaim: *app
         globalMounts:

--- a/kubernetes/apps/tailscale-system/taildrive/ks.yaml
+++ b/kubernetes/apps/tailscale-system/taildrive/ks.yaml
@@ -48,7 +48,8 @@ spec:
       # (source 2Gi, destination 8Gi), and a 100Gi restic repo wants more index
       # cache than the 2Gi source default would give it.
       VOLSYNC_CACHE_CAPACITY: 10Gi
-      # tailscaled runs as root in this pod, so files landing in the share are
-      # root-owned. The restic mover has to match or it cannot read them.
-      VOLSYNC_PUID: "0"
-      VOLSYNC_PGID: "0"
+      # Must track the pod's runAsUser/fsGroup (65534/nobody -- see the
+      # helmrelease for why Taildrive forces a non-root uid). If these drift
+      # apart the mover cannot read what the file server writes.
+      VOLSYNC_PUID: "65534"
+      VOLSYNC_PGID: "65534"


### PR DESCRIPTION
Follow-up to #905. That PR got the node onto the tailnet and the share registered — both of which work — but nothing actually *served* the share.

**Verified working on the cluster before opening this PR** (details at the bottom).

## Root cause

Taildrive refuses to run its file server as root. tailscaled runs it as the share's owning UNIX account, and [`drive/driveimpl/remote_impl.go`](https://github.com/tailscale/tailscale/blob/main/drive/driveimpl/remote_impl.go) tries three branches in order:

1. `sudo -n -u <user>` — **not in this image**
2. `su <user> -c …` — needs `CAP_SETUID`/`CAP_SETGID`, which `drop: ALL` removed
3. in-process, behind `assertNotRoot()` — **hard-fails on uid 0**

So branch 3 was the only reachable one, and it was root. The symptom was a tight retry loop:

```
su check failed: exit status 1
user server /usr/local/bin/tailscaled stopped with error "root" is root
```

## Fix

Run as **65534/nobody**, which lands on branch 3 as intended — `starting taildrive file server as ourselves` — with **no capabilities at all**.

65534 specifically, and not the estate's usual 568: `assertNotRoot()` calls `user.Current()`, which resolves the uid out of `/etc/passwd`. 568 has no entry in this image, so it wouldn't fail open — it'd fail *differently*, with `failed to find current user`. `nobody` is the only non-system account the image defines.

Two consequences of going non-root, both handled:

- **`/run` is root-owned `0755`.** containerboot symlinks its socket into `/run/tailscale` so the CLI finds it on the default path; as nobody it can't create that dir, and the postStart hook then has no socket to talk to. Added an emptyDir.

- **`fsGroup` is not sufficient for the state dir.** It sets group ownership and adds group write but *never changes the uid*, so `/var/lib/tailscale` stayed root-owned and tailscaled's `chmod` on it failed with `EPERM`. This is the trap `iam/tsiam.yaml` already documents in a comment. Fixed with the same `fix-permissions` init container `tsidp` uses.

### The misleading failure worth knowing about

That `chmod` failure lands a long way from its cause. tailscaled falls back to an in-memory store → never logs in → never receives a netmap → `DriveSharingEnabled()` is false → the share PUT returns:

```
403: taildrive sharing not enabled, please add the attribute "drive:share" to this node in your ACLs' "nodeAttrs" section
```

That reads exactly like an ACL problem and is not one. **The ACL grants in `acl-manager.ts` are live and correct** — proven by the root-running pod, which registered under `tag:shared-drive` and created the share successfully. Anyone who hits this message should check the state dir before touching the policy file.

Only the state dir is walked recursively. `/shared` is already setgid and group-writable via fsGroup, and `-R` over a 100Gi share on every restart would be a real cost.

`VOLSYNC_PUID`/`PGID` follow to 65534 so the restic mover can still read what the file server writes.

## Verification

Live on the cluster, before this PR was opened:

- Pod `1/1 Running`, no restarts
- `tailscale drive list` → `shared  /shared  nobody`
- Logs show `starting taildrive file server as ourselves`; the `store.New failed` error is gone and it reaches `active login: taildrive.opossum-yo.ts.net` → `ipn state Starting -> Running`
- **WebDAV round-trip from a real tailnet peer** (`cheesesandwich`, `david.driscoll@`, via the existing `admin-drive-access` grant): `PUT` → `201`, `GET` → content intact, `DELETE` → `204`, `GET` → `404`
- `hk check` green across all 8 steps

The live Deployment currently carries this fix as an out-of-band `kubectl patch`. Merging replaces it with the declared state; **if this sits unmerged past the next HelmRelease reconcile, Flux reverts taildrive to the broken root config.**

## Note for later

Gating startup on a `postStart` hook means Kubernetes withholds container logs until the hook returns — so during the 2-minute failure window there were no logs at all, which made this materially harder to diagnose. It works correctly now, but a sidecar that waits on the socket would be more debuggable if this ever needs revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)