### PR TITLE
feat(tier1): move Group B Tier-1 storage (home-assistant, matter, mosquitto) to longhorn-critical

### DIFF
--- a/kubernetes/apps/stargate-command/home-assistant/ks.yaml
+++ b/kubernetes/apps/stargate-command/home-assistant/ks.yaml
@@ -50,5 +50,10 @@ spec:
       APP: *app
       NAMESPACE: *namespace
       VOLSYNC_CAPACITY: 40Gi
+      # Tier-1 (piece 12 Group B): must survive low-power mode, so the PVC
+      # lives on the critical tier -- 3 replicas, one per control plane.
+      # Migrated from the component's `longhorn` default 2026-08-19 via the
+      # piece-13 choreography (final sync -> RD restore -> PVC recreate).
+      VOLSYNC_STORAGECLASS: longhorn-critical
       TAILSCALE_SERVICE: home-assistant-app
       TAILSCALE_HOST: home

--- a/kubernetes/apps/stargate-command/matter/ks.yaml
+++ b/kubernetes/apps/stargate-command/matter/ks.yaml
@@ -42,3 +42,7 @@ spec:
       APP: *app
       NAMESPACE: *namespace
       VOLSYNC_CAPACITY: 4Gi
+      # Tier-1 (piece 12 Group B): the Matter/Thread bridge must survive
+      # low-power mode. Migrated 2026-08-19, same choreography as
+      # home-assistant.
+      VOLSYNC_STORAGECLASS: longhorn-critical

--- a/kubernetes/apps/stargate-command/mosquitto/helmrelease.yaml
+++ b/kubernetes/apps/stargate-command/mosquitto/helmrelease.yaml
@@ -87,7 +87,11 @@ spec:
         statefulset:
           volumeClaimTemplates:
           - name: data
-            storageClass: longhorn
+            # Tier-1 (piece 12 Group B). No VolSync on this app, so the
+            # 2026-08-19 migration cloned data-mosquitto-0/1 onto the new
+            # class imperatively and recreated the StatefulSet (this template
+            # field is immutable on a live STS).
+            storageClass: longhorn-critical
             accessMode: ReadWriteOnce
             size: 4Gi
             globalMounts:


### PR DESCRIPTION
Companion to #963, per [12-longhorn-critical-tier.md Group B](docs/cluster-consolidation/12-longhorn-critical-tier.md). This repo is the live source for `stargate-command` — equestria's `flux-system` GitRepository already points here, so equestria-cluster#3180 edited a dead copy (harmless; left merged for tree consistency).

⚠ The three apps' Kustomizations are suspended; cutover happens one app at a time. mosquitto has **no VolSync backup**, so its PVCs are cloned imperatively before the StatefulSet recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)