### PR TITLE
feat(talos): fluttershy becomes a worker

### DIFF
--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -184,7 +184,10 @@ nodes:
     installDisk: "/dev/sda"
     machineSpec:
       secureboot: false
-    controlPlane: true
+    # Rotated out of the control plane 2026-08-18, piece 19 (2 of 3). Talos
+    # cannot demote in place, so this was a drain -> etcd leave -> wipe ->
+    # rejoin-as-worker cycle, not a flag flip on a live node.
+    controlPlane: false
     userVolumes: &intel_un1290_user_volumes
       - name: longhorn
         filesystem:


### PR DESCRIPTION
Piece 19, **2 of 3**. Talos cannot demote a control-plane node in place, so this was drain → etcd leave → wipe (STATE + EPHEMERAL) → rejoin with a worker machine config. The flag has to land *before* `talos:add-node` runs, or the node rejoins as a control plane and the whole cycle achieves nothing.

## Executed 2026-08-18

- **Longhorn eviction first** (Step 1b) — all **77 replicas** moved off before the wipe rather than being rebuilt from surviving copies afterwards, so redundancy never dropped. This is the improvement hard-hat's rotation didn't get.
- **etcd 5 → 4 members** (kerfuffle, milky-way, othalla, pegasus), all in sync at the same raft index, no alarms.
- **drain** evicted 18 non-daemonset pods. `traefik` and `coredns` held at 2/2 behind their PDBs, so **ingress and DNS never dropped**. The Longhorn instance-managers evicted on their own without touching their PDBs — confirming piece 19 Step 3's "it is lag, not a lie" correction.
- **`home-assistant` (Tier 1)** rescheduled to hard-hat and reattached its Longhorn volume with no manual intervention.
- **wipe** confirmed by the authenticated Talos API returning `x509: certificate signed by unknown authority` — the STATE partition and its certs are gone.

## State after this

| role | nodes |
|---|---|
| workers | shining-armor, hard-hat, **fluttershy** |
| control planes | kerfuffle, milky-way, othalla, pegasus |

`kerfuffle` is the last rotation and it's the hard one — it holds the CNPG **primary**, OpenBao's **active** instance, and ~80 Longhorn replicas. All three need relocating before its drain, unlike fluttershy which held none of them.

## Follow-up this PR does not do

Per piece 19 **Step 1d**, once the node is back:

```bash
kubectl -n longhorn-system patch nodes.longhorn.io fluttershy --type merge \
  -p '{"spec":{"allowScheduling":true,"evictionRequested":false}}'
kubectl -n longhorn-system patch nodes.longhorn.io milky-way --type merge -p '{"spec":{"allowScheduling":true}}'
kubectl -n longhorn-system patch nodes.longhorn.io pegasus  --type merge -p '{"spec":{"allowScheduling":true}}'
```

`milky-way` and `pegasus` were de-scheduled mid-drain to keep rebuilds off their saturated SATA disks (93.5 % utilisation, 470 ms writes — see #939). Leaving that in place would **silently defeat piece 20**, because Tier-1 volumes could never place a replica onto the control planes.

Kubernetes also keeps the stale `node-role.kubernetes.io/control-plane` label regardless of what Talos rejoined as, so that needs removing by hand and the demotion confirmed with `talosctl get machinetype` rather than from the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)