### PR TITLE
feat(tier1): move Group A Tier-1 PVCs (technitium, tsidp, tsiam) to longhorn-critical

### DIFF
--- a/kubernetes/apps/equestria/dns/technitium/ks.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/ks.yaml
@@ -41,3 +41,8 @@ spec:
     substitute:
       APP: *app
       NAMESPACE: *namespace
+      # Tier-1 (piece 12 Group A): estate DNS must survive low-power mode, so
+      # the PVC lives on the critical tier — 3 replicas, one per control plane.
+      # Migrated from the component's `longhorn` default 2026-08-19 via the
+      # piece-13 choreography (final sync → RD restore → PVC recreate).
+      VOLSYNC_STORAGECLASS: longhorn-critical

--- a/kubernetes/apps/tailscale-system/iam/ks.yaml
+++ b/kubernetes/apps/tailscale-system/iam/ks.yaml
@@ -53,10 +53,13 @@ spec:
       # restic mover restores the signing key with ownership tsiam can read.
       VOLSYNC_PUID: "65532"
       VOLSYNC_PGID: "65532"
-      # Named explicitly: this cluster has TWO default StorageClasses (longhorn and
-      # openebs-hostpath), so an unqualified PVC can silently land on non-replicated
-      # node-local storage. See david-driscoll/vault#113.
-      VOLSYNC_STORAGECLASS: longhorn
+      # Tier-1 (piece 12 Group A): the signing key must survive low-power mode,
+      # so the PVC lives on the critical tier — 3 replicas, one per control
+      # plane. Migrated from plain `longhorn` 2026-08-19 via the scale-to-0 +
+      # final-sync + RD-restore + PVC-recreate choreography (piece 13 §Storage
+      # tier); remember components/volsync stamps force: enabled, so changing
+      # this on a Bound PVC makes Flux delete-and-recreate it.
+      VOLSYNC_STORAGECLASS: longhorn-critical
       # A JWK and a tsnet state dir. Kilobytes, not gigabytes.
       VOLSYNC_CAPACITY: 1Gi
       # Both movers read this. It defaults to 2Gi in the ReplicationSource but

--- a/kubernetes/apps/tailscale-system/idp/ks.yaml
+++ b/kubernetes/apps/tailscale-system/idp/ks.yaml
@@ -36,8 +36,8 @@ spec:
       NAMESPACE: *namespace
       VOLSYNC_PUID: "1000"
       VOLSYNC_PGID: "1000"
-      # VOLSYNC_STORAGECLASS: longhorn-critical intentionally omitted — that
-      # StorageClass isn't live yet (piece 12 hasn't landed as of 2026-08-13).
-      # Falls back to the component's `longhorn` default; retag once 12 ships
-      # (see piece 13's "Storage tier" section for why retagging in place
-      # isn't a one-line edit once the PVC is Bound).
+      # Tier-1 (piece 12 Group A): OIDC signing keys must survive low-power
+      # mode — losing this PVC mints new keys and breaks every relying party.
+      # Piece 12 landed 2026-08-19 (PR #960); migrated from the component's
+      # `longhorn` default the same day via the piece-13 choreography.
+      VOLSYNC_STORAGECLASS: longhorn-critical


### PR DESCRIPTION
Pieces 13/15 follow-up to #960. Declares `VOLSYNC_STORAGECLASS: longhorn-critical` for the three Group A Tier-1 apps per [12-longhorn-critical-tier.md §The list](docs/cluster-consolidation/12-longhorn-critical-tier.md).

⚠ **Do not resume the suspended Kustomizations by hand** — `components/volsync` stamps `force: enabled`, so this diff delete-recreates each Bound PVC. The apps' Kustomizations (`tailscale-system/tsidp`, `tailscale-system/tsiam`, `equestria/technitium`) are suspended; the per-app cutover (scale-to-0 → final RS sync → fresh RD restore → PVC delete → resume) is being run one app at a time, and resumes each Kustomization only at its own cutover step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)