### PR TITLE
feat(talos): kerfuffle becomes a worker — piece 19 complete

### DIFF
--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -236,7 +236,10 @@ nodes:
     installDisk: "/dev/sda"
     machineSpec:
       secureboot: false
-    controlPlane: true
+    # Rotated out of the control plane 2026-08-19, piece 19 (3 of 3 -- the last
+    # one). Talos cannot demote in place, so this was drain -> etcd leave ->
+    # wipe -> rejoin-as-worker. etcd is now the ex-SGC trio alone.
+    controlPlane: false
     userVolumes: *intel_un1290_user_volumes
     nodeLabels: *nodeLabels
     nodeAnnotations: *intel_un1290_annotations


### PR DESCRIPTION
The last of the three rotations. **Piece 19 is done.**

| role | nodes |
|---|---|
| control plane | milky-way, othalla, pegasus *(the ex-SGC trio)* |
| workers | hard-hat, fluttershy, kerfuffle, shining-armor |

etcd is now **3 members, quorum 2**. [vault#127](https://github.com/david-driscoll/vault/issues/127) is closed by construction — neither PNY SATA node runs etcd any more.

## kerfuffle was the hard one

It held all three singletons fluttershy didn't:

- **CNPG primary.** `postgres-primary`'s PDB allows **0** disruptions, so a drain refuses outright. Promoted `postgres-2` (on shining-armor — a worker, so it won't need moving again in a future rotation), then destroyed the old primary; it re-provisioned onto fluttershy.
- **OpenBao's active instance**, which failed over to milky-way during the drain exactly as the runbook expects.
- **105 Longhorn replicas** (fluttershy had 77), evicted with **zero failures remaining**.

Worth noting [#939](https://github.com/david-driscoll/home-operations/pull/939) earned its keep: fluttershy's eviction took ~2.5h with the failure count spiking to **61**, an ext4 abort, and hours of livelocked retries. kerfuffle moved **38% more replicas** in ~2h with failures never exceeding 4 and ending at 0.

## Four things the runbook doesn't mention

**1. `etcd leave` releases the API VIP.** kerfuffle was the last control plane on `10.10.206.x`, and the seconds-long gap before pegasus claimed `10.10.206.201` killed the in-flight drain with an i/o timeout. **Draining *before* the etcd leave avoids this** — the documented order only worked on fluttershy because kerfuffle was still there to hold the VIP. This is the most important correction here.

**2. A stale Helm hook pod blocked the drain outright.** `spegel-cleanup-wait` — bare, no controller, `Running` since 2026-08-13 with an unfired `hook-succeeded` delete policy. `kubectl drain` refuses without `--force`. It would have blocked *any* drain of this node, including an automated `tuppr` Talos upgrade, so it was a latent trap rather than just today's obstacle.

**3. `cnpg destroy`'s stuck-detach chain needs one more step than documented.** Clearing `spec.nodeID` is not enough — the Longhorn attachment ticket re-asserts it (the doc predicts this but doesn't say what to do). **Removing the ticket from `volumeattachments.longhorn.io` is what actually breaks the deadlock.** The stale-check mattered too: the destroyed instance's PVC gets a *new* PV with the same claim name, so deleting "the postgres-1 PV" without checking `creationTimestamp` would have destroyed the live database volume.

**4. Longhorn's webhook can reject the detach with a literal `BUG: replica should be 1 for strict-local volume`.** That's transient — the window where the replacement replica briefly makes the count 2 — and clears itself. Forcing the PV finalizer at the first 500 would orphan the Longhorn volume for nothing.

## Outstanding

Per piece 19 **Step 1d**, once the node is Ready:

```bash
kubectl -n longhorn-system patch nodes.longhorn.io kerfuffle --type merge \
  -p '{"spec":{"allowScheduling":true,"evictionRequested":false}}'
kubectl uncordon kerfuffle
kubectl label node kerfuffle node-role.kubernetes.io/control-plane-
```

Expect a slow bootstrap: the node has an empty image cache and kubelet serializes pulls (fluttershy took ~40 min to get Longhorn usable *after* going `Ready`). `registry` also moved off kerfuffle, so pulls come from upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)