### PR TITLE
feat(taildrive): add family and documents shares

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,9 @@ stacks/unifi-network/tailscale-acl.json
 # Bare patterns here, so they match at any depth.
 kubeconfig
 talosconfig
+
+# Plaintext SOPS scratch files. The VS Code SOPS extension writes a decrypted
+# twin next to the encrypted file as `.decrypted~<name>.sops.yaml` while you
+# edit it, and leaves it behind if the editor dies. Bare pattern, so it matches
+# at any depth; the trailing glob covers .sops.json/.sops.env twins too.
+.decrypted~*

--- a/kubernetes/apps/tailscale-system/taildrive/helmrelease.yaml
+++ b/kubernetes/apps/tailscale-system/taildrive/helmrelease.yaml
@@ -49,9 +49,15 @@ spec:
           # like an ACL problem and is not one.
           #
           # Same shape as tsidp's fix-permissions init container. Only the state
-          # dir is walked: /shared is already setgid + group-writable from
-          # fsGroup, which is all the file server needs, and -R over a 100Gi
-          # share would be a real cost on every restart.
+          # dir is walked; the share dirs get a non-recursive chown, which is
+          # all the file server needs, and -R over a 100Gi volume would be a
+          # real cost on every restart.
+          #
+          # The share chowns are not redundant with fsGroup. kubelet creates a
+          # missing subPath directory as root:root, and fsGroupChangePolicy
+          # OnRootMismatch skips the recursive walk because the volume root
+          # already matches 65534 -- so a newly added share would land
+          # unwritable by nobody without this.
           fix-permissions:
             image:
               repository: busybox
@@ -61,7 +67,7 @@ spec:
               - -c
               - |
                 chown -R 65534:65534 /var/lib/tailscale
-                chown 65534:65534 /shared
+                chown 65534:65534 /shared /family /documents
             securityContext:
               # Must be explicit: the pod sets runAsNonRoot: true, and the
               # kubelet rejects a container that inherits it while asking for
@@ -124,9 +130,13 @@ spec:
             # LocalAPI call, so it has to be made against a running tailscaled.
             # postStart runs concurrently with the entrypoint and the container
             # is not marked Running until it returns, so retrying the real
-            # command until it succeeds is both the wait and the assertion.
+            # command until it succeeds doubles as the wait for the daemon.
             # It is idempotent: re-running it on every restart just re-asserts
             # a share that is already in prefs.
+            #
+            # It is NOT an assertion that a share is serveable -- the path is
+            # never validated (see the persistence block). It only proves the
+            # LocalAPI is reachable and drive sharing is enabled.
             lifecycle:
               postStart:
                 exec:
@@ -143,6 +153,14 @@ spec:
                         fi
                         sleep 2
                       done
+
+                      # tailscaled is up by the time the loop above exits, so
+                      # the rest need no retry -- and a failure here is a real
+                      # failure (bad share name, drive not enabled) rather than
+                      # a startup race, so it should surface immediately.
+                      tailscale drive share family /family || exit 1
+                      tailscale drive share documents /documents || exit 1
+
                       tailscale drive list
             probes:
               liveness: &probe
@@ -226,10 +244,22 @@ spec:
       data:
         existingClaim: *app
         globalMounts:
-          # Both subPaths are load-bearing. Mounting the volume root at /shared
-          # would put the tailscale state dir -- node key, machine key -- inside
-          # the directory served over WebDAV to every peer with a drive grant.
+          # Every subPath here is load-bearing. Mounting the volume root at a
+          # share path would put the tailscale state dir -- node key, machine
+          # key -- inside a directory served over WebDAV to every peer with a
+          # drive grant.
+          #
+          # A share MUST be mounted here to work. `tailscale drive share` does
+          # not validate the path: cmd/tailscale/cli/drive.go only runs
+          # filepath.Abs, and ipnlocal.DriveSetShare just writes it into prefs
+          # (its only error is ErrDriveNotEnabled). So an unmounted share dir
+          # succeeds at the CLI, lists in `tailscale drive list`, goes Ready,
+          # reconciles green -- and then ENOENTs for every peer that opens it.
           - path: /shared
             subPath: shared
+          - path: /family
+            subPath: family
+          - path: /documents
+            subPath: documents
           - path: *state
             subPath: .tailscale-state


### PR DESCRIPTION
Two more Taildrive shares alongside `shared`, each on its own subPath of the existing 100Gi PVC so they survive restarts and land in the nightly volsync backup.

## The mounts are the load-bearing part

`tailscale drive share` never validates the path it is handed. In v1.102.2, `cmd/tailscale/cli/drive.go`'s `runDriveShare` only runs `filepath.Abs` — no `os.Stat`, no `IsDir` — and `ipnlocal.DriveSetShare` just normalizes the name and writes the share into prefs, with `ErrDriveNotEnabled` as its only error.

So a share pointed at a directory that isn't mounted:

- succeeds at the CLI
- appears in `tailscale drive list`
- passes the postStart hook
- goes Ready, and reconciles green

…and then ENOENTs for every peer that opens it. Same quiet, downstream-shifted failure shape as the uid bug in #906.

An init-container `mkdir` cannot substitute for the mount: init containers share *volumes* with the app container, not their writable layers, so the directory is discarded when the init container exits.

## Other changes

**Share chowns stay, and are not redundant with `fsGroup`.** kubelet creates a missing subPath directory as `root:root`, and `fsGroupChangePolicy: OnRootMismatch` skips the recursive walk because the volume root already matches 65534 — so a new share dir would otherwise land unwritable by nobody.

**Collapsed the per-share retry loops in postStart.** Once the first `drive share` succeeds tailscaled is up, so the later loops could never spin. They only stood to stall 2m apiece behind a `"tailscaled never came up"` message that would be wrong by construction and wouldn't name the failing share. They're plain `|| exit 1` calls now, so a real failure (bad share name, drive not enabled) surfaces immediately. Worst-case postStart stays at 2m instead of growing to 6m.

**Unrelated drive-by:** moved the SOPS scratch-file ignore out of the Talos credentials stanza in `.gitignore` into its own commented block, and broadened it to `.decrypted~*` so `.sops.json` / `.sops.env` twins are covered too.

## ACL note — needs a decision

`family` already has an explicit `rw` grant for `groups.friendsAndFamily` in `stacks/unifi-network/acl-manager.ts`. **`documents` does not** — it falls through to the `{ access: "ro", shares: ["*"] }` entry in that same grant, so it's read-only for friends/family and rw only for admins.

If that's not the intent, `family-drive-access` needs a `{ access: "rw", shares: ["documents"] }` entry plus a Pulumi run on `unifi-network`. Not included here since it's a separate stack and a separate call.

## Verification

- `hk` pre-commit stack green: `flate` (351 passed, `tailscale-system/taildrive` ✓), `yamllint --strict`, typos, trailing-whitespace, newlines
- Rendered YAML parses with all four subPath mounts present
- Both shell blocks pass `sh -n`

Not yet deployed — the two new subPath dirs will be created empty by kubelet on first mount. Existing `shared/` data is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
