### PR TITLE
feat(k8s): tolerate the control-plane taint before it exists

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/helm/values.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/helm/values.yaml
@@ -10,3 +10,25 @@ prometheus:
   servicemonitor:
     enabled: true
 enableCertificateOwnerRef: true
+
+# Placement flexibility once allowSchedulingOnControlPlanes goes false. These
+# are Deployments, not DaemonSets -- nothing breaks without the toleration,
+# they would just be confined to the two worker nodes.
+#
+# The chart exposes a SEPARATE tolerations key per Deployment and there is no
+# shared/global one, so all three are set. All three default to [].
+#   * top-level -> cert-manager controller
+#   * webhook   -> cert-manager-webhook
+#   * cainjector-> cert-manager-cainjector
+#
+# `startupapicheck.tolerations` also exists and is deliberately left alone: it
+# is a short-lived Helm hook Job, not a running workload, and it is fine on a
+# worker.
+tolerations: &controlPlaneToleration
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+webhook:
+  tolerations: *controlPlaneToleration
+cainjector:
+  tolerations: *controlPlaneToleration

--- a/kubernetes/apps/flux-system/flux-instance/helm/values.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/helm/values.yaml
@@ -20,6 +20,37 @@ instance:
     path: kubernetes/flux/cluster
   kustomize:
     patches:
+    - # Tolerate the control-plane taint that arrives with
+      # allowSchedulingOnControlPlanes: false.
+      #
+      # This has to be a kustomize patch. The FluxInstance CRD has no
+      # tolerations/nodeSelector field -- checked against the flux-instance
+      # chart 0.58.0 values schema, which exposes only distribution,
+      # components, cluster, commonMetadata, storage, sharding, sync and
+      # kustomize.patches. flux-operator owns these Deployments and reconciles
+      # them continuously, so patching them by hand (or with a postRenderer on
+      # some other release) would simply be reverted; kustomize.patches is the
+      # managed path and is what the rest of this file already uses.
+      #
+      # These are Deployments, so nothing breaks without this -- the four
+      # controllers would just be confined to the two worker nodes. See the PR
+      # description for the argument about whether that is actually desirable
+      # on 4-core/16GiB control planes.
+      patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: all
+        spec:
+          template:
+            spec:
+              tolerations:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: Exists
+                  effect: NoSchedule
+      target:
+        kind: Deployment
+        name: (kustomize-controller|helm-controller|source-controller|notification-controller)
     - # Increase the number of workers
       patch: |
         - op: add

--- a/kubernetes/apps/flux-system/flux-operator/helm/values.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/helm/values.yaml
@@ -1,4 +1,12 @@
 ---
+# Placement flexibility once allowSchedulingOnControlPlanes goes false. The
+# operator is what reconciles the FluxInstance (and therefore the four Flux
+# controllers), so it is the one flux-system pod that should not be boxed into
+# the smallest possible node set. Plain chart value, default [].
+tolerations:
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
 serviceMonitor:
   create: true
 web:

--- a/kubernetes/apps/kube-system/features/amd/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/features/amd/helmrelease.yaml
@@ -59,3 +59,17 @@ spec:
     securityContext:
       allowPrivilegeEscalation: true
     node_selector_enabled: true
+    # Covers BOTH DaemonSets: deviceplugin-daemonset.yaml and labeller.yaml
+    # each render `.Values.tolerations`, so this reaches
+    # amd-gpu-device-plugin-daemonset and amd-gpu-labeller-daemonset.
+    #
+    # Helm REPLACES lists, so the chart's own CriticalAddonsOnly entry is
+    # repeated here verbatim -- omitting it would silently drop it.
+    tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      # Added: keeps the plugin schedulable once the control planes are
+      # tainted by allowSchedulingOnControlPlanes: false.
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule

--- a/kubernetes/apps/kube-system/features/intel-gpu/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/features/intel-gpu/helmrelease.yaml
@@ -47,3 +47,13 @@ spec:
     nodeFeatureRule: true
     sharedDevNum: 5 # Allow 5 containers per GPU (10 total slots across 2 nodes)
     allocationPolicy: balanced # Spread workloads evenly across available GPUs
+    # NOTE: this chart renders a GpuDevicePlugin CR, not a DaemonSet -- the
+    # intel-device-plugin-operator turns the CR into the
+    # intel-gpu-plugin-intel-gpu-plugin DaemonSet. `tolerations` is a passthrough
+    # field on the CR spec (templates/gpu.yaml), so it does reach the pods, but
+    # the operator is the thing that applies it: hand-patching the DaemonSet
+    # would be reverted. Chart default is [], so nothing is being replaced here.
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule

--- a/kubernetes/apps/kube-system/features/node-feature-discovery/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/features/node-feature-discovery/helmrelease.yaml
@@ -45,3 +45,16 @@ spec:
     recreate: true
   uninstall:
     keepHistory: false
+  values:
+    # nfd-worker is the DaemonSet that has to run on EVERY node -- it is what
+    # publishes the feature labels the GPU plugins and intel-gpu-exporter
+    # select on, so a control plane without it looks featureless.
+    #
+    # Only `worker` is set here. `master.tolerations` already ships a
+    # node-role.kubernetes.io/control-plane entry as a chart default, and
+    # nfd-gc / nfd-topology-updater are not DaemonSets pinned to every node.
+    worker:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule

--- a/kubernetes/apps/kube-system/features/nvidia/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/features/nvidia/helmrelease.yaml
@@ -57,3 +57,24 @@ spec:
     nfd:
       enabled: false
     runtimeClassName: nvidia
+    # One list, three DaemonSets: daemonset-device-plugin.yml, daemonset-gfd.yml
+    # and daemonset-mps-control-daemon.yml all render `.Values.tolerations`
+    # verbatim, so this covers nvidia-device-plugin,
+    # nvidia-device-plugin-gpu-feature-discovery and
+    # nvidia-device-plugin-mps-control-daemon at once.
+    #
+    # Helm REPLACES lists rather than merging them, so the two entries the
+    # chart ships by default are repeated here verbatim. Dropping them would
+    # silently remove the CriticalAddonsOnly and nvidia.com/gpu tolerations.
+    # Keep them in sync when bumping the chart.
+    tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      # Added: keeps the plugins schedulable once the control planes are
+      # tainted by allowSchedulingOnControlPlanes: false.
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule

--- a/kubernetes/apps/kube-system/multus/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/multus/helmrelease.yaml
@@ -58,3 +58,48 @@ spec:
         repository: ghcr.io/k8snetworkplumbingwg/multus-cni
         tag: v4.3.0@sha256:ec4e5dfe12b675e4dcbf4e9cd14892f7b4c8ac27aa0dc93cf2e9be0bdd7d764a
       # resources: {}
+
+  # ---- control-plane toleration ------------------------------------------
+  # A postRenderer and not a chart value, verified rather than assumed against
+  # chart 1.3.3 itself. This is a bjw-s common-library chart whose
+  # templates/common.yaml defines a `multus.hardcodedValues` block containing
+  #
+  #     controllers.multus.pod.tolerations:
+  #       - key: CriticalAddonsOnly
+  #         operator: Exists
+  #
+  # and that block WINS the merge against user values. Both of the obvious
+  # value paths were rendered locally with `helm template` and both were
+  # silently ignored, emitting only the hardcoded CriticalAddonsOnly entry:
+  #   * controllers.multus.pod.tolerations  (the app-template per-controller key)
+  #   * defaultPodOptions.tolerations       (the app-template global key)
+  # There is no other toleration hook in the chart -- values.yaml exposes only
+  # image/resources/cni keys. So the rendered manifest is the only lever.
+  #
+  # multus is a CNI DaemonSet: a node without it cannot attach secondary
+  # network interfaces, so it must tolerate the control-plane taint that
+  # arrives with allowSchedulingOnControlPlanes: false.
+  #
+  # The patch REPLACES the whole tolerations list, so CriticalAddonsOnly is
+  # repeated here to preserve it. Re-diff against the chart's hardcodedValues
+  # when bumping the pinned digest above.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: DaemonSet
+              name: multus
+            patch: |
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: multus
+              spec:
+                template:
+                  spec:
+                    tolerations:
+                      - key: CriticalAddonsOnly
+                        operator: Exists
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: Exists
+                        effect: NoSchedule

--- a/kubernetes/apps/longhorn-system/longhorn/values.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/values.yaml
@@ -10,6 +10,36 @@
   # backupTargetCredentialSecret: s3-secret
 preUpgradeChecker:
   upgradeVersionCheck: false
+
+# Tolerate the control-plane taint that arrives when
+# `allowSchedulingOnControlPlanes` is flipped to false in
+# talos/patches/controller/cluster.yaml. Longhorn splits its workloads in two
+# and each half needs a DIFFERENT knob -- setting only one of them leaves the
+# storage plane half-tainted:
+#
+#   * USER-DEPLOYED (longhorn-manager DaemonSet, longhorn-ui,
+#     longhorn-driver-deployer) are rendered by this chart, so they take a
+#     normal pod-spec toleration list. That is `global.tolerations` here, and
+#     it applies on the next Helm upgrade with no preconditions.
+#     Per-component `longhornManager.tolerations` etc. OVERRIDE rather than
+#     merge with this (`default .Values.global.tolerations ...`), so setting
+#     the global once is both sufficient and the safer shape.
+#
+#   * SYSTEM-MANAGED (instance-manager, engine-image, longhorn-csi-plugin,
+#     backing-image-manager, share-manager) are created by longhorn-manager at
+#     runtime, NOT by Helm. They are selected by the
+#     `longhorn.io/managed-by: longhorn-manager` label and are reachable only
+#     through the `taint-toleration` SETTING below -- a pod-spec toleration
+#     here would never reach them.
+#
+# See the detach caveat on defaultSettings.taintToleration below; it is the
+# operationally important half.
+global:
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+
 persistence:
   defaultDataLocality: best-effort
 defaultSettings:
@@ -50,7 +80,43 @@ defaultSettings:
   storageOverProvisioningPercentage: 600
   upgradeChecker: true
   priorityClass: system-node-critical
-  # taintToleration: key1=value1:NoSchedule; key2:NoExecute
+  # Tolerations for the SYSTEM-MANAGED components only (instance-manager,
+  # engine-image, longhorn-csi-plugin, backing-image-manager, share-manager).
+  # The user-deployed half is `global.tolerations` at the top of this file --
+  # read the comment there first, the two are not interchangeable.
+  #
+  # FORMAT: semicolon-separated `key=value:effect` or `key:effect`. A key with
+  # no `=value` parses to operator Exists, which is what we want here; all
+  # whitespace is stripped before parsing. Verified against parseToleration()
+  # in types/setting.go @ v1.12.x, not just the docs.
+  #
+  # !! DETACH CAVEAT -- READ BEFORE FLIPPING THE TAINT !!
+  # This setting is ACCEPTED but DEFERRED while any Longhorn volume is
+  # attached. Longhorn <= 1.5 hard-rejected the change ("cannot modify
+  # toleration setting before all volumes are detached"); since #7173 (1.6)
+  # the Setting CR write succeeds and updateTaintToleration() in
+  # controller/setting_controller.go instead gates on
+  # AreAllVolumesDetachedState(), logging ErrorInvalidState and requeuing on
+  # the one-hour settingControllerResyncPeriod until every volume is detached.
+  #
+  # So on a cluster with live volumes this half does NOT apply on merge, and
+  # NOTHING SURFACES THE FAILURE: `helm upgrade` succeeds, the HelmRelease goes
+  # Ready, and only longhorn-manager's log says otherwise. Adding a toleration
+  # is not a special case -- any add/change/remove takes the same gate.
+  #
+  # This is survivable rather than urgent because the control-plane taint is
+  # NoSchedule, which does not evict running pods: the existing csi-plugin and
+  # engine-image pods keep running on the control planes. It bites on the next
+  # pod RECREATE there (reboot, Talos upgrade, DaemonSet rollout), after which
+  # they cannot come back and volumes attached via that node break.
+  #
+  # BEFORE flipping allowSchedulingOnControlPlanes, confirm this actually
+  # landed rather than assuming:
+  #   kubectl -n longhorn-system get ds longhorn-csi-plugin \
+  #     -o jsonpath='{.metadata.annotations.longhorn\.io/last-applied-tolerations}'
+  # If that does not contain node-role.kubernetes.io/control-plane, the
+  # setting is still pending and needs a volumes-detached window.
+  taintToleration: node-role.kubernetes.io/control-plane:NoSchedule
   # systemManagedComponentsNodeSelector: "label-key1:label-value1"
   # disableSchedulingOnCordonedNode: false
   # replicaZoneSoftAntiAffinity: false

--- a/kubernetes/apps/network/crowdsec/values.yaml
+++ b/kubernetes/apps/network/crowdsec/values.yaml
@@ -232,6 +232,17 @@ lapi:
   deployAnnotations:
     reloader.stakater.com/auto: "true"
 agent:
+  # The agent is a DaemonSet that tails pod logs on the node it runs on, so a
+  # control plane without one is a blind spot rather than a broken pod. Chart
+  # default is [], so nothing is being replaced.
+  #
+  # `lapi` is deliberately NOT given the same toleration: it is a single-replica
+  # Deployment with two Longhorn PVCs, and widening where it may schedule does
+  # not move its data. Leave it on the workers.
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
   # `agent.acquisition` lives inline in helmrelease.yaml, not here -- see the
   # comment there. D6 (vault#111 Q4): the `namespace: '*', podName: postgres-*`
   # entry is gone. Parsing every Postgres pod's logs cluster-wide is noise in

--- a/kubernetes/apps/observability/alertmanager/values.yaml
+++ b/kubernetes/apps/observability/alertmanager/values.yaml
@@ -32,6 +32,13 @@ alertmanager:
 
   alertmanagerSpec:
     replicas: 1
+    # Placement flexibility only. Alertmanager is a StatefulSet with a 1Gi
+    # Longhorn PVC (below); a toleration widens where it MAY schedule but does
+    # not move the volume, so the pod still follows its data.
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
     alertmanagerConfiguration:
       name: alertmanager
     # alertmanagerConfiguration:

--- a/kubernetes/apps/observability/alloy/helmrelease.yaml
+++ b/kubernetes/apps/observability/alloy/helmrelease.yaml
@@ -59,6 +59,13 @@ spec:
     controller:
       podAnnotations:
         reloader.stakater.com/auto: "true"
+      # alloy runs as a DaemonSet and scrapes/collects from the node it is on,
+      # so a control plane without it is an observability blind spot. Chart
+      # default is [], so nothing is being replaced.
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
     serviceMonitor:
       enabled: true
     ingress:

--- a/kubernetes/apps/observability/intel-gpu-exporter/helmrelease.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/helmrelease.yaml
@@ -112,6 +112,14 @@ spec:
       # and on neither AMD node.
       nodeSelector:
         intel.feature.node.kubernetes.io/gpu: "true"
+      # The nodeSelector above already confines this to the Intel Quick Sync
+      # nodes; the toleration only stops the control-plane taint from
+      # subtracting any of them once allowSchedulingOnControlPlanes is false.
+      # It does not widen the node set.
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
       # hostPID is deliberately NOT set, though upstream's README uses it.
       # It is only needed for the per-client breakdown (intel_gpu_top reads
       # /proc/*/fdinfo to attribute usage to processes), which powers

--- a/kubernetes/apps/observability/loki/helmrelease.yaml
+++ b/kubernetes/apps/observability/loki/helmrelease.yaml
@@ -91,6 +91,13 @@ spec:
     singleBinary:
       replicas: 1
       priorityClassName: observability-critical
+      # Placement flexibility only. This is a StatefulSet with a 60Gi Longhorn
+      # PVC (persistence below); the toleration widens where it MAY schedule
+      # but does not move the volume, so the pod still follows its data.
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
       persistence:
         enabled: true
         storageClass: longhorn

--- a/kubernetes/apps/observability/prometheus/values.yaml
+++ b/kubernetes/apps/observability/prometheus/values.yaml
@@ -36,6 +36,19 @@ prometheus:
   thanosServiceMonitor:
     enabled: true
   prometheusSpec:
+    # Placement flexibility only. Prometheus is a StatefulSet with a 20Gi
+    # Longhorn PVC (storageSpec below); a toleration widens where it MAY
+    # schedule but does not move the volume, so the pod still follows its data.
+    #
+    # Scope note: this release also renders kube-state-metrics and the
+    # Prometheus operator, which are NOT given tolerations here -- they are
+    # stateless Deployments that are fine on the workers, and the request was
+    # for Prometheus itself. prometheus-node-exporter already tolerates
+    # everything via the chart default.
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
     scrapeInterval: 60s
     evaluationInterval: 60s
     externalUrl: https://prometheus.${CLUSTER_DOMAIN}

--- a/kubernetes/apps/observability/silences/helmrelease.yaml
+++ b/kubernetes/apps/observability/silences/helmrelease.yaml
@@ -35,3 +35,9 @@ spec:
       tag: 0.18.0
     networkPolicy:
       enabled: false
+    # Stateless Deployment; placement flexibility only. Top-level key in this
+    # chart, default [].
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule

--- a/kubernetes/apps/observability/tempo/helmrelease.yaml
+++ b/kubernetes/apps/observability/tempo/helmrelease.yaml
@@ -54,3 +54,10 @@ spec:
       size: 10Gi
     serviceMonitor:
       enabled: true
+    # Top-level key in this chart (there is only one workload). Placement
+    # flexibility only -- Tempo is a StatefulSet with a 10Gi PVC, so the
+    # toleration widens where it MAY schedule without moving its data.
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule

--- a/kubernetes/apps/openebs-system/openebs/values.yaml
+++ b/kubernetes/apps/openebs-system/openebs/values.yaml
@@ -2,6 +2,18 @@
 localpv-provisioner:
   localpv:
     basePath: &basePath /var/mnt/extra/openebs/local
+    # The provisioner is a Deployment, but the hostpath volumes it hands out
+    # are node-local: if it cannot run on a control plane it cannot provision
+    # openebs-hostpath PVCs for pods there. Key is
+    # `localpv-provisioner.localpv.tolerations`, default [].
+    #
+    # Every other engine in this chart (zfs, lvm, mayastor, rawfile) is
+    # disabled below, so this is the only openebs-system workload that needs
+    # one.
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
   hostpathClass:
     enabled: true
     name: openebs-hostpath


### PR DESCRIPTION
## ⚠️ This is a prerequisite — merge and reconcile green BEFORE flipping the taint

`talos/patches/controller/cluster.yaml` still has `allowSchedulingOnControlPlanes: true` and **is deliberately untouched by this PR**. Flipping it taints all five control planes with `node-role.kubernetes.io/control-plane:NoSchedule`. A live survey found several infrastructure DaemonSets with no matching toleration — including `longhorn-manager` (`tolerations: []`), which on a seven-node cluster would leave five nodes without a Longhorn manager.

**Do not flip the taint until this PR is merged, reconciled, and the Longhorn check below passes.**

One precision note that matters for planning: `NoSchedule` **does not evict running pods**. Nothing breaks the instant the taint appears — the existing pods keep running. The breakage arrives on the next pod *recreate* on a control plane (reboot, Talos upgrade, DaemonSet rollout), after which the pod cannot come back. So this is a "must land first" change, not a "the cluster falls over at 3am" change.

Toleration used everywhere is the specific one:

```yaml
- key: node-role.kubernetes.io/control-plane
  operator: Exists
  effect: NoSchedule
```

not a blanket `operator: Exists`, which would also defeat `NotReady`/`unreachable` eviction — the exact failure mode this cluster hit.

**Every value key was verified against the real chart** (`helm show values` / `helm template` against the pinned version), not assumed, and each edit was re-rendered to confirm the toleration actually reaches the pod spec. That process caught three things that a values-key guess would have got wrong — see the callouts below.

---

## 🔴 Longhorn: the detach question, answered

**Short answer: no, it will not be rejected — but it will silently not apply, which is worse.**

### It is accepted and deferred, not rejected

Longhorn ≤ 1.5 hard-rejected the change in `ValidateSetting` (`cannot modify toleration setting before all volumes are detached`). **That code is gone from 1.6 onward** (longhorn/longhorn#7173) — confirmed absent from `v1.6.x`, `v1.7.x` and `v1.12.x`. On 1.12.1 the only remaining validation is format-only.

The gate moved into the controller. `updateTaintToleration()` in `controller/setting_controller.go` @ v1.12.x:

```go
detached, err := sc.ds.AreAllVolumesDetachedState()
if !detached {
    return &types.ErrorInvalidState{Reason: "...when there are attached volumes. It will be eventually applied"}
}
```

So with volumes attached: the `Setting` CR write succeeds, the controller errors and requeues on the one-hour `settingControllerResyncPeriod`, and the toleration is applied whenever all volumes are next detached.

### Why that is the dangerous shape

**`helm upgrade` succeeds. The HelmRelease goes Ready. Flux is green. Nothing surfaces the failure** except a log line in longhorn-manager. It is entirely possible to merge this, see everything green, flip the taint, and discover months later that `longhorn-csi-plugin` was never tolerating anything.

Adding a toleration is **not** a special case — `getNotUpdatedTolerationList()` treats add, change and remove identically.

### Verify before flipping, do not assume

```bash
kubectl -n longhorn-system get ds longhorn-csi-plugin \
  -o jsonpath='{.metadata.annotations.longhorn\.io/last-applied-tolerations}'
```

If that does not contain `node-role.kubernetes.io/control-plane`, the setting is **still pending** and needs a volumes-detached window before the taint flip is safe.

### 🔑 The setting alone is not enough — Longhorn needed two knobs

This is the part that would have quietly broken the storage plane. Longhorn splits its workloads and each half takes a *different* mechanism:

| Half | Workloads | Mechanism | Applies when |
|---|---|---|---|
| **User-deployed** (Helm-rendered) | `longhorn-manager` (DS), `longhorn-ui`, `longhorn-driver-deployer` | `global.tolerations` (pod-spec list) | Immediately, on next Helm upgrade |
| **System-managed** (created by longhorn-manager at runtime) | `instance-manager`, `engine-image-*`, `longhorn-csi-plugin`, backing-image-manager, share-manager | `defaultSettings.taintToleration` (string setting) | **Deferred until all volumes detach** |

`defaultSettings.taintToleration` selects only objects labelled `longhorn.io/managed-by: longhorn-manager`, and the chart's `longhorn-manager` DaemonSet **does not carry that label**. So the setting alone would never have reached `longhorn-manager` — the single highest-stakes DaemonSet in the survey. Both are now set.

(There is a stale comment above `updateTaintToleration()` in the Longhorn source claiming it deletes "user-deployed and system-managed" components. The label filter in `collectRuntimeObjects()` and the docs both contradict it. Trust the filter.)

The value format was confirmed against `parseToleration()` in `types/setting.go`, not just the docs: semicolon-separated, `key:effect` with no `=value` parses to operator `Exists`. `node-role.kubernetes.io/control-plane:NoSchedule` is correct.

**Caveat when it does apply:** it is disruptive by design — DaemonSets and instance-manager pods are *deleted*, not patched, and the docs note the Longhorn system cannot be operated during the update.

---

## Per-component status

### Storage — highest stakes

| Component | Where | Notes |
|---|---|---|
| `longhorn-manager` | `longhorn-system/longhorn/values.yaml` → `global.tolerations` | ✅ Applies immediately |
| `longhorn-csi-plugin`, `engine-image-ei-*` | same file → `defaultSettings.taintToleration` | ⚠️ **Deferred** — see above |
| `longhorn-ui`, `longhorn-driver-deployer` | covered by `global.tolerations` | ✅ Bonus, not in survey |

Longhorn's own DaemonSets were **not** hand-patched — Longhorn manages them and would revert it.

### Networking

| Component | Where | Notes |
|---|---|---|
| `kube-system/multus` | `multus/helmrelease.yaml` → **`postRenderers`** | 🔍 See callout below |
| `network/crowdsec-agent` | `network/crowdsec/values.yaml` → `agent.tolerations` | ✅ |

**🔍 multus needed a postRenderer, not a value.** The bjw-s chart 1.3.3 defines a `multus.hardcodedValues` block in `templates/common.yaml` that hardcodes `tolerations: [CriticalAddonsOnly]` — and **that block wins the merge against user values**. Both plausible value paths were rendered locally and both were silently ignored:

- `controllers.multus.pod.tolerations` (app-template per-controller key) → no-op
- `defaultPodOptions.tolerations` (app-template global key) → no-op

The chart exposes no other toleration hook. The postRenderer was verified end-to-end by rendering the chart and running the extracted patch through `kustomize build`. It replaces the whole list, so `CriticalAddonsOnly` is repeated to preserve it.

### Node feature / GPU

| Component | Where | Notes |
|---|---|---|
| `node-feature-discovery-worker` | `features/node-feature-discovery/helmrelease.yaml` → `worker.tolerations` | ✅ `master.tolerations` already had it as a chart default |
| `intel-gpu-plugin-intel-gpu-plugin` | `features/intel-gpu/helmrelease.yaml` → `tolerations` | ✅ Passthrough onto the `GpuDevicePlugin` CR; the operator owns the DaemonSet |
| `amd-gpu-device-plugin-daemonset`, `amd-gpu-labeller-daemonset` | `features/amd/helmrelease.yaml` → `tolerations` | ✅ One list covers both |
| `nvidia-device-plugin`, `-gpu-feature-discovery`, `-mps-control-daemon` | `features/nvidia/helmrelease.yaml` → `tolerations` | ✅ One list covers all three |

⚠️ **Helm replaces lists rather than merging them.** The amd and nvidia charts ship non-empty `tolerations` defaults, so those defaults (`CriticalAddonsOnly`, `nvidia.com/gpu`) are repeated verbatim in the new lists. Omitting them would have silently removed them. Noted inline for the next chart bump.

### Observability

| Component | Where | Notes |
|---|---|---|
| `observability/alloy` | `alloy/helmrelease.yaml` → `controller.tolerations` | ✅ DaemonSet |
| `observability/intel-gpu-exporter` | `intel-gpu-exporter/helmrelease.yaml` → `defaultPodOptions.tolerations` | ✅ Its `nodeSelector` still confines it to Intel nodes |
| `observability/alertmanager` | `alertmanager/values.yaml` → `alertmanager.alertmanagerSpec.tolerations` | 📦 Stateful — see note |
| `observability/prometheus` | `prometheus/values.yaml` → `prometheus.prometheusSpec.tolerations` | 📦 Stateful — see note |
| `observability/loki` | `loki/helmrelease.yaml` → `singleBinary.tolerations` | 📦 Stateful — see note |
| `observability/tempo` | `tempo/helmrelease.yaml` → `tolerations` | 📦 Stateful — see note |
| `observability/silences` | `silences/helmrelease.yaml` → `tolerations` | ✅ Stateless Deployment |

📦 **A toleration does not make a stateful workload movable.** Prometheus (20Gi), Loki (60Gi), Alertmanager (1Gi) and Tempo (10Gi) all have Longhorn PVCs. This only widens where the pod *may* schedule; it does not move data, and a strict-local or single-replica volume still pins the pod to wherever its replica lives.

### Other namespaces

| Component | Where | Notes |
|---|---|---|
| `openebs-system` (localpv-provisioner) | `openebs/values.yaml` → `localpv-provisioner.localpv.tolerations` | ✅ Only enabled engine; the rest (zfs/lvm/mayastor/rawfile) are off |
| `cert-manager` controller / webhook / cainjector | `cert-manager/helm/values.yaml` → `tolerations`, `webhook.tolerations`, `cainjector.tolerations` | ✅ All three; no shared key exists |
| `flux-operator` | `flux-operator/helm/values.yaml` → `tolerations` | ✅ |
| Flux controllers (source/kustomize/helm/notification) | `flux-instance/helm/values.yaml` → `instance.kustomize.patches` | 🔍 See callout below |

**🔍 flux-system had to go through the managed path.** Flux here is a `FluxInstance` (flux-operator), and the CRD has **no** tolerations field — confirmed against the flux-instance 0.58.0 values schema, which exposes only `distribution`, `components`, `cluster`, `commonMetadata`, `storage`, `sharding`, `sync` and `kustomize.patches`. flux-operator reconciles those Deployments continuously, so a hand-patch or postRenderer would be reverted. `kustomize.patches` is the managed path and is already the idiom in that file.

### Verified as needing no change

| Component | Why |
|---|---|
| `nfs-system` — **entire namespace** | `csi-nfs-node` tolerates everything (`operator: Exists`); `csi-nfs-controller` **and** its `snapshot-controller` both consume a chart-default `controller.tolerations` that already includes `node-role.kubernetes.io/control-plane`. The repo values do not override it. **No edit made.** |
| `cilium`, `spegel`, `node-exporter`, `smartctl-exporter-0` | Already tolerate, per the original survey. Untouched. |

---

## 🤔 One judgement call worth your explicit sign-off

**Should the Flux controllers actually run on the control planes?**

I implemented it as requested, but flagging rather than silently deciding, because there is a real argument the other way:

- **Against:** the control planes are 4-core/16 GiB and **dropped out of the cluster under load tonight**. `kustomize-controller` runs `--concurrent=20` with a 1 GiB memory limit, `source-controller` carries a Helm cache, `helm-controller` has a 1 GiB limit and OOM-watch. These are bursty, memory-hungry workloads, and co-locating them with etcd/apiserver risks feeding the exact cascade that just happened. etcd is unforgiving about CPU steal.
- **For:** with only two workers, confining all four controllers plus the operator to two nodes means one worker loss puts the entire GitOps control loop on a single node.

If control-plane stability is the priority, the better tool is not "no toleration" but a **toleration plus a `preferredDuringScheduling` node affinity toward the workers** — that keeps the control planes as overflow capacity without making them a normal destination. Happy to follow up with that if you want it; I did not add it here to keep this PR to one mechanism.

The same trade-off applies far more weakly to cert-manager and silences (small, stateless) — I have no concerns there.

## Follow-ups not done

- `cert-manager.startupapicheck.tolerations` exists and was left alone — it is a short-lived Helm hook Job, fine on a worker. Worth adding only if you want cert-manager upgrades to survive both workers being full.
- `crowdsec.lapi` was left alone deliberately: single-replica Deployment with two Longhorn PVCs, so widening its placement gains nothing.
- kube-state-metrics and the Prometheus operator (rendered by the `prometheus` release) were left alone — stateless and out of the requested scope.
- `nfd-gc` / `nfd-topology-updater` left alone — not per-node DaemonSets.

## Validation

- `mise run flate` — ✅ **351 passed, 2 skipped, ~1.4s** (the 2 skips are the pre-existing missing-`vault`-secret GitRepositories). Notably, **none of the new value keys were reported as "values not used by the chart"**, which independently confirms every key is real.
- `hk check` — ✅ all hooks green (`typos`, `yamllint`, `flate`, `trailing-whitespace`, `newlines`, `detect-private-key`, `check-case-conflict`, large-files, merge-conflict).
- Each chart additionally re-rendered locally with the modified repo values to confirm the toleration lands in the actual pod spec — including the two indirect cases (multus via `kustomize build`, intel-gpu via the `GpuDevicePlugin` CR).

**No cluster was mutated.** Repo changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
