### PR TITLE
ci(flux): port flate/eso-values-lint from equestria-cluster

### DIFF
--- a/.config/hk.pkl
+++ b/.config/hk.pkl
@@ -108,6 +108,27 @@ local linters = new Mapping<String, Step> {
       "flate test all --path ./kubernetes/flux/cluster --allow-missing-secrets --source-retry-attempts 10 --no-progress"
   }
 
+  // Closes the blind spot named in the `flate` comment directly above: this is
+  // the step that DOES run Flux postBuild envsubst and the external-secrets
+  // `templateAs: Values` template engine, over the files a kustomize
+  // `configMapGenerator` slurps whole. Ported from equestria-cluster with the
+  // flux-local workflow (piece 21); the same binary runs as the
+  // `eso-values-lint` job in .github/workflows/flux-local.yaml.
+  //
+  // Both renderers treat a *comment* as live text, so a `${VAR}` or `{{ ... }}`
+  // inside one is executed -- twice the cause of a CrowdSec outage
+  // (equestria-cluster#2977, #2980 / vault#111). It caught one live instance in
+  // this repo on import, in the postgres values.yaml.
+  //
+  // `go -C` is required: the module is nested and there is no go.mod at the
+  // repo root, so `go run ./scripts/...` cannot resolve it. Because `-C` also
+  // changes the run'd program's working directory, the target path has to be
+  // absolute.
+  ["eso-values-lint"] = new Step {
+    glob = List("kubernetes/**/*.yaml", "kubernetes/**/*.yml")
+    check = "go -C scripts/eso-values-lint run . \"$(git rev-parse --show-toplevel)/kubernetes\""
+  }
+
   // Configured by `.yamllint`, which disables the purely cosmetic rules and
   // keeps the ones that catch manifests Flux would silently mis-apply — above
   // all `key-duplicates`, where a repeated key in a HelmRelease drops the

--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -75,6 +75,20 @@ run = [
   'flate test all --path ./kubernetes/flux/cluster --allow-missing-secrets --source-retry-attempts 10',
 ]
 
+[tasks.eso-values-lint]
+description = 'Lint configMapGenerator-slurped files for live envsubst/Go-template in comments'
+# The half `flate` cannot see: Flux postBuild envsubst and the external-secrets
+# `templateAs: Values` engine both treat a comment as live text, so a `${VAR}`
+# or `{{ ... }}` inside one is executed. Twice the cause of a CrowdSec outage
+# (vault#111). Kept in step with the `eso-values-lint` step in .config/hk.pkl
+# and the job of the same name in .github/workflows/flux-local.yaml.
+#
+# `go -C` is required (nested module, no go.mod at the repo root) and it also
+# changes the program's working directory, so the target must be absolute.
+run = [
+  'go -C scripts/eso-values-lint run . "$(git rev-parse --show-toplevel)/kubernetes"',
+]
+
 [tasks.pkl-vscode]
 description = 'Install the Pkl VS Code extension (not on the marketplace; installed from VSIX)'
 # Ported from rocketsurgeonsguild/Specular. Not part of [hooks] postinstall on

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,45 @@
+---
+# Areas
+- name: area/bootstrap
+  color: "0e8a16"
+- name: area/docs
+  color: "0e8a16"
+- name: area/github
+  color: "0e8a16"
+- name: area/kubernetes
+  color: "0e8a16"
+- name: area/renovate
+  color: "0e8a16"
+- name: area/scripts
+  color: "0e8a16"
+- name: area/talos
+  color: "0e8a16"
+- name: area/templates
+  color: "0e8a16"
+- name: area/taskfile
+  color: "0e8a16"
+# Renovate Types
+- name: renovate/container
+  color: "027fa0"
+- name: renovate/github-action
+  color: "027fa0"
+- name: renovate/grafana-dashboard
+  color: "027fa0"
+- name: renovate/github-release
+  color: "027fa0"
+- name: renovate/helm
+  color: "027fa0"
+# Semantic Types
+- name: type/digest
+  color: "ffeC19"
+- name: type/patch
+  color: "ffeC19"
+- name: type/minor
+  color: "ff9800"
+- name: type/major
+  color: "f6412d"
+# Uncategorized
+- name: community
+  color: "370fb2"
+- name: hold
+  color: "ee0701"

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - renovate

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -1,0 +1,138 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: "flate"
+
+# Ported from equestria-cluster on 2026-08-18 as part of piece 21 (repo
+# consolidation). Unchanged except for this note: every path it depends on
+# already exists here -- `kubernetes/flux/cluster` is the Flux entrypoint, and
+# `flate` is pinned to the same v0.5.0 in .config/mise.toml that the action
+# below resolves, so `mise run flate` locally and the `test` job here run the
+# identical command. equestria-cluster's `sgc-sync.yaml` was deliberately NOT
+# ported: it syncs files into the SGC repo, which is being decommissioned
+# (docs/cluster-consolidation/22-decommission-sgc.md).
+
+on:
+  pull_request:
+    branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-job:
+    name: Pre-Job
+    runs-on: ubuntu-latest
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Get Changed Files
+        id: changed-files
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          files: kubernetes/**
+
+  test:
+    name: Test
+    needs: pre-job
+    runs-on: ubuntu-latest
+    if: ${{ needs.pre-job.outputs.any_changed == 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup flate
+        uses: home-operations/flate/action@2862e47ed4d6efebeffb43c7691ee6df06b4536c # v0.5.0
+        with:
+          cache: true
+
+      - name: Run flate test
+        run: flate test all --path ./kubernetes/flux/cluster --allow-missing-secrets --source-retry-attempts 10
+
+  # `flate test` renders Helm charts. It does NOT run Flux postBuild envsubst
+  # and it does NOT run the external-secrets template engine, so it passes
+  # cleanly on a values file that will take an app to zero pods. It did exactly
+  # that on #2977 and again on #2980 (vault#111). This job runs those two
+  # renderers, which is the only way this class of break is visible before it
+  # reaches the cluster. Not gated on `pre-job`: it also has to run when only
+  # the linter itself changes.
+  eso-values-lint:
+    name: ESO Values Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: scripts/eso-values-lint/go.mod
+          cache-dependency-path: scripts/eso-values-lint/go.sum
+
+      # The linter's own regression tests, including the negative case that
+      # `$${...}` must not be flagged. A checker nobody trusts gets disabled.
+      - name: Test eso-values-lint
+        run: go -C scripts/eso-values-lint test ./...
+
+      - name: Run eso-values-lint
+        run: go -C scripts/eso-values-lint run . "${GITHUB_WORKSPACE}/kubernetes"
+
+  diff:
+    name: Diff
+    needs: pre-job
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    if: ${{ needs.pre-job.outputs.any_changed == 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup flate
+        uses: home-operations/flate/action@2862e47ed4d6efebeffb43c7691ee6df06b4536c # v0.5.0
+        with:
+          base: ${{ github.event.repository.default_branch }}
+          cache: true
+
+      - name: Run flate diff
+        id: diff
+        run: |
+          flate diff all --path ./kubernetes/flux/cluster --allow-missing-secrets --source-retry-attempts 10 -o github > diff.patch
+          cat diff.patch >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo 'diff<<EOF'
+            cat diff.patch
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Add Comment
+        if: ${{ steps.diff.outputs.diff != '' }}
+        continue-on-error: true
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12
+        with:
+          message-id: "${{ github.event.pull_request.number }}/kubernetes"
+          message-failure: Diff was not successful
+          message: |
+            ${{ steps.diff.outputs.diff }}
+
+  flux-local-status:
+    name: flate Success
+    needs: ["test", "diff", "eso-values-lint"]
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Any jobs failed?
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+
+      - name: All jobs passed or skipped?
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: echo "All jobs passed or skipped" && echo "${{ toJSON(needs.*.result) }}"

--- a/kubernetes/apps/database/postgres/app/resources/values.yaml
+++ b/kubernetes/apps/database/postgres/app/resources/values.yaml
@@ -72,7 +72,7 @@ backups:
     # fresh archive path (recovery keeps reading the old one, which stays
     # immutable):
     #
-    #   backups.s3.path: "/barman/${CLUSTER_CNAME}-<stamp>"
+    #   backups.s3.path: "/barman/$${CLUSTER_CNAME}-<stamp>"
     #
     # This is almost certainly why the recovery block used to point at a
     # separate "-restore" bucket: the same collision, worked around by

--- a/scripts/eso-values-lint/go.mod
+++ b/scripts/eso-values-lint/go.mod
@@ -1,0 +1,5 @@
+module github.com/david-driscoll/home-operations/scripts/eso-values-lint
+
+go 1.24
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/scripts/eso-values-lint/go.sum
+++ b/scripts/eso-values-lint/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/scripts/eso-values-lint/main.go
+++ b/scripts/eso-values-lint/main.go
@@ -1,0 +1,530 @@
+// Command eso-values-lint guards the two renderers that run over files a
+// kustomize `configMapGenerator` slurps whole, and that neither `kustomize
+// build`, nor `helm template`, nor `flate test` exercises.
+//
+// Both have caused a CrowdSec outage (equestria-cluster#2977, #2980 /
+// vault#111). The failure mode is the same both times: a *comment* in a
+// generated file is not a comment by the time the file is rendered.
+//
+//	stage 1  kustomize configMapGenerator
+//	         reads the file as one opaque string. Comments are part of it.
+//	stage 2  Flux postBuild envsubst
+//	         runs over the whole built output, so a `${NAME}` anywhere in that
+//	         string -- comments included -- is substituted. Undefined names
+//	         expand to the empty string with no error and no log line.
+//	stage 3  external-secrets `templateAs: Values`
+//	         runs the whole string through Go text/template. A `{{` inside a
+//	         comment is a live action: bad syntax fails the ExternalSecret
+//	         outright (no Secret at all, so any HelmRelease pointing at it
+//	         cannot resolve its values), and good syntax silently expands a
+//	         real secret into a comment.
+//
+// Checks, in the order they are reported:
+//
+//	ESO-PARSE   file reached by `templateAs: Values` does not parse as a Go
+//	            text/template. This is the exact error external-secrets
+//	            reports, produced by the same parser.
+//	ESO-EXEC    it parses but will not execute.
+//	ESO-COMMENT a comment line in such a file contains `{{`.
+//	ENVSUBST    a comment line in ANY generated file contains a LIVE `${`.
+//	            `$$` is envsubst's escape, so `$${NAME}` is fine; the run of
+//	            dollars before the brace has to be even.
+//
+// KNOWN LIMITS, so nobody disables this over a surprise:
+//
+//   - The two comment checks are line-based: any line whose first non-space
+//     character is `#` is treated as a comment. Inside a YAML block scalar
+//     such a line is content, not a comment, so a shell snippet embedded in
+//     values that legitimately wants `${NAME}` on a `#` line will be flagged.
+//     Escape it (`$${NAME}`) or reword. As of writing there is no such case in
+//     either cluster repo.
+//   - ESO-EXEC executes against a map synthesised from the template's own
+//     field references, so it proves the template RUNS. It cannot prove a key
+//     exists in the provider -- only external-secrets, holding the live
+//     secret, can do that.
+//   - `secretGenerator` is not scanned. Neither repo uses one; add it here if
+//     that changes, since stage 2 applies to those files identically.
+//
+// Usage: go run ./scripts/eso-values-lint [root ...]   (default: ./kubernetes)
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"text/template"
+	"text/template/parse"
+
+	"gopkg.in/yaml.v3"
+)
+
+type finding struct {
+	check string
+	file  string
+	line  int
+	msg   string
+}
+
+type generated struct {
+	// path of the file on disk
+	path string
+	// ConfigMap name as written in kustomization.yaml, e.g. "${APP}-values".
+	// Left unsubstituted on purpose: the ExternalSecret spells it the same way.
+	cmName string
+	// key the file lands under inside the ConfigMap
+	key string
+	// kustomization.yaml that generates it
+	from string
+}
+
+// check identifiers, as they appear in output
+const (
+	checkParse    = "ESO-PARSE"
+	checkExec     = "ESO-EXEC"
+	checkComment  = "ESO-COMMENT"
+	checkEnvsubst = "ENVSUBST"
+)
+
+// exit codes
+const (
+	exitOK      = 0
+	exitFinding = 1
+	exitFailure = 2 // the linter itself could not run
+)
+
+const esoCommentAdvice = "external-secrets templates this whole file, so this comment is " +
+	"executable code. Describe the sequence in words, or move the value out of the templated file."
+
+// report is the outcome of a run: what was inspected, and what was wrong.
+type report struct {
+	findings         []finding
+	checkedGenerated int
+	checkedTemplates int
+}
+
+func main() {
+	roots := os.Args[1:]
+	if len(roots) == 0 {
+		roots = []string{"kubernetes"}
+	}
+	os.Exit(run(roots, os.Stdout, os.Stderr))
+}
+
+func run(roots []string, stdout, stderr io.Writer) int {
+	rep, err := scan(roots)
+	if err != nil {
+		fmt.Fprintf(stderr, "eso-values-lint: %v\n", err)
+		return exitFailure
+	}
+
+	slices.SortFunc(rep.findings, func(a, b finding) int {
+		if c := strings.Compare(a.file, b.file); c != 0 {
+			return c
+		}
+		return a.line - b.line
+	})
+
+	for _, f := range rep.findings {
+		if f.line > 0 {
+			fmt.Fprintf(stdout, "%s:%d: [%s] %s\n", f.file, f.line, f.check, f.msg)
+		} else {
+			fmt.Fprintf(stdout, "%s: [%s] %s\n", f.file, f.check, f.msg)
+		}
+	}
+	fmt.Fprintf(stdout, "\neso-values-lint: %d generated file(s) checked, %d of them rendered by "+
+		"external-secrets `templateAs: Values`, %d finding(s)\n",
+		rep.checkedGenerated, rep.checkedTemplates, len(rep.findings))
+
+	if len(rep.findings) > 0 {
+		return exitFinding
+	}
+	return exitOK
+}
+
+func scan(roots []string) (report, error) {
+	var rep report
+	for _, root := range roots {
+		dirs, err := kustomizationDirs(root)
+		if err != nil {
+			return rep, err
+		}
+		for _, dir := range dirs {
+			if err := scanDir(dir, &rep); err != nil {
+				return rep, fmt.Errorf("%s: %w", dir, err)
+			}
+		}
+	}
+	return rep, nil
+}
+
+func scanDir(dir string, rep *report) error {
+	gens, err := generatedFiles(dir)
+	if err != nil || len(gens) == 0 {
+		return err
+	}
+	templated, err := esoTemplatedKeys(dir)
+	if err != nil {
+		return err
+	}
+
+	for _, g := range gens {
+		// #nosec G304 -- the path comes from the repo's own kustomization.yaml,
+		// which is the thing being linted. There is no untrusted input here.
+		src, err := os.ReadFile(g.path)
+		if err != nil {
+			return err
+		}
+		rep.checkedGenerated++
+		text := string(src)
+
+		// ENVSUBST applies to every generated file: stage 2 does not care
+		// whether stage 3 exists.
+		rep.findings = append(rep.findings, unescapedSubstitution(g.path, text)...)
+
+		if !templated[g.cmName+"\x00"+g.key] {
+			continue
+		}
+		rep.checkedTemplates++
+		rep.findings = append(rep.findings,
+			commentSequence(g.path, text, "{{", checkComment, esoCommentAdvice)...)
+		rep.findings = append(rep.findings, goTemplate(g.path, text)...)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------- discovery
+
+func kustomizationDirs(root string) ([]string, error) {
+	var dirs []string
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Name() == "kustomization.yaml" || d.Name() == "kustomization.yml" {
+			dirs = append(dirs, filepath.Dir(p))
+		}
+		return nil
+	})
+	return dirs, err
+}
+
+// Minimal shapes for the two documents this tool has to understand. Only the
+// fields that matter are modelled; everything else is ignored on decode.
+
+type configMapGenerator struct {
+	Name  string   `yaml:"name"`
+	Files []string `yaml:"files"`
+}
+
+type kustomizationDoc struct {
+	ConfigMapGenerator []configMapGenerator `yaml:"configMapGenerator"`
+}
+
+type templateItem struct {
+	Key        string `yaml:"key"`
+	TemplateAs string `yaml:"templateAs"`
+}
+
+type templateConfigMap struct {
+	Name  string         `yaml:"name"`
+	Items []templateItem `yaml:"items"`
+}
+
+type templateFromEntry struct {
+	ConfigMap templateConfigMap `yaml:"configMap"`
+}
+
+type secretTemplate struct {
+	TemplateFrom []templateFromEntry `yaml:"templateFrom"`
+}
+
+type secretTarget struct {
+	Template secretTemplate `yaml:"template"`
+}
+
+type externalSecretSpec struct {
+	Target secretTarget `yaml:"target"`
+}
+
+type externalSecretDoc struct {
+	Kind string             `yaml:"kind"`
+	Spec externalSecretSpec `yaml:"spec"`
+}
+
+func generatedFiles(dir string) ([]generated, error) {
+	var out []generated
+	for _, name := range []string{"kustomization.yaml", "kustomization.yml"} {
+		p := filepath.Join(dir, name)
+		// #nosec G304 -- p is a kustomization.yaml under a root given on argv.
+		raw, err := os.ReadFile(p)
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		var doc kustomizationDoc
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			// A kustomization we cannot parse is not this tool's problem;
+			// flate/kustomize will report it far better than we can.
+			continue
+		}
+		for _, gen := range doc.ConfigMapGenerator {
+			for _, entry := range gen.Files {
+				key, rel := entry, entry
+				if i := strings.Index(entry, "="); i >= 0 {
+					key, rel = entry[:i], entry[i+1:]
+				} else {
+					key = filepath.Base(entry)
+				}
+				fp := filepath.Clean(filepath.Join(dir, rel))
+				if _, err := os.Stat(fp); err != nil {
+					continue
+				}
+				out = append(out, generated{path: fp, cmName: gen.Name, key: key, from: p})
+			}
+		}
+	}
+	return out, nil
+}
+
+// esoTemplatedKeys returns the set of "<configMap name>\x00<key>" pairs that an
+// ExternalSecret in dir renders with `templateAs: Values`.
+func esoTemplatedKeys(dir string) (map[string]bool, error) {
+	set := map[string]bool{}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		ext := filepath.Ext(e.Name())
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+		// #nosec G304 -- dir is a repo path supplied on argv.
+		raw, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return nil, err
+		}
+		dec := yaml.NewDecoder(strings.NewReader(string(raw)))
+		for {
+			var doc externalSecretDoc
+			if err := dec.Decode(&doc); err != nil {
+				break // EOF, or a document this tool does not model
+			}
+			if doc.Kind != "ExternalSecret" {
+				continue
+			}
+			for _, tf := range doc.Spec.Target.Template.TemplateFrom {
+				for _, item := range tf.ConfigMap.Items {
+					if item.TemplateAs == "Values" {
+						set[tf.ConfigMap.Name+"\x00"+item.Key] = true
+					}
+				}
+			}
+		}
+	}
+	return set, nil
+}
+
+// ------------------------------------------------------------------- checks
+
+// commentSequence reports `seq` appearing on a line whose first non-space
+// character is `#`. JSON has no comments, so it is skipped.
+func commentSequence(path, text, seq, check, msg string) []finding {
+	var out []finding
+	forEachCommentLine(path, text, func(i int, line string) {
+		if strings.Contains(line, seq) {
+			out = append(out, finding{check: check, file: path, line: i + 1,
+				msg: fmt.Sprintf("comment contains %q. %s", seq, msg)})
+		}
+	})
+	return out
+}
+
+// unescapedSubstitution reports a LIVE `${...}` in a comment. `$$` is
+// envsubst's escape for a literal dollar, so `$${NAME}` survives verbatim and
+// is fine; the run of dollars immediately before the brace has to be even for
+// that to hold.
+func unescapedSubstitution(path, text string) []finding {
+	var out []finding
+	forEachCommentLine(path, text, func(i int, line string) {
+		for j := 1; j < len(line); j++ {
+			if line[j] != '{' || line[j-1] != '$' {
+				continue
+			}
+			dollars := 0
+			for k := j - 1; k >= 0 && line[k] == '$'; k-- {
+				dollars++
+			}
+			if dollars%2 == 1 {
+				out = append(out, finding{check: checkEnvsubst, file: path, line: i + 1,
+					msg: "comment contains a live substitution. Flux postBuild envsubst " +
+						"expands it even inside a comment -- an undefined name expands to " +
+						"nothing and eats the text around it, and a defined one bakes a real " +
+						"cluster value into the ConfigMap. Double the dollar sign to escape " +
+						"it, or describe the sequence in words."})
+				return
+			}
+		}
+	})
+	return out
+}
+
+func forEachCommentLine(path, text string, fn func(i int, line string)) {
+	if ext := filepath.Ext(path); ext == ".json" {
+		return // JSON has no comments
+	}
+	for i, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimLeft(line, " \t-")
+		if !strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		fn(i, line)
+	}
+}
+
+var undefinedFunc = regexp.MustCompile(`function "([^"]+)" not defined`)
+
+// goTemplate parses (and then executes) the file exactly as external-secrets'
+// v2 engine does. Unknown function names are stubbed on demand rather than
+// vendored: the engine ships sprig plus its own helpers, and this check is
+// about syntax and executability, not about a function's return value.
+func goTemplate(path, text string) []finding {
+	funcs := template.FuncMap{}
+	var tmpl *template.Template
+	for attempt := 0; ; attempt++ {
+		t, err := template.New(filepath.Base(path)).
+			Funcs(funcs).
+			Option("missingkey=error").
+			Parse(text)
+		if err == nil {
+			tmpl = t
+			break
+		}
+		if m := undefinedFunc.FindStringSubmatch(err.Error()); m != nil && attempt < 64 {
+			funcs[m[1]] = func(_ ...any) any { return "" }
+			continue
+		}
+		return []finding{{check: checkParse, file: path, line: templateErrLine(path, err),
+			msg: fmt.Sprintf("does not parse as a Go text/template, so external-secrets "+
+				"cannot render it and writes NO Secret at all: %v", err)}}
+	}
+
+	data := map[string]any{}
+	for _, t := range tmpl.Templates() {
+		if t.Tree != nil {
+			collectFields(t.Tree.Root, data)
+		}
+	}
+	if err := tmpl.Execute(discard{}, data); err != nil {
+		return []finding{{check: checkExec, file: path, line: templateErrLine(path, err),
+			msg: fmt.Sprintf("parses but does not execute: %v", err)}}
+	}
+	return nil
+}
+
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }
+
+// templateErrLine digs the line number out of a text/template error, which
+// formats as `template: <name>:<line>: <detail>`.
+func templateErrLine(path string, err error) int {
+	prefix := "template: " + filepath.Base(path) + ":"
+	s := err.Error()
+	i := strings.Index(s, prefix)
+	if i < 0 {
+		return 0
+	}
+	rest := s[i+len(prefix):]
+	n := 0
+	for _, r := range rest {
+		if r < '0' || r > '9' {
+			break
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+// collectFields walks the parse tree and seeds `data` with every top-level
+// field the template dereferences, so Execute exercises the action tree
+// instead of tripping over missingkey=error on the first reference. It cannot
+// verify that a key really exists in the provider -- only external-secrets,
+// holding the live secret, can do that.
+func collectFields(n parse.Node, data map[string]any) {
+	switch v := n.(type) {
+	case nil:
+		return
+	case *parse.ListNode:
+		if v == nil {
+			return
+		}
+		for _, c := range v.Nodes {
+			collectFields(c, data)
+		}
+	case *parse.ActionNode:
+		collectFields(v.Pipe, data)
+	case *parse.PipeNode:
+		if v == nil {
+			return
+		}
+		for _, c := range v.Cmds {
+			collectFields(c, data)
+		}
+	case *parse.CommandNode:
+		for _, a := range v.Args {
+			collectFields(a, data)
+		}
+	case *parse.IfNode:
+		collectFields(v.Pipe, data)
+		collectFields(v.List, data)
+		collectFields(v.ElseList, data)
+	case *parse.RangeNode:
+		collectFields(v.Pipe, data)
+		collectFields(v.List, data)
+		collectFields(v.ElseList, data)
+	case *parse.WithNode:
+		collectFields(v.Pipe, data)
+		collectFields(v.List, data)
+		collectFields(v.ElseList, data)
+	case *parse.FieldNode:
+		seed(data, v.Ident)
+	case *parse.ChainNode:
+		collectFields(v.Node, data)
+		seed(data, v.Field)
+	default:
+		// Leaf nodes (text, literals, dot) reference nothing to seed.
+	}
+}
+
+func seed(data map[string]any, idents []string) {
+	cur := data
+	for i, id := range idents {
+		if i == len(idents)-1 {
+			if _, ok := cur[id]; !ok {
+				cur[id] = "x"
+			}
+			return
+		}
+		next, ok := cur[id].(map[string]any)
+		if !ok {
+			next = map[string]any{}
+			cur[id] = next
+		}
+		cur = next
+	}
+}

--- a/scripts/eso-values-lint/main_test.go
+++ b/scripts/eso-values-lint/main_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The fixture reproduces the real shape: a kustomization whose
+// configMapGenerator slurps values.yaml, and an ExternalSecret that renders
+// that ConfigMap key with `templateAs: Values`.
+const fixtureKustomization = `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+configMapGenerator:
+  - name: ${APP}-values
+    files:
+      - values.yaml=./values.yaml
+`
+
+const fixtureExternalSecret = `apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP}-values
+spec:
+  target:
+    template:
+      templateFrom:
+      - target: Data
+        configMap:
+          name: ${APP}-values
+          items:
+          - key: values.yaml
+            templateAs: Values
+`
+
+// writeFixture lays down a one-app tree and returns its root.
+func writeFixture(t *testing.T, values, kustomization string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "app")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"kustomization.yaml":  kustomization,
+		"externalsecret.yaml": fixtureExternalSecret,
+		"values.yaml":         values,
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func checksFor(t *testing.T, values string) []string {
+	t.Helper()
+	rep, err := scan([]string{writeFixture(t, values, fixtureKustomization)})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if rep.checkedGenerated != 1 || rep.checkedTemplates != 1 {
+		t.Fatalf("discovery failed: generated=%d templated=%d (want 1/1)",
+			rep.checkedGenerated, rep.checkedTemplates)
+	}
+	var got []string
+	for _, f := range rep.findings {
+		got = append(got, f.check)
+	}
+	return got
+}
+
+func TestChecks(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		body  string
+		want  []string
+		never []string
+	}{
+		{
+			// The actual outage: vault#111 / equestria-cluster#2980.
+			name: "unparsable action in a comment fails like external-secrets does",
+			body: "---\n# see {{ ... }} for the syntax\nkey: value\n",
+			want: []string{"ESO-COMMENT", "ESO-PARSE"},
+		},
+		{
+			// #2977: parses fine, but envsubst ate the comment.
+			name: "live substitution in a comment",
+			body: "---\n# set this from ${SOME_VAR}\nkey: value\n",
+			want: []string{"ENVSUBST"},
+		},
+		{
+			// Regression guard: `$$` is the escape and must stay silent, or
+			// every values file carrying $${REGISTRATION_TOKEN} goes red.
+			name:  "escaped substitution in a comment is not a finding",
+			body:  "---\n# literal $${REGISTRATION_TOKEN} reaches the container\nkey: value\n",
+			never: []string{"ENVSUBST"},
+		},
+		{
+			name: "parseable action in a comment still leaks a secret into it",
+			body: "---\n# example: {{ .password }}\nkey: \"{{ .password }}\"\n",
+			want: []string{"ESO-COMMENT"},
+		},
+		{
+			name:  "ordinary templated values file is clean",
+			body:  "---\n# a perfectly ordinary comment\nkey: \"{{ .password }}\"\n",
+			never: []string{"ESO-COMMENT", "ESO-PARSE", "ESO-EXEC", "ENVSUBST"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := checksFor(t, tc.body)
+			for _, w := range tc.want {
+				if !contains(got, w) {
+					t.Errorf("missing %s; got %v", w, got)
+				}
+			}
+			for _, n := range tc.never {
+				if contains(got, n) {
+					t.Errorf("unexpected %s; got %v", n, got)
+				}
+			}
+		})
+	}
+}
+
+// A file that is generated but NOT rendered by external-secrets must still be
+// checked for envsubst, and must never be reported as a broken template.
+func TestUntemplatedFileOnlyGetsEnvsubstCheck(t *testing.T) {
+	root := writeFixture(t, "---\n# mentions {{ .password }} and ${SOME_VAR}\nkey: value\n",
+		strings.Replace(fixtureKustomization, "${APP}-values", "other-values", 1))
+	rep, err := scan([]string{root})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if rep.checkedTemplates != 0 {
+		t.Fatalf("file should not be treated as ESO-templated, got %d", rep.checkedTemplates)
+	}
+	for _, f := range rep.findings {
+		if f.check != "ENVSUBST" {
+			t.Errorf("unexpected %s on an untemplated file", f.check)
+		}
+	}
+}
+
+// The reported line number has to be usable, since that is how the error gets
+// found: the live cluster pointed at values.yaml:8.
+func TestParseErrorReportsLineNumber(t *testing.T) {
+	body := "---\n#\n#\n#\n#\n#\n#\n# {{ ... }}\nkey: value\n"
+	rep, err := scan([]string{writeFixture(t, body, fixtureKustomization)})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	for _, f := range rep.findings {
+		if f.check == "ESO-PARSE" {
+			if f.line != 8 {
+				t.Errorf("ESO-PARSE line = %d, want 8", f.line)
+			}
+			return
+		}
+	}
+	t.Fatal("no ESO-PARSE finding")
+}
+
+func TestUnknownFunctionsDoNotFailTheParse(t *testing.T) {
+	// external-secrets ships sprig; this tool stubs names on demand rather
+	// than vendoring it, so a sprig pipeline must not be reported as broken.
+	got := checksFor(t, "---\nkey: \"{{ .password | b64enc | quote }}\"\n")
+	for _, c := range got {
+		if c == "ESO-PARSE" || c == "ESO-EXEC" {
+			t.Errorf("sprig pipeline wrongly reported as %s", c)
+		}
+	}
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Piece 21 moved the kubernetes tree into home-operations but left its CI behind, so **`kubernetes/**` has had no PR validation here at all**. This ports it.

## Ported

| file | what |
|---|---|
| `.github/workflows/flux-local.yaml` | `flate test`, `flate diff` (+ PR comment), `eso-values-lint`, aggregate status gate |
| `scripts/eso-values-lint/` | self-contained Go module (only dep `yaml.v3`), module path renamed to home-operations |
| `.github/labels.yaml` | **fixes a latent bug** — see below |
| `.github/release.yaml` | excludes renovate from release notes |

Both workflow path dependencies already exist here: `kubernetes/flux/cluster` is the Flux entrypoint, and `flate` is pinned to the same **v0.5.0** in `.config/mise.toml` that the action resolves — so `mise run flate` locally and the CI `test` job run byte-identical commands.

**`labels.yaml` was the latent bug:** `label-sync.yaml` was already in this repo, but the `.github/labels.yaml` it reads was not — with `delete-other-labels: true`. A manual dispatch would have failed against a missing config.

## Deliberately not ported

- **`sgc-sync.yaml`** — syncs files *into* the SGC repo, which is being decommissioned (`docs/cluster-consolidation/22-decommission-sgc.md`). Decommission debris, not something to carry forward.
- **`label-sync.yaml`** — already byte-identical here.
- **`renovate.json5`** — verified rather than assumed: this repo's copy is already a superset (446 lines vs 327) with full flux / helm-values / kubernetes / helmfile manager coverage over `kubernetes/**`.

## Wired into the local hook stack too

`.config/hk.pkl`'s comment on the `flate` step already names its own blind spot:

> flate does NOT run Flux postBuild envsubst or the external-secrets template engine, so it passes cleanly on a values file that would take an app to zero pods.

That is exactly what this linter covers, so it belongs there and not only in CI. It joins the shared `linters` map (so all four hooks pick it up), plus a matching `mise run eso-values-lint` task following the `flate` precedent.

One wrinkle, recorded in both comments: **`go -C` is mandatory** — the module is nested and there's no `go.mod` at the repo root, so `go run ./scripts/eso-values-lint` fails outright. And because `-C` also moves the program's working directory, the target path has to be absolute (`$(git rev-parse --show-toplevel)/kubernetes`).

## It caught a live bug on import

```
kubernetes/apps/database/postgres/app/resources/values.yaml:75
[ENVSUBST] comment contains a live substitution
```

A doc comment reading `backups.s3.path: "/barman/${CLUSTER_CNAME}-<stamp>"`. That file really is slurped whole by `configMapGenerator` (`kustomization.yaml:17`), so Flux postBuild expands it *inside the comment*. Benign today only because `CLUSTER_CNAME` happens to be defined — it's the exact shape that caused vault#111 when the variable was undefined. Escaped to `$${CLUSTER_CNAME}`; the linter now reports **0 findings**.

## Verification

- `hk check` green across all 14 steps — `flate` (351 passed, 2 skipped for missing secrets), `actionlint`, `pkl`, `yamllint`, and the new `eso-values-lint`
- the linter's own Go regression tests pass, including the negative case that `$${...}` must not be flagged
- one `typos` fix (`unparseable` → `unparsable`) — this repo's typos config is stricter than equestria-cluster's

🤖 Generated with [Claude Code](https://claude.com/claude-code)