### PR TITLE
feat(longhorn): critical/bulk storage tiering — piece 12 phases 1-4

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/values.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/values.yaml
@@ -42,6 +42,20 @@ global:
 
 persistence:
   defaultDataLocality: best-effort
+  # Restrict the default `longhorn` class to `bulk`-tagged workers so Tier-2
+  # volumes can never place — or replenish — a replica onto a control-plane
+  # disk (docs/cluster-consolidation/12-longhorn-critical-tier.md, Phase 4).
+  #
+  # The chart renders this into the `longhorn-storageclass` ConfigMap, not a
+  # StorageClass object; longhorn-manager handles the immutable-parameters
+  # recreate itself (sub-second delete+create gap). Nodes MUST carry the `bulk`
+  # tag before this reconciles — a selector with zero matching nodes leaves
+  # every new default-class PVC Pending forever, VolSync's included. Keep any
+  # change here scoped to the `persistence:` block: `defaultSettings`/`global`
+  # edits roll all seven longhorn-managers at once (maxUnavailable: 100%).
+  defaultNodeSelector:
+    enable: true
+    selector: "bulk"
 defaultSettings:
   createDefaultDiskLabeledNodes: false
   defaultDataLocality: best-effort

--- a/kubernetes/apps/longhorn-system/storageclass/critical.yaml
+++ b/kubernetes/apps/longhorn-system/storageclass/critical.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-critical
+reclaimPolicy: Delete
+provisioner: driver.longhorn.io
+parameters:
+  # Tier-1 data that must survive low-power mode (D6): 3 replicas restricted
+  # to the `critical`-tagged control planes. With replica-soft-anti-affinity
+  # false this places exactly one replica per control plane.
+  # See docs/cluster-consolidation/12-longhorn-critical-tier.md.
+  numberOfReplicas: "3"
+  nodeSelector: "critical"
+  dataLocality: best-effort
+  replicaAutoBalance: best-effort
+  staleReplicaTimeout: "30"
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -39,6 +39,10 @@ nodes:
     nodeLabels: &nodeLabels
       node.longhorn.io/create-default-disk: 'config'
     nodeAnnotations:
+      # Longhorn node tag, re-seeded automatically on a full node rebuild.
+      # Only read while Node.spec.tags is empty — a live tag set by kubectl
+      # patch always wins. See docs/cluster-consolidation/12-longhorn-critical-tier.md.
+      node.longhorn.io/default-node-tags: '["bulk"]'
       node.longhorn.io/default-disks-config: |
         {
           "disks": [
@@ -146,6 +150,7 @@ nodes:
       # Pin Technitium DNS to this node — it has enp2s0, required for ipvlan L2 NAD
       technitium-dns: "true"
     nodeAnnotations: &amd_minifm_annotations
+      node.longhorn.io/default-node-tags: '["bulk"]'
       node.longhorn.io/default-disks-config: |
         {
           "disks": [
@@ -200,6 +205,7 @@ nodes:
           maxSize: 1TB
     nodeLabels: *nodeLabels
     nodeAnnotations: &intel_un1290_annotations
+      node.longhorn.io/default-node-tags: '["bulk"]'
       node.longhorn.io/default-disks-config: |
         {
           "disks": [
@@ -276,6 +282,9 @@ nodes:
           maxSize: 1TB
     nodeLabels: *nodeLabels
     nodeAnnotations: &nodeAnnotations
+      # `critical` = D6's low-power survivors: Tier-1 data must live on the
+      # control planes. See docs/cluster-consolidation/12-longhorn-critical-tier.md.
+      node.longhorn.io/default-node-tags: '["critical"]'
       node.longhorn.io/default-disks-config: |
         {
           "disks": [


### PR DESCRIPTION
Executes [piece 12](docs/cluster-consolidation/12-longhorn-critical-tier.md) Phases 1–4, following the executable plan and corrections from #958. Part of [vault#84](https://github.com/david-driscoll/vault/issues/84).

## Already live (Phases 1+2 — done at PR time, not at merge)

The `node.longhorn.io/default-node-tags` annotations in `talos/talconfig.yaml` were applied to all seven nodes via `talosctl apply-config --mode=no-reboot` (single-line diff per node, verified by dry-run first). Since every `nodes.longhorn.io` had empty `spec.tags`, `syncDefaultNodeTags` seeded them immediately — so Phase 1's `kubectl patch` step was never needed; the durable form did both jobs:

```
milky-way / othalla / pegasus                       -> [critical]
hard-hat / fluttershy / kerfuffle / shining-armor   -> [bulk]
```

Tagging is inert on its own (no class references the tags yet; `allow-empty-node-selector-volume: true`), which is why applying it with rebuilds still in flight was safe.

## Lands at merge

- **Phase 3** — `longhorn-critical` StorageClass: 3 replicas, `nodeSelector: "critical"` → exactly one replica per control plane, by construction. Additive; safe any time.
- **Phase 4** — `persistence.defaultNodeSelector: bulk` on the default `longhorn` class. Diff is confined to the `persistence:` block, so no manager roll; longhorn-manager performs the immutable-parameters recreate itself from the `longhorn-storageclass` ConfigMap (sub-second gap). Tags are already live, so the zero-eligible-nodes VolSync trap cannot fire.

## ⚠ Merge gate

Per Phase 0: merge in a quiet moment — **no rebuild in flight, no node draining, ideally no VolSync sync running**. At review time the post-kerfuffle rebuilds were still draining (4 active). Check before merging:

```
kubectl --context admin@equestria -n longhorn-system get volumes.longhorn.io \
  -o custom-columns='NAME:.metadata.name,ROBUSTNESS:.status.robustness' | grep -v healthy
```

## After merge (from the doc)

1. Phase 4 verification: ConfigMap shows `nodeSelector: "bulk"` → live class parameters show `bulk` → still exactly one default class → no Pending PVCs.
2. The two scratch-PVC placement proofs (§ Rehearsed placement proof).
3. Not included here, per the doc's sequencing: **Phase 5** (bulk selector on `longhorn-cache`/`longhorn-snapshot` + `force: true` on the storageclass Kustomization — separate commit so recreate windows don't overlap), the Tier-1 volume migration (pieces 13/15), and the Tier-2 `nodeSelector` backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
