### PR TITLE
fix(longhorn): three defaultSettings keys the chart was silently dropping

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/values.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/values.yaml
@@ -47,9 +47,60 @@ defaultSettings:
   defaultDataLocality: best-effort
   defaultLonghornStaticStorageClass: longhorn
   defaultReplicaCount: 2
-  guaranteedInstanceManagerCpu: 5
-  nodeDownPoddeletionPolicy: Delete-both-statefulset-and-deployment-pod
-  volumeAttachmentRecoveryPolicy: never
+  # Chart key is nodeDownPodDeletionPolicy -- capital D in "Deletion". This asked
+  # for `nodeDownPoddeletionPolicy` and got nothing, because
+  # templates/default-setting.yaml wraps every key in
+  # `{{- if not (kindIs "invalid" .Values.defaultSettings.<key>) }}`: a misspelled
+  # key is indistinguishable from an unset one, so it raises no error and simply
+  # never reaches the longhorn-default-setting ConfigMap. Live
+  # `node-down-pod-deletion-policy` read `do-nothing`, Longhorn's default.
+  #
+  # The VALUE was wrong too, and would have failed just as quietly on its own. The
+  # choices are exact lowercase strings and isValidChoice() in types/setting.go is
+  # a plain slices.Contains, so the old capital `Delete-both-...` would have been
+  # dropped by filterCustomizedDefaultSettings() with one log line ("will continue
+  # applying other customized settings") and no other signal. Two silent failures
+  # stacked; fixing only the key would have looked like a fix and changed nothing.
+  #
+  # Load-bearing for docs/cluster-consolidation/24-power-states.md: under
+  # `do-nothing`, StatefulSet pods stranded on a powered-off worker are never
+  # deleted and therefore never reschedule onto a control plane. 20-low-power-tier.md
+  # section 5 already describes the float-and-relocate behaviour this enables --
+  # it was describing something that was not switched on.
+  nodeDownPodDeletionPolicy: delete-both-statefulset-and-deployment-pod
+
+  # REMOVED, not corrected: `guaranteedInstanceManagerCpu: 5` (chart key is
+  # guaranteedInstanceManagerCPU, capital CPU) and `volumeAttachmentRecoveryPolicy:
+  # never`. Both were swallowed by the same kindIs "invalid" guard and neither has
+  # ever been in effect here.
+  #
+  #   * guaranteedInstanceManagerCPU is a PERCENTAGE of each node's allocatable
+  #     CPU, not millicores, and the chart default is 12 -- so `5` was a
+  #     REDUCTION, not the increase its 4-core-control-plane framing suggests. At
+  #     the live 12% that is 474m on milky-way/othalla/pegasus (3950m allocatable),
+  #     1914m on hard-hat, 2394m on the 20-core workers. Upstream's own sizing
+  #     formula (running instances * 0.1 / allocatable * 100) wants far MORE than
+  #     12% on every node in this cluster: hard-hat carries ~67 running
+  #     engines+replicas, i.e. ~42%, which is already above the setting's own 0-40
+  #     ceiling. Dropping the guarantee to 5% would weaken exactly the nodes that
+  #     livelocked during the piece-19 rebuilds (see
+  #     concurrentReplicaRebuildPerNodeLimit below) and exactly the control planes
+  #     12-longhorn-critical-tier.md is about to promote to the critical tier. The
+  #     5 arrived unexplained with the repo migration (5fa1a7f2) and no rationale
+  #     was ever recorded, so the chart default stands -- which is also what is
+  #     already live, making this half of the change a no-op. If the small control
+  #     planes ever need their own number, the per-node override is
+  #     `node.spec.instanceManagerCPURequest`, which takes precedence over this
+  #     global setting.
+  #
+  #   * volumeAttachmentRecoveryPolicy is absent from chart 1.12.1 because the
+  #     setting itself is gone: `volume-attachment-recovery-policy` was marked
+  #     SettingTypeDeprecated in longhorn-manager 1.2.x and deleted outright in
+  #     1.3.0, superseded by nodeDownPodDeletionPolicy above. Its `never` choice
+  #     meant "the default Kubernetes behavior of never deleting volume
+  #     attachments" -- the do-nothing option -- so even had it worked, it would
+  #     have been arguing against the line it sat next to.
+
   # Chart key is orphanResourceAutoDeletion (chart 1.12.0) and the value is a
   # SEMICOLON-separated list of resource types, not a boolean. The old
   # `orphanAutoDeletion: true` matched no key in the chart, so it was dropped


### PR DESCRIPTION
Three keys in `kubernetes/apps/longhorn-system/longhorn/values.yaml` never reached the cluster. `templates/default-setting.yaml` guards every key with `{{- if not (kindIs "invalid" .Values.defaultSettings.<key>) }}`, so a misspelled key is indistinguishable from an unset one — no error from Helm, none from Flux, and the rendered `longhorn-default-setting` ConfigMap simply omits it. Verified against `longhorn@v1.12.1` (the pinned chart) and live `settings.longhorn.io` on `admin@equestria`, 2026-08-19.

Found while writing #958, which documents the divergence in `docs/cluster-consolidation/12-longhorn-critical-tier.md` and deliberately does not fix it.

| In `values.yaml` | Chart key | Live value | Action |
|---|---|---|---|
| `nodeDownPoddeletionPolicy` | `nodeDownPodDeletionPolicy` | `do-nothing` | **fixed** — key *and* value |
| `guaranteedInstanceManagerCpu: 5` | `guaranteedInstanceManagerCPU` | `{"v1":"12","v2":"12"}` | **deleted** — arithmetic doesn't support it |
| `volumeAttachmentRecoveryPolicy: never` | *none* | n/a | **deleted** — setting removed in 1.3.0 |

## The value was wrong too

Fixing only the key would have looked like a fix and changed nothing. The valid choice is `delete-both-statefulset-and-deployment-pod`, **all lowercase**, and `isValidChoice()` in `types/setting.go` is a plain `slices.Contains`. The capital `Delete-` would have been skipped by `filterCustomizedDefaultSettings()` in `datastore/longhorn.go` with a single log line — *"will continue applying other customized settings"* — and no other signal. Same silent failure, one layer down. Both halves corrected.

## Why `guaranteedInstanceManagerCPU` is deleted rather than fixed

It's a **percentage of each node's allocatable CPU, not millicores**, and the chart default is **12** — so `5` was a *reduction*, not the increase its 4-core-control-plane framing implies.

| node | allocatable | live @ 12% | would be @ 5% | running engines+replicas |
|---|---|---|---|---|
| milky-way / othalla / pegasus | 3950m | 474m | 197m | 27 / 25 / 22 |
| hard-hat | 15950m | 1914m | 797m | **67** |
| fluttershy / kerfuffle / shining-armor | 19950m | 2394m | 997m | 45 / 3 / 59 |

Upstream's own sizing formula (`instances × 0.1 / allocatable × 100`) wants *more* than 12% on every node here — hard-hat's ~67 instances work out to ~42%, already above the setting's own 0–40 ceiling. Cutting to 5% would weaken exactly the nodes that livelocked during the piece-19 rebuilds (#939) and exactly the control planes #958 is about to promote to the critical tier. The `5` arrived unexplained with the repo migration (`5fa1a7f2`) with no recorded rationale, so the chart default stands — which is also what's live, making this half a **no-op**. If the small control planes ever need their own number, the per-node override is `node.spec.instanceManagerCPURequest`, which takes precedence over the global; that's noted in the file.

`volumeAttachmentRecoveryPolicy` was renamed away rather than typo'd: `volume-attachment-recovery-policy` was marked `SettingTypeDeprecated` in longhorn-manager 1.2.x and deleted outright in **1.3.0**, superseded by `nodeDownPodDeletionPolicy`. Its `never` choice meant *"the default Kubernetes behavior of never deleting volume attachments"* — the do-nothing option — so even had it worked, it would have been arguing against the line it sat next to.

## Blast radius, measured

`helm template` against the pinned chart with these values, diffed against the live ConfigMap:

```
12a13
> node-down-pod-deletion-policy: "delete-both-statefulset-and-deployment-pod"
```

One added line. The other two were never rendered, so removing them is a literal no-op, and dropping `guaranteedInstanceManagerCPU` leaves the live 12% untouched.

## This does *not* roll the longhorn-manager DaemonSet

Contrary to how this change was scoped: that DaemonSet neither mounts `longhorn-default-setting` nor carries a checksum annotation on its pod template (checked in `chart/templates/daemonset-sa.yaml` and against the live object — its only volumes are hostPaths plus the gRPC TLS secret). longhorn-manager reads the ConfigMap through the API in `datastore.syncSettingCRsWithCustomizedDefaultSettings` and applies it live. The `updateStrategy.rollingUpdate.maxUnavailable: 100%` hazard is real and is live, but it's reached only by a change that touches the pod template — which this isn't.

## Still wants a deliberate window

This flips `node-down-pod-deletion-policy` from `do-nothing` to actively force-deleting StatefulSet and Deployment pods on nodes Longhorn considers down. That's the point — it's load-bearing for `docs/cluster-consolidation/24-power-states.md`'s float-and-relocate model — but don't land it while a node is draining or a rebuild is in flight.

## One follow-up left open

`docs/cluster-consolidation/20-low-power-tier.md:358` asserts the live value **is** `Delete-both-statefulset-and-deployment-pod` as of 2026-08-13. It never was, and §5's float-and-relocate reasoning is built on it. Not touched here because #957 is rewriting that exact table — and its new version still carries the misspelled key name and the capital-D value. Better as a fixup on that branch than a conflict here.

`mise exec -- hk check` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
