### PR TITLE
fix(pecron-monitor): break the openbao scheme apart in prose comments

### DIFF
--- a/docker/alpha-site/pecron-monitor/compose.yaml
+++ b/docker/alpha-site/pecron-monitor/compose.yaml
@@ -16,9 +16,11 @@ services:
       TZ: ${TIMEZONE}
     volumes:
       # config/config.yaml is the in-repo template: Pulumi renders it (variable
-      # substitution + vals resolving the ref+openbao:// references) and copies
-      # the result here before this compose command ever runs, so the file is
-      # guaranteed to exist — a direct file mount is safe.
+      # substitution + vals resolving the <ref+openbao scheme>:// references)
+      # and copies the result here before this compose command ever runs, so
+      # the file is guaranteed to exist — a direct file mount is safe.
+      # The scheme is broken apart above on purpose: vals does not know what a
+      # comment is, so a well-formed reference in one resolves or fails the run.
       - ./config/config.yaml:/config/config.yaml:ro
       - /opt/stacks-data/${APP}/data:/data
     networks:

--- a/docker/alpha-site/pecron-monitor/config/config.yaml
+++ b/docker/alpha-site/pecron-monitor/config/config.yaml
@@ -2,9 +2,13 @@
 #
 # This is the SOURCE OF TRUTH for the pecron-monitor config, rules included.
 # DockgeLxc renders it on deploy: ${CLUSTER_KEY}/${APP} substitution first,
-# then vals resolves every ref+openbao:// reference, and the resolved file
-# lands at /opt/stacks/pecron-monitor/config/config.yaml on the host, which
-# compose.yaml mounts read-only into the container.
+# then vals resolves every <ref+openbao scheme>:// reference below, and the
+# resolved file lands at /opt/stacks/pecron-monitor/config/config.yaml on the
+# host, which compose.yaml mounts read-only into the container.
+#
+# That scheme is deliberately broken apart in this comment: vals does not know
+# what a comment is, so a well-formed reference written in prose either bakes a
+# secret into the rendered file or fails the run outright.
 #
 # The repo is public, so anything that authenticates — cloud email/password,
 # per-device auth_key AND device_key — plus the devices' lan_ips lives in


### PR DESCRIPTION
**Fixes the currently-failing `stacks/home` run.** Follow-up to #964.

Both pecron-monitor files described the render pipeline using a literal, well-formed reference scheme inside a YAML comment. vals does not know what a comment is, so the string survived resolution and the residue guard in `components/store/refs.ts` failed the run:

```
/share/source/docker/alpha-site/pecron-monitor/compose.yaml: document still contains 1
unresolved secret-reference scheme(s) after vals eval: ref+openbao:// (line 19)
/share/source/docker/alpha-site/pecron-monitor/config/config.yaml: … (line 5)
```

Surfacing as `error serializing property "create"` on the DockgeLxc file-copy commands — which is exactly the failure mode that file's header warns about ("a well-formed `ref+…://` URL in a comment resolves … or fails the run … killed every home-operations run the day this landed").

Rewritten the sanctioned way — the scheme broken apart in prose — with a short note in each file saying why, so the next editor does not helpfully "fix" it back.

Verified against the guard's own regex (`ref\+[a-z0-9]+://`): compose.yaml now has **0** matches; config.yaml has **11**, all of them real references (email, password, and 3 devices × auth_key/device_key/lan_ip) and **none** in comments.

The operator's `pulumi` OpenBao policy was separately confirmed to read both `secrets/clusters/alpha-site/apps/pecron-monitor/{cloud,devices}` paths, so resolution itself is not at issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)