### PR TITLE
fix(flux): point github-status commit statuses at home-operations

### DIFF
--- a/kubernetes/flux/meta/cluster-secrets.sops.yaml
+++ b/kubernetes/flux/meta/cluster-secrets.sops.yaml
@@ -49,7 +49,7 @@ stringData:
   POSTGRES_LIMITS_MEMORY: ENC[AES256_GCM,data:nQiU,iv:QkKwGty0j3b54HrR8TmjF9lbue5HAaEbRIbTQX9QQ/c=,tag:KVv77gcZurngTW760yMxfg==,type:str]
   POSTGRES_SHARED_BUFFERS: ENC[AES256_GCM,data:3QaaA25u,iv:FtSkfiZ276FdIQhPJDcDyWgB/OaXxe0ISQEJA3qdax4=,tag:PvPpqrznBM11eJ3iQRWdXQ==,type:str]
   GITHUB_REPOSITORY: ENC[AES256_GCM,data:7sp8QPuuBqaaQfmd+zRTXqGHn+meSbmHycGRzSNxXpsMtf2FOnajfD5FgXj42f1ItvZn,iv:P1MDbcrKicHU2XSn3uFU6x4KB2uoonsXbKYsDb9Eous=,tag:UAg3m2dgJFu0u/ZksLKKwA==,type:str]
-  GITHUB_REPOSITORY_OWNER: ENC[AES256_GCM,data:2Up1wzZQPU59gSRviWoDXLaGBuo2udlvB3nRRmDjTuo=,iv:QxyvJcUCxlatbOAyPFV91238e3HNE/xF4w03C6yPlKc=,tag:5/aJb4HlYx56p6Lgr05jow==,type:str]
+  GITHUB_REPOSITORY_OWNER: ENC[AES256_GCM,data:mFE3Nr7bu1Tuzei1P6UVUiD/W4RggSJEFpihkMTW,iv:VcNUJEK5mE2LVSkweT57dpqbA47R44DyAIqXREpW0C4=,tag:61cqwgbgjRvJGNpuvW+ycw==,type:str]
   QBITTORRENT_IP: ENC[AES256_GCM,data:80uKuzx65aHgSWvnCA==,iv:CFem/Cwu0aZqSylAw0a0sZB0ZOo6HzCxbEyCkvCgMWk=,tag:Vs8USb74JjAKOc7JVbIqKg==,type:str]
   CHRONY_VIP: ENC[AES256_GCM,data:zXxFRdxukCwZKOinSA==,iv:MMvX1MG0DidnRljQAoLgSv/LcD/hjomCUsDTYRVCFBc=,tag:gCpStLBmPIldhfH03v5tQQ==,type:str]
   CHRONY_TAILSCALE_VIP: ENC[AES256_GCM,data:yr4nvMymJ5A/m9CXVnqL,iv:YjMp42AcK+dWOCq63pzUKNPKzloL8OAZifFfOQerJhI=,tag:PRnDQhctXAzzr3WRXtl1aQ==,type:str]
@@ -78,7 +78,7 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age150z0s36kl9vud8728c5e4zqq6nmyywekk76rwvjclcsfc8mrxuuqr0qfg6
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-13T03:25:18Z"
-  mac: ENC[AES256_GCM,data:atS/MxEhm0oqyht6Duog17UDdyufZXOLfMH/DYZNYqkomrOnrcX9NE1LZoIiXVpU37KIr0gtpMgj5o7F0tuW37eqOkJXsnxq1yWNS7snCEtBot+PhJpCTQc+VIPdnU+WqotKONJF5r4tq0JrxtTn1IrUS9C6U2LPyNQ+f0hvDr8=,iv:jUDX4Nus/raQ+/Rh1hl59gOk9DcaovUJuUqtSbUu2mg=,tag:0gCQ2eMb6vQf25GcIfgopA==,type:str]
+  lastmodified: "2026-08-18T00:38:26Z"
+  mac: ENC[AES256_GCM,data:YWNRMsMK6wXKrAXiF//HsQBjXFY4vzJSXamAfKUgbaXRBrQwzntekgWbs5UhCaKJdEp/5r6YBiVTuxO3kc3J9fnoOx7lxUBqzdeVrI/nvNCNlKAT5uh0Xd1P5r6DcQEYlTyqFb84bsS3IOx1AK5vAZG4b7r6dehLkcSLYs6+2U4=,iv:1S/ydrldaXMeFaTkmEB1YYIZUbh6cX1WKrrndTQNMYo=,tag:5njzbAevorg+uxIfqzQFfA==,type:str]
   mac_only_encrypted: true
   version: 3.13.2


### PR DESCRIPTION
Every Kustomization reconcile has been logging a `NotificationDispatchFailed` warning since the repo consolidation:

```
could not create commit status:
POST https://api.github.com/repos/david-driscoll/equestria-cluster/statuses/<sha>:
422 No commit found for SHA
```

## What it actually is

I originally reported this as an alert pointing at a repo it "can never resolve commits from," which implied a dead feature worth deleting. That was wrong, and worth correcting: it's a **stale value**, not a broken integration.

`components/alerts/github-status/provider.yaml` builds its address from `${GITHUB_REPOSITORY_OWNER}`, and that variable still held `david-driscoll/equestria-cluster`. So notification-controller was faithfully posting this repo's commit statuses to the pre-consolidation repo, which has never seen those SHAs — hence the 422.

Repointing it doesn't just silence a warning, it **restores the feature**: each Flux Kustomization reconcile posts a commit status, so PRs show whether a change actually reconciled per-Kustomization.

## Change

One value in `cluster-secrets.sops.yaml`:

```
GITHUB_REPOSITORY_OWNER: david-driscoll/equestria-cluster
                      -> david-driscoll/home-operations
```

The diff is that key re-encrypted plus sops's own `lastmodified`/`mac`, nothing else.

Blast radius is nil — `${GITHUB_REPOSITORY_OWNER}` has exactly **one** consumer in the repo, the Provider address.

## Verification

Patched the `tailscale-system` Provider live to the new address, reconciled a Kustomization, and confirmed the status landed on this repo:

```
success   kustomization/golink/2e778d60   reconciliation succeeded
```

on commit `5dcd37d1`. That also settles the one open question — whether the GitHub App installation can reach `home-operations`. **It can.**

One Provider (of 18) currently carries this as an out-of-band patch; merging applies it to all 18 via the secret, and Flux will revert the patched one back to the stale address on its next reconcile if this doesn't land.

`hk check` clean on the modified file. (`hk check --all` reports pre-existing biome formatting drift in `scripts/op-to-bao/index.ts`, unrelated to this change and left alone.)

## Two things I found but did not change

- **`GITHUB_REPOSITORY_OWNER` is misnamed.** It holds `owner/repo`, not an owner. Renaming it to something like `GITHUB_STATUS_REPO` would remove the trap that caused this, but it widens the diff beyond one value — happy to do it as a follow-up.
- **`GITHUB_REPOSITORY` is dead *and* stale.** It holds `https://github.com/david-driscoll/equestria-cluster` and has **zero** consumers anywhere in the repo. It's harmless today, but it's a loaded footgun for whoever wires up the next integration and reaches for the obvious-looking variable. Worth deleting in its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)