### PR TITLE
fix(longhorn): cap rebuild concurrency for the SATA nodes

### DIFF
--- a/docs/cluster-consolidation/12-longhorn-critical-tier.md
+++ b/docs/cluster-consolidation/12-longhorn-critical-tier.md
@@ -235,6 +235,99 @@ with only 3 nodes ever carrying the `critical` tag, that's what forces
 exactly one `longhorn-critical` replica per control plane — there's no
 fourth `critical` node for a spillover replica to land on.
 
+### Answering "which three" with measurements (2026-08-18)
+
+The section above leaves the choice open — follow the control plane, or follow the faster
+disk. Running [19](19-rotate-equestria-control-planes.md)'s eviction on `fluttershy`
+produced the numbers that settle it, measured mid-drain while ~340 GB of replicas moved:
+
+| node | Longhorn disk | utilisation | avg write latency | temp |
+|---|---|---|---|---|
+| `milky-way` | Transcend SATA `/dev/sda` | **93.5 %** | **126 ms** | 75 °C |
+| `pegasus` | Transcend SATA `/dev/sda` | **89.7 %** | **470 ms** | 73 °C |
+| `othalla` | Transcend SATA `/dev/sda` | 3.7 % (idle) | — | 64 °C |
+| `fluttershy` (source) | Samsung 990 EVO Plus | 6.3 % | — | 49 °C |
+
+**The answer is: keep `critical` on the control planes anyway, and prioritise step 3.**
+
+The disks are the worse ones, but that is not what `critical` is *for*. Tier-1 is small and
+low-IOPS — home-assistant 43 GB, technitium 5.4 GB, mosquitto 8.6 GB, matter 4.3 GB,
+crowdsec ~6.5 GB, about **68 GB of real data** (162 GB counting volsync caches/dests). That
+load is negligible on any of these drives. What is *not* negligible is what is on them
+today:
+
+| node | in use | scheduled |
+|---|---|---|
+| `milky-way` | 172.7 GB | 534.7 GB |
+| `othalla` | 159.0 GB | 735.5 GB |
+| `pegasus` | 220.1 GB | 562.7 GB |
+
+Roughly **70 % of that is Tier-2 bulk** — loki, thanos, jellyfin, immich, the *arr stack —
+which has no reason to be on a control-plane disk at all. So the problem was never that
+`critical` points at slow disks; it is that **nothing points anything away from them**.
+Step 3 is the fix, and it is the step this piece already warns is "the one that matters
+most and is easiest to skip."
+
+Tag assignment for the post-[19](19-rotate-equestria-control-planes.md) topology, replacing
+Step 1's original list:
+
+```bash
+# critical - the three control planes (D6 needs Tier-1 data to survive here)
+for n in milky-way othalla pegasus; do
+  kubectl -n longhorn-system patch nodes.longhorn.io $n --type merge -p '{"spec":{"tags":["critical"]}}'
+done
+# bulk - the four workers, all NVMe-backed
+for n in hard-hat fluttershy kerfuffle shining-armor; do
+  kubectl -n longhorn-system patch nodes.longhorn.io $n --type merge -p '{"spec":{"tags":["bulk"]}}'
+done
+```
+
+### What step 3 would have prevented, concretely
+
+With no tags and no selector, eviction picks targets by **free space alone**. `milky-way` and
+`pegasus` were emptiest after their own wipes, so every rebuild went there while three NVMe
+nodes sat idle. Consequences, all observed:
+
+- throughput collapsed to 1–2 % per five minutes;
+- rebuilds began failing and restarting from 0 % — one 64 GiB volume fell from 93 % to 3 %,
+  and the failed-replica count went 0 → 3 → 6 → 9 in about twenty minutes;
+- both drives climbed toward the 85 °C at which `pegasus` previously shut its XFS filesystem
+  down mid-rebuild.
+
+The stopgap was `allowScheduling: false` on both nodes, which is documented in
+[19](19-rotate-equestria-control-planes.md) Step 1b-bis along with the matching undo. Step 3
+is what makes the stopgap unnecessary.
+
+**Root cause of the failures was a livelock, not a failing disk.** No kernel I/O errors and
+no SMART errors on any drive. `concurrent-replica-rebuild-per-node-limit` defaults to **5**,
+which is tuned for NVMe: five simultaneous rebuilds onto one Transcend SATA saturate it, the
+rebuild data connections time out and drop (`Data server connection closed by remote
+error=EOF`), Longhorn marks the replicas failed and retries all five — discarding the
+progress each time. Lowered to **2** in
+`kubernetes/apps/longhorn-system/longhorn/values.yaml`; two rebuilds that finish beat five
+that restart. This matters most on the remaining rotations — `kerfuffle` holds ~80 replicas.
+
+### Implementation constraint step 3 has to route around
+
+**StorageClass `parameters` are immutable.** Turning on `persistence.defaultNodeSelector`
+changes the auto-created `longhorn` class's parameters, so `helm upgrade` **fails** rather
+than updating it — the class has to be deleted and recreated. Existing PVs are unaffected
+(they are already bound), but any PVC created in that window fails, so it wants a quiet
+moment rather than a routine reconcile.
+
+The same applies to adding a selector to the hand-written classes in
+`kubernetes/apps/longhorn-system/storageclass/snapshot.yaml` (`longhorn-cache`,
+`longhorn-snapshot`, `longhorn-local`) — and note that Kustomization is configured
+`force: false` (`storageclass/ks.yaml:20`), so Flux will surface an immutable-field error
+rather than recreating them. Either flip `force: true` for that Kustomization or delete the
+classes by hand as part of the change.
+
+**A third trap, from landing PR #912:** `longhorn-manager`'s DaemonSet ships
+`updateStrategy.rollingUpdate.maxUnavailable: 100%`. Any change to these values rolls **all
+seven managers at once**, leaving the cluster with no Longhorn control plane for ~90 s. It
+recovers on its own and eviction state survives in the CRs, but it stalls any rebuild in
+flight — so do not land a Longhorn values change while a node is draining.
+
 ### Longhorn settings that matter to this piece (v1.12.0, live)
 
 | Setting | Value | Relevance |

--- a/kubernetes/apps/longhorn-system/longhorn/values.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/values.yaml
@@ -65,6 +65,25 @@ defaultSettings:
   orphanResourceAutoDeletion: instance
   orphanResourceAutoDeletionGracePeriod: 300
   replicaAutoBalance: best-effort
+
+  # Chart default is 5. That is tuned for NVMe and is actively harmful on the
+  # ex-SGC nodes, whose Longhorn disk is a Transcend TS1TMTS425S SATA
+  # (milky-way/othalla/pegasus, /dev/sda). Five concurrent rebuilds onto one of
+  # those drives saturates it -- measured 93.5% utilisation and 470 ms average
+  # write latency during fluttershy's eviction on 2026-08-18 -- so the rebuild
+  # data connections time out and drop (`Data server connection closed by
+  # remote  error=EOF`), Longhorn marks the replicas failed, and retries all
+  # five again. Each retry DISCARDS the progress: one 64 GiB volume fell from
+  # 93% back to 3%, and the failed-replica count went 0 -> 3 -> 6 -> 9 in about
+  # twenty minutes. It is a livelock, not a failing disk -- there were no
+  # kernel I/O errors and no SMART errors on any of those drives.
+  #
+  # Two rebuilds that finish beat five that time out and restart. This matters
+  # most on the remaining piece-19 rotations: kerfuffle holds ~80 replicas.
+  # See docs/cluster-consolidation/19-rotate-equestria-control-planes.md
+  # (Step 1b-bis) and 12-longhorn-critical-tier.md.
+  concurrentReplicaRebuildPerNodeLimit: 2
+
   storageMinimalAvailablePercentage: 5
   storageReservedPercentageForDefaultDisk: 10
   autoCleanupSnapshotAfterOnDemandBackupCompleted: true


### PR DESCRIPTION
Found while running piece 19's Longhorn eviction on `fluttershy`. **One-line behaviour change plus the design work it exposed** — no tagging and no StorageClass change here, those need a quiet window (reasons below).

## The bug

`concurrent-replica-rebuild-per-node-limit` defaults to **5**, which is tuned for NVMe. The ex-SGC nodes keep Longhorn on a Transcend `TS1TMTS425S` **SATA** drive (`/dev/sda`), and five simultaneous rebuilds saturate one. Measured mid-drain:

| node | Longhorn disk | utilisation | avg write latency | temp |
|---|---|---|---|---|
| `milky-way` | Transcend SATA | **93.5 %** | **126 ms** | 75 °C |
| `pegasus` | Transcend SATA | **89.7 %** | **470 ms** | 73 °C |
| `fluttershy` (rebuild source) | Samsung 990 EVO Plus | 6.3 % | — | 49 °C |

At that point the rebuild data connections time out and drop —

```
Data server connection closed by remote  error=EOF
Replica rebuildings for map[...5 replicas...] are in progress on this node,
which reaches or exceeds the concurrent limit value 5
```

— Longhorn marks the replicas failed and retries all five, **discarding the progress each time**. One 64 GiB volume fell from 93 % back to 3 %, and the failed-replica count went `0 → 3 → 6 → 9` in roughly twenty minutes.

**This is a livelock, not a failing disk.** No kernel I/O errors and no SMART errors on any drive. Two rebuilds that finish beat five that restart.

It matters most on what's left of piece 19: `kerfuffle` holds ~80 replicas against `fluttershy`'s 77, and by then `fluttershy` will be a worker absorbing load too.

## Verified, not assumed

This file has previously carried a `defaultSettings` key that matched nothing in the chart and was silently dropped (`orphanAutoDeletion` — see the comment a few lines above). So:

- key exists in the chart — `helm show values` line 340
- `helm template --set defaultSettings.concurrentReplicaRebuildPerNodeLimit=2` renders `concurrent-replica-rebuild-per-node-limit: "2"` into the settings ConfigMap

## Piece 12 gets the measurements that answer its own question

Piece 12 asks whether `critical` should follow the control plane or the faster disk, now that piece 19 inverts them. **Answer: keep it on the control planes.**

Tier-1 is ~68 GB of low-IOPS data (home-assistant 43 GB, technitium, mosquitto, matter, crowdsec) — negligible on any of these drives. The real problem is what's there now:

| node | in use | scheduled |
|---|---|---|
| `milky-way` | 172.7 GB | 534.7 GB |
| `othalla` | 159.0 GB | 735.5 GB |
| `pegasus` | 220.1 GB | 562.7 GB |

Roughly **70 % is Tier-2 bulk** — loki, thanos, jellyfin, immich, the *arr stack. `critical` pointing at slow disks was never the issue; **nothing points anything away from them**. That's step 3, which piece 12 already calls "the one that matters most and is easiest to skip."

## Three implementation constraints, recorded

1. **StorageClass `parameters` are immutable.** Enabling `persistence.defaultNodeSelector` changes the auto-created `longhorn` class, so `helm upgrade` *fails* rather than updating — it needs delete-and-recreate. `storageclass/ks.yaml:20` is `force: false`, so Flux surfaces an immutable-field error rather than recreating.
2. **`longhorn-manager` ships `maxUnavailable: 100%`.** Any change to these values rolls all seven managers at once (~90 s with no Longhorn control plane). Observed live when #912 landed — it stalled an in-flight eviction. **Don't land a Longhorn values change while a node is draining.**
3. The post-19 tag assignment, replacing step 1's pre-migration list (which tagged hard-hat/fluttershy/kerfuffle `critical` — now exactly backwards).

## Timing

Because of constraint 2, this should merge when **no node is mid-drain**. It's otherwise low risk: one setting, no data movement, revert by removing the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)