### PR TITLE
docs(plan): record where the consolidation actually stands, and why piece 19 is parked

### DIFF
--- a/docs/cluster-consolidation/19-rotate-equestria-control-planes.md
+++ b/docs/cluster-consolidation/19-rotate-equestria-control-planes.md
@@ -8,6 +8,72 @@ provably drainable). Feeds [20 — low-power tier](20-low-power-tier.md), which 
 surviving 3 control planes — this phase deliberately does **not** touch
 `allowSchedulingOnControlPlanes`.
 
+> **Status 2026-08-18 — one node of three done, then deliberately parked.**
+>
+> | node | state |
+> |---|---|
+> | `hard-hat` | **worker.** Drained, out of etcd, wiped, rejoined. `machinetype: worker`, no control-plane statics, uncordoned, stale role label removed |
+> | `fluttershy` | control plane, untouched |
+> | `kerfuffle` | control plane, untouched. Holds `postgres-1` (**primary**) and the most Longhorn replicas of any node |
+>
+> etcd is at 5 members (the 3 ex-SGC nodes plus fluttershy and kerfuffle), healthy, no alarms.
+>
+> **Why it is parked, and it is not the Step 6 gate.** The end state this phase produces —
+> control plane entirely on `milky-way`/`othalla`/`pegasus` — puts etcd, the apiserver, the
+> scheduler and the controller-manager on **4-core / 16 GiB** machines, replacing **16–20 core /
+> 48–64 GiB** ones:
+>
+> | | cores | memory |
+> |---|---|---|
+> | fluttershy, kerfuffle | 20 | 64 GiB |
+> | shining-armor | 20 | 48 GiB |
+> | hard-hat | 16 | 48 GiB |
+> | milky-way, othalla, pegasus | **4** | **16 GiB** |
+>
+> That is a 4× reduction in control-plane CPU, and it was never stated as a consequence anywhere
+> in this plan. It needs an explicit decision before `fluttershy` and `kerfuffle` are rotated,
+> because each rotation is a wipe-and-rejoin and is therefore expensive to undo. Three options,
+> none yet chosen: continue as written and move Longhorn storage off the control planes; keep six
+> control planes and rotate nobody; or invert the plan — rejoin `hard-hat` as a control plane and
+> make the ex-SGC nodes workers.
+>
+> **Do not read the 2026-08-17 instability as evidence for that decision.** See the incident note
+> below: it was a bad ethernet cable, not node sizing. The sizing question stands on its own
+> arithmetic, and is now the *only* argument in play.
+
+## The 2026-08-17 milky-way incident — a hardware fault that reads exactly like resource exhaustion
+
+Recorded because the misdiagnosis cost several hours and the symptom profile is genuinely
+deceptive.
+
+`milky-way` presented as a node buckling under load: its etcd health check failed every ~5
+minutes (`context deadline exceeded`), it flapped `NotReady` nine times, its `longhorn-manager`
+logged `i/o timeout` reaching the API service VIP, Longhorn drained it from 22 replicas to 2,
+and rebuilds targeting it errored while identical rebuilds targeting `pegasus` succeeded. On a
+4-core control plane also running etcd, apiserver, scheduler and Cilium, "it is out of CPU" is
+the obvious reading. It was wrong.
+
+The actual fault was **66% packet loss on one ethernet cable.** What ruled software out:
+
+1. A reboot did not fix it.
+2. A full wipe (STATE + EPHEMERAL) did not fix it — the loss persisted into maintenance mode,
+   with no cluster software running at all.
+3. `pegasus` and `othalla` — identical hardware, same switch — sat at 0% loss throughout.
+
+After the cable was replaced: 0.0% loss over 30 packets, 5/5 clean Talos API probes, and etcd
+`HEALTH: OK` stable across the rejoin where it had previously failed every 5 minutes.
+
+**The lesson for the remaining nodes:** on a partially-connected node, every layer reports the
+symptom in its own vocabulary — etcd says deadline exceeded, kubelet says NotReady, Longhorn says
+i/o timeout, the scheduler says the node is unhealthy. None of them says "packet loss". Before
+attributing that pattern to load, run `ping -c 30` against the node and against a sibling. It
+takes ten seconds and would have saved this one.
+
+A second, smaller trap from the same incident: `talosctl version --insecure` and
+`talosctl shutdown --insecure` **print help text and exit 0** rather than erroring on the
+unrecognised flag. Both were briefly read as success. `--insecure` is valid on `apply-config` and
+`reset` only; a node in maintenance mode therefore cannot be shut down remotely at all.
+
 ## What this phase delivers
 
 Equestria's three original control planes — **hard-hat**, **fluttershy**, **kerfuffle** — leave

--- a/docs/cluster-consolidation/README.md
+++ b/docs/cluster-consolidation/README.md
@@ -103,6 +103,32 @@ completed and eleven days have passed:
   [19](19-rotate-equestria-control-planes.md) flags this and gives an alternative node
   ordering; confirm against the Proxmox host inventory before relying on either.
 
+## Where the plan actually stands — 2026-08-18
+
+| Piece | State |
+|---|---|
+| 07 authentik → alpha-site | **done.** Cut over 2026-08-16; all three public names plus the tailnet name serve from alpha-site |
+| 15 migrate apps | **done.** tsidp/tsiam live on equestria; SGC's `sgc` namespace held only superseded authentik |
+| 18 SGC → control planes | **done.** All three SGC nodes wiped and rejoined to equestria. **SGC no longer exists as a cluster** |
+| 19 rotate equestria CPs | **1 of 3, parked.** `hard-hat` is a worker; `fluttershy`/`kerfuffle` untouched — see 19's status block for why |
+| 22 decommission SGC | **phase 1 largely done**, phase 2 (ACLs, `clusters/sgc.yaml`, OpenBao mount, CNPG bucket) waits for power-off |
+
+Current cluster: 7 nodes, 5 etcd members, all Ready.
+
+**Two things the plan never accounted for, both now load-bearing on decisions:**
+
+- **The ex-SGC nodes are a quarter the size of what they replace** — 4 cores / 16 GiB against
+  16–20 cores / 48–64 GiB. Piece 19's end state puts the whole control plane on them. Unresolved.
+- **Their disks run hot and are the weakest hardware in the estate.** `pegasus` hit 85 °C and its
+  XFS filesystem shut down mid-rebuild; relocating it dropped it to 53 °C. `milky-way` carries 6
+  reallocated and 6 pending sectors. Piece 12's `critical` tier assumed the control planes would
+  be the fast, healthy disks — after piece 19 they are the opposite.
+
+**Sequencing correction:** several pieces were executed out of the documented order and it mostly
+worked, but two ordering rules turned out to be real and are now written into the pieces that own
+them — release-before-claim for any DNS name (07 §4, 22 rule 1), and evict-before-wipe for
+Longhorn replicas (19 Step 1b).
+
 ## Decision ledger
 
 Decisions David has made on the issue. Plans must not relitigate these.


### PR DESCRIPTION
**Documentation only.** Six pieces were executed today and the plan reflected none of it.

## Status, in one place

| Piece | State |
|---|---|
| 07 authentik → alpha-site | **done** — cut over 2026-08-16, all four names serving |
| 15 migrate apps | **done** |
| 18 SGC → control planes | **done** — SGC no longer exists as a cluster |
| 19 rotate equestria CPs | **1 of 3, parked** |
| 22 decommission SGC | phase 1 largely done; phase 2 waits for power-off |

## Why piece 19 is parked — and it is not the Step 6 gate

The end state puts the entire control plane on the ex-SGC nodes:

| | cores | memory |
|---|---|---|
| fluttershy, kerfuffle | 20 | 64 GiB |
| shining-armor | 20 | 48 GiB |
| hard-hat | 16 | 48 GiB |
| milky-way, othalla, pegasus | **4** | **16 GiB** |

A **4× reduction in control-plane CPU**, never stated as a consequence anywhere in the plan. Each rotation is a wipe-and-rejoin, so it is expensive to undo — this wants deciding before the next node, not after. Three options are laid out; none is chosen.

## The milky-way incident

Worth recording because the misdiagnosis cost hours and the symptom profile is genuinely deceptive.

It presented as a small node exhausting itself: etcd health checks failing every ~5 min, nine `NotReady` flaps, `longhorn-manager` i/o timeouts to the API VIP, Longhorn draining it 22 → 2 replicas, rebuilds erroring only there. On a 4-core control plane that reading is obvious. **It was wrong.**

What ruled software out: a reboot didn't fix it, a full wipe didn't fix it (loss persisted into maintenance mode with no cluster software running), and two identical siblings on the same switch sat at 0%. The fault was **66% packet loss on one ethernet cable**. After replacement: 0.0% over 30 packets, 5/5 clean API probes, etcd stable.

The generalisable lesson: every layer reported it in its own vocabulary — etcd said deadline exceeded, kubelet said NotReady, Longhorn said i/o timeout — and none said "packet loss". `ping -c 30` against the node and a sibling takes ten seconds.

**Crucially this means the instability is *not* evidence about node sizing.** The sizing question stands on its own arithmetic and is now the only argument in play.

## Two smaller traps recorded

- `talosctl version --insecure` / `shutdown --insecure` **print help and exit 0** rather than erroring. Both briefly read as success. `--insecure` is valid on `apply-config` and `reset` only.
- A node in maintenance mode therefore **cannot be shut down remotely at all**.

## Also in the README

The two things the plan never accounted for and that now bear on decisions: the node-size inversion above, and that the ex-SGC disks are the weakest hardware in the estate (pegasus hit 85 °C and its XFS shut down mid-rebuild; milky-way has 6 reallocated + 6 pending sectors). Piece 12's `critical` tier assumed control planes would be the *fast, healthy* disks — after piece 19 they are the opposite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)