### PR TITLE
fix(talos): hard-hat becomes a worker, and stop Homebrew shadowing pinned tools

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -86,6 +86,20 @@ run = ['bash scripts/install-pkl-vscode.sh']
 experimental = true
 prereleases = true
 idiomatic_version_file_enable_tools = ["dotnet"]
+# Put mise's tool paths AHEAD of the ambient PATH.
+#
+# Without this, /opt/homebrew/bin shadows every pinned tool. Found 2026-08-17
+# when `talos:validate-config` refused to run: it compares `talosctl version`
+# against talos/talenv.yaml and reported v1.13.5 while [tools] pins 1.13.8 —
+# because all 15 talos tasks were resolving Homebrew's talosctl, not mise's.
+# The gate was right and the environment was wrong.
+#
+# It is not hypothetical or talosctl-specific: the estate has hit the same
+# shadowing with a Homebrew `pulumi` ahead of mise's. Pinning a tool version in
+# [tools] means nothing if a task can silently run a different binary, and the
+# failure is quiet — a Talos config generated for 1.13.8 validated by a 1.13.5
+# client.
+activate_aggressive = true
 
 [env]
 # Secret values are `vals` references, resolved per command:

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -126,7 +126,11 @@ nodes:
       model: "KINGSTON SNV3S1000G"
     machineSpec:
       secureboot: false
-    controlPlane: true
+    # Rotated out to a worker 2026-08-17 (piece 19). Talos cannot demote a
+    # control plane in place, so this node was drained, removed from etcd,
+    # wiped and rejoined — the same mechanism piece 18 used to promote the
+    # ex-SGC nodes, run in the other direction.
+    controlPlane: false
     userVolumes:
       - name: longhorn
         filesystem:


### PR DESCRIPTION
Two changes from executing [piece 19](docs/cluster-consolidation/19-rotate-equestria-control-planes.md)'s first node. The second is the more consequential.

## hard-hat is now a worker

Drained, removed from etcd, wiped, rejoined. Talos cannot demote a control plane in place, so this is the same wipe-and-rejoin [piece 18](docs/cluster-consolidation/18-sgc-nodes-join-control-plane.md) used to *promote* the ex-SGC nodes, run in the other direction.

Verified after the fact rather than assumed:

```
machine-type:        worker
etcd members:        5  (hard-hat absent)
control-plane pods:  0 on hard-hat
```

Two leftovers the rejoin doesn't handle, cleared by hand: the Step 1 cordon, and a stale `node-role.kubernetes.io/control-plane` label that Kubernetes keeps on the Node object regardless of what Talos rejoined as.

## `activate_aggressive` — the pinned-tool problem

`talos:validate-config` refused to run, reporting `talosctl is v1.13.5 but talos/talenv.yaml asks for v1.13.8`.

**The gate was right and the environment was wrong.** mise tasks were resolving `/opt/homebrew/bin/talosctl`, not the `[tools]` pin:

```
$ command -v talosctl      (inside a mise task)
/opt/homebrew/bin/talosctl
  in-task talosctl: v1.13.5
```

All **15** talos tasks were affected — including ones that generate and validate machine configs. A config produced for 1.13.8 was being validated by a 1.13.5 client, and nothing said so.

Pinning a version in `[tools]` means nothing if a task can silently run a different binary, and this failure is quiet rather than loud. It is also **not talosctl-specific** — the estate has hit the same shadowing with a Homebrew `pulumi` ahead of mise's. Fixing it once at the settings level beats patching fifteen call sites and then the next tool after that.

After the change, `talos:validate-config` passes and validates all 7 configs with the correct client.

## Verification

- [x] `hk check` — 9 checks pass, yamllint included
- [x] `talos:validate-config` green; all 7 configs valid for metal mode
- [x] hard-hat's worker status confirmed from Talos, etcd and the pod list — not from labels

## Not in this PR

fluttershy and kerfuffle are still control planes. kerfuffle holds `postgres-1` (the primary) and 112 Longhorn replicas, so it needs a `cnpg promote` first and — worth considering — a Longhorn eviction before its wipe rather than a rebuild storm after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)