### PR TITLE
feat(pecron-monitor): battery monitor stack on alpha-site

### DIFF
--- a/docker/alpha-site/pecron-monitor/compose.yaml
+++ b/docker/alpha-site/pecron-monitor/compose.yaml
@@ -1,0 +1,30 @@
+services:
+  pecron-monitor:
+    container_name: pecron-monitor
+    # Upstream publishes no container image, so this builds on the host from a
+    # pinned git ref (the deploy command already runs `docker compose build`).
+    # Bump the ref AND the image tag together when upgrading.
+    build:
+      context: https://github.com/attractify-logan/pecron-monitor.git#v0.8.0
+    image: pecron-monitor:v0.8.0
+    restart: unless-stopped
+    dns:
+      - 100.100.100.100
+    environment:
+      PYTHONUNBUFFERED: "1"
+      PECRON_STATE_PATH: /data/pecron-state.json
+      TZ: ${TIMEZONE}
+    volumes:
+      # config.yaml carries the Pecron cloud credentials and per-device auth
+      # keys, so it is hand-copied to /opt/stacks-data/${APP}/config.yaml on the
+      # host (backed up by backrest), never checked into this repo. Mounting the
+      # directory rather than the file means a deploy that lands before the copy
+      # just crash-loops until the file appears, instead of Docker manufacturing
+      # a directory at the file's path and wedging the later copy.
+      - /opt/stacks-data/${APP}:/config:ro
+      - /opt/stacks-data/${APP}/data:/data
+    networks:
+      - dockge_default
+networks:
+  dockge_default:
+    external: true


### PR DESCRIPTION
Adds a `pecron-monitor` Dockge stack to alpha-site, monitoring the three Pecron batteries (Primary / Backup / Spare) and publishing them to Home Assistant over MQTT (`replicator.driscoll.tech`).

## Design notes

- **No published image upstream** — [attractify-logan/pecron-monitor](https://github.com/attractify-logan/pecron-monitor) ships only a Dockerfile, so the stack builds from a **pinned git context** (`#v0.8.0`). The deploy command already runs `docker compose build`, and the image is pre-built on the host (arm64, verified).
- **The full config — rules engine included — is source-controlled** as `config/config.yaml`, a stack template rendered at deploy time like every other stack file: `${CLUSTER_KEY}`/`${APP}` substitution, then vals resolves the `ref+openbao://` references. This repo is public, so everything that authenticates — cloud email/password, per-device `auth_key` **and** `device_key` — lives in OpenBao under `secrets/clusters/alpha-site/apps/pecron-monitor/{cloud,devices}` (already written). The `tsl_cache` blocks are the model's TSL schema, not secrets.
- **Bridge network, not `network_mode: host`** — the local transport is direct TCP to each battery's LAN IP (192.168.100.x, verified reachable from the LXC), no broadcast involved.
- Runtime state persists under `/opt/stacks-data/pecron-monitor/data` (backed up by backrest): `pecron-state.json` (restore-outputs snapshots) and `pecron-monitor-rules.json` (rules-engine state via `rule_state.path`). Deliberately NOT in the repo — the app writes them.
- `typos.toml` learns `standy`: the vendor's TSL key `device_standy_times_as` is an identifier, not prose.

No `definition.yaml`: the service has no web UI — nothing for Traefik, authentik, or gatus to front.

Deploy is the usual `stacks/home` pulumi run. After it verifies, the now-superseded hand-copied `/opt/stacks-data/pecron-monitor/config.yaml` on the host should be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)