### PR TITLE
feat(low-power): Technitium onto the control planes, critical-tier PriorityClass, downscaler in dry-run

### DIFF
--- a/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/helmrelease.yaml
@@ -149,8 +149,13 @@ spec:
         runAsGroup: 0
         seccompProfile:
           type: RuntimeDefault
-      # Pin to hard-hat (10.10.206.14) via talconfig nodeLabel technitium-dns=true.
-      # That node is a control plane node, so tolerate the NoSchedule taint.
+      # Pin to the control planes via talconfig nodeLabel technitium-dns=true.
+      # Moved off hard-hat 2026-08-19: the label now sits on milky-way/othalla/pegasus
+      # and the ipvlan NAD binds their enp3s0, so the LAN resolver survives a
+      # low-power window with every worker off — see
+      # docs/cluster-consolidation/20-low-power-tier.md §0.3.
+      # The toleration below is what makes that survive the §4 control-plane taint;
+      # a nodeSelector matching only tainted nodes without it is an unschedulable pod.
       nodeSelector:
         technitium-dns: "true"
       tolerations:

--- a/kubernetes/apps/equestria/dns/technitium/macvlan-nad.yaml
+++ b/kubernetes/apps/equestria/dns/technitium/macvlan-nad.yaml
@@ -16,8 +16,16 @@ metadata:
     # bridge, while ipvlan L2 shares the parent MAC so it works without any
     # Proxmox reconfiguration.
     #
-    # Nodes with NIC enp2s0 must be labeled: kubectl label node <name> technitium-dns=true
-    # The pod's nodeSelector ensures it only lands on a labeled worker node.
+    # master is enp3s0 — the CONTROL PLANE LAN NIC. Changed from enp2s0 (the
+    # worker NIC) on 2026-08-19 to move Technitium onto the control planes for
+    # low-power / battery mode: see docs/cluster-consolidation/20-low-power-tier.md
+    # §0.3. The address below does not change, because every node is a /16 inside
+    # 10.10.0.0/16 behind gateway 10.10.0.1 — one broadcast domain — so the same
+    # static LAN address is equally valid on either parent interface.
+    #
+    # Nodes with NIC enp3s0 must be labeled: kubectl label node <name> technitium-dns=true
+    # The label is set from talos/talconfig.yaml on milky-way/othalla/pegasus; the pod's
+    # nodeSelector ensures it only lands on one of them.
     #
     # Tailscale DNS access: the Connector subnet router already advertises
     # the LAN subnet to the tailnet, so Tailscale clients with --accept-routes
@@ -28,7 +36,7 @@ spec:
       "cniVersion": "0.3.1",
       "name": "technitium-dns-net",
       "type": "ipvlan",
-      "master": "enp2s0",
+      "master": "enp3s0",
       "mode": "l2",
       "ipam": {
         "type": "static",

--- a/kubernetes/apps/equestria/home/freshrss/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/freshrss/helmrelease.yaml
@@ -35,6 +35,10 @@ spec:
       *app :
         annotations:
           reloader.stakater.com/auto: "true"
+          # Low Power keep-list: survives `downscaler/force-downtime` on the
+          # equestria namespace. Per-workload exclude beats the namespace toggle
+          # (scaler.py define_scope). docs/cluster-consolidation/24-power-states.md
+          downscaler/exclude: "true"
         replicas: 1
         pod:
           securityContext:

--- a/kubernetes/apps/equestria/home/immich/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/immich/helmrelease.yaml
@@ -34,6 +34,10 @@ spec:
       *app :
         annotations:
           reloader.stakater.com/auto: "true"
+          # Low Power keep-list: survives `downscaler/force-downtime` on the
+          # equestria namespace. Per-workload exclude beats the namespace toggle
+          # (scaler.py define_scope). docs/cluster-consolidation/24-power-states.md
+          downscaler/exclude: "true"
         replicas: 1
         pod:
           securityContext:

--- a/kubernetes/apps/equestria/home/n8n/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/n8n/helmrelease.yaml
@@ -35,6 +35,10 @@ spec:
       *app :
         annotations:
           reloader.stakater.com/auto: "true"
+          # Low Power keep-list: survives `downscaler/force-downtime` on the
+          # equestria namespace. Per-workload exclude beats the namespace toggle
+          # (scaler.py define_scope). docs/cluster-consolidation/24-power-states.md
+          downscaler/exclude: "true"
         replicas: 1
         pod:
           securityContext:

--- a/kubernetes/apps/equestria/home/obsidian-sync/helmrelease.yaml
+++ b/kubernetes/apps/equestria/home/obsidian-sync/helmrelease.yaml
@@ -43,6 +43,10 @@ spec:
       *app :
         annotations:
           reloader.stakater.com/auto: "true"
+          # Low Power keep-list: survives `downscaler/force-downtime` on the
+          # equestria namespace. Per-workload exclude beats the namespace toggle
+          # (scaler.py define_scope). docs/cluster-consolidation/24-power-states.md
+          downscaler/exclude: "true"
 
         containers:
           app:

--- a/kubernetes/apps/equestria/media/jellyfin/helmrelease.yaml
+++ b/kubernetes/apps/equestria/media/jellyfin/helmrelease.yaml
@@ -35,6 +35,10 @@ spec:
       *app :
         annotations:
           reloader.stakater.com/auto: "true"
+          # Low Power keep-list: survives `downscaler/force-downtime` on the
+          # equestria namespace. Per-workload exclude beats the namespace toggle
+          # (scaler.py define_scope). docs/cluster-consolidation/24-power-states.md
+          downscaler/exclude: "true"
         containers:
           jellyfin:
             image:

--- a/kubernetes/apps/equestria/media/plex/helmrelease.yaml
+++ b/kubernetes/apps/equestria/media/plex/helmrelease.yaml
@@ -35,6 +35,10 @@ spec:
       *app :
         annotations:
           reloader.stakater.com/auto: "true"
+          # Low Power keep-list: survives `downscaler/force-downtime` on the
+          # equestria namespace. Per-workload exclude beats the namespace toggle
+          # (scaler.py define_scope). docs/cluster-consolidation/24-power-states.md
+          downscaler/exclude: "true"
         containers:
           *app :
             image:

--- a/kubernetes/apps/equestria/media/pulsarr/helmrelease.yaml
+++ b/kubernetes/apps/equestria/media/pulsarr/helmrelease.yaml
@@ -36,6 +36,10 @@ spec:
       *app :
         annotations:
           reloader.stakater.com/auto: "true"
+          # Low Power keep-list: survives `downscaler/force-downtime` on the
+          # equestria namespace. Per-workload exclude beats the namespace toggle
+          # (scaler.py define_scope). docs/cluster-consolidation/24-power-states.md
+          downscaler/exclude: "true"
         strategy: Recreate
         containers:
           *app :

--- a/kubernetes/apps/equestria/pvr/dispatcharr/helmrelease.yaml
+++ b/kubernetes/apps/equestria/pvr/dispatcharr/helmrelease.yaml
@@ -36,6 +36,10 @@ spec:
       app:
         annotations:
           reloader.stakater.com/auto: "true"
+          # Low Power keep-list: survives `downscaler/force-downtime` on the
+          # equestria namespace. Per-workload exclude beats the namespace toggle
+          # (scaler.py define_scope). docs/cluster-consolidation/24-power-states.md
+          downscaler/exclude: "true"
         strategy: Recreate
         initContainers:
           chown-dbdir:

--- a/kubernetes/apps/equestria/pvr/xcproxy/helmrelease.yaml
+++ b/kubernetes/apps/equestria/pvr/xcproxy/helmrelease.yaml
@@ -39,6 +39,10 @@ spec:
       *app :
         annotations:
           reloader.stakater.com/auto: "true"
+          # Low Power keep-list: survives `downscaler/force-downtime` on the
+          # equestria namespace. Per-workload exclude beats the namespace toggle
+          # (scaler.py define_scope). docs/cluster-consolidation/24-power-states.md
+          downscaler/exclude: "true"
         containers:
           main:
             image:

--- a/kubernetes/apps/kube-system/kube-downscaler/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/kube-downscaler/helmrelease.yaml
@@ -1,0 +1,106 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: py-kube-downscaler
+  namespace: kube-system
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.3.12
+    digest: sha256:261d8213ae8f9c4fb65d565589f85b5e365eb1af738c57356df52d329f2015bf
+  url: oci://ghcr.io/caas-team/charts/py-kube-downscaler
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-downscaler
+  namespace: kube-system
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: py-kube-downscaler
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  values:
+    # Low Power mode's shed mechanism. See
+    # docs/cluster-consolidation/24-power-states.md — "Mechanism".
+    #
+    # POLARITY, and it is two separate things:
+    #   * SCOPE is opt-out — every workload is in scope unless it carries
+    #     `downscaler/exclude: "true"` or lives in an excluded namespace. That is what
+    #     makes a NEW app shed by default in Low Power without anyone remembering to
+    #     opt it in.
+    #   * ACTION is inert — with no DEFAULT_UPTIME/DEFAULT_DOWNTIME set, the upstream
+    #     defaults are `always`/`never`, so this controller scales NOTHING until a
+    #     namespace is annotated. Installing it changes no behaviour.
+    #
+    # The Full <-> Low Power toggle is therefore a live annotation, no Git commit:
+    #   kubectl annotate namespace equestria downscaler/force-downtime=true  --overwrite
+    #   kubectl annotate namespace equestria downscaler/force-downtime=false --overwrite
+    #
+    # `downscaler/force-downtime` is read from the NAMESPACE only — there is no
+    # workload-level equivalent — and a per-workload `downscaler/exclude: "true"` beats
+    # it (scaler.py `define_scope`, :97). That precedence is what lets the Low Power
+    # keep-list (plex, jellyfin, immich, …) share the `equestria` namespace with the
+    # shed-list. Original replica counts are stored per workload as
+    # `downscaler/original-replicas` and restored on the way back up.
+    arguments:
+      - --interval=60
+      - --include-resources=deployments,statefulsets,cronjobs,scaledobjects
+      # SAFETY: remove this line only after reading a full scan in the logs and
+      # confirming the would-be actions match the intended shed-list. Until then this
+      # controller reports and does not act. Leaving it here permanently is the other
+      # failure mode: the toggle would be flipped and nothing would happen.
+      - --dry-run
+
+    # Tier 0 and Tier 1 (docs/cluster-consolidation/20-low-power-tier.md §1) can never be
+    # shed. They are never annotated with force-downtime either, so this list is
+    # belt-and-braces — its job is to make a mistyped `kubectl annotate` inert.
+    excludedNamespaces:
+      - py-kube-downscaler
+      - kube-downscaler
+      - kube-system
+      - longhorn-system
+      - cert-manager
+      - nfs-system
+      - flux-system
+      - cloudnative-pg
+      - volsync-system
+      - openebs-system
+      - network
+      - stargate-command
+      - tailscale-system
+      # Tier 1 by 24 §1's amendment — these stay up during Battery.
+      - observability
+      - pulumi
+
+    resources:
+      requests:
+        cpu: 25m
+        memory: 128Mi
+      limits:
+        memory: 512Mi

--- a/kubernetes/apps/kube-system/kube-downscaler/ks.yaml
+++ b/kubernetes/apps/kube-system/kube-downscaler/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kube-downscaler
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/kube-downscaler
+  prune: true
+  wait: false
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/kube-downscaler/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kube-downscaler/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -28,6 +28,8 @@ resources:
   - ./etcd/ks.yaml
   - ./headlamp/ks.yaml
   - ./multus/ks.yaml
+  - ./priority-class/ks.yaml
+  - ./kube-downscaler/ks.yaml
   - ./openbao/ks.yaml
   - ./openbao-replica/ks.yaml
   - ./vsc-retention/ks.yaml

--- a/kubernetes/apps/kube-system/priority-class/ks.yaml
+++ b/kubernetes/apps/kube-system/priority-class/ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kube-system-priority-class
+  namespace: &namespace kube-system
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/kube-system/priority-class
+  prune: true
+  # See home-operations:docs/cluster-consolidation/27-migration-churn-failure-modes.md.
+  deletionPolicy: Orphan
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/kube-system/priority-class/kustomization.yaml
+++ b/kubernetes/apps/kube-system/priority-class/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - priority-class.yaml

--- a/kubernetes/apps/kube-system/priority-class/priority-class.yaml
+++ b/kubernetes/apps/kube-system/priority-class/priority-class.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: critical-tier
+description: >-
+  Tier 0/1 low-power survivors — DNS, NTP, MQTT, Home Assistant, ingress and cluster
+  platform. See docs/cluster-consolidation/20-low-power-tier.md §4.
+# Deliberately BELOW Kubernetes' system-cluster-critical (2000000000) and the Longhorn
+# chart's longhorn-critical (1000000000), and above observability-critical (1000) and
+# every unset (0) pod. Priority governs preemption under contention, not placement: with
+# the workers powered off, Tier-2 pods simply go Pending. The value of this class is the
+# case where a control plane is LOST mid-window and the two survivors must evict the
+# right things.
+#
+# Three same-named-looking objects, three different kinds — do not assume a `kubectl get`
+# of one says anything about the others:
+#   * this PriorityClass                 `critical-tier`
+#   * the Longhorn chart's PriorityClass `longhorn-critical`
+#   * piece 12's StorageClass            `longhorn-critical`
+value: 100000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority

--- a/kubernetes/apps/stargate-command/chrony/helmrelease.yaml
+++ b/kubernetes/apps/stargate-command/chrony/helmrelease.yaml
@@ -37,7 +37,11 @@ spec:
           reloader.stakater.com/auto: "true"
         replicas: 1
         pod:
-          priorityClassName: system-cluster-critical
+          # critical-tier, not system-cluster-critical: this is an application pod,
+          # and the Kubernetes system-reserved class let it preempt genuine
+          # control-plane components on a 4-core node. See
+          # docs/cluster-consolidation/20-low-power-tier.md §4.
+          priorityClassName: critical-tier
           affinity:
             podAntiAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/apps/stargate-command/chrony/ks.yaml
+++ b/kubernetes/apps/stargate-command/chrony/ks.yaml
@@ -14,6 +14,8 @@ spec:
       app.kubernetes.io/name: *app
       driscoll.dev/name: *app
   dependsOn:
+    - name: kube-system-priority-class
+      namespace: kube-system
     - name: sgc-secrets
       namespace: *namespace
   path: ./kubernetes/apps/stargate-command/chrony

--- a/kubernetes/apps/stargate-command/home-assistant/helmrelease.yaml
+++ b/kubernetes/apps/stargate-command/home-assistant/helmrelease.yaml
@@ -39,7 +39,11 @@ spec:
         pod:
           restartPolicy: Always
           terminationGracePeriodSeconds: 30
-          priorityClassName: system-cluster-critical
+          # critical-tier, not system-cluster-critical: this is an application pod,
+          # and the Kubernetes system-reserved class let it preempt genuine
+          # control-plane components on a 4-core node. See
+          # docs/cluster-consolidation/20-low-power-tier.md §4.
+          priorityClassName: critical-tier
         initContainers:
           fix-permissions:
             image:

--- a/kubernetes/apps/stargate-command/home-assistant/ks.yaml
+++ b/kubernetes/apps/stargate-command/home-assistant/ks.yaml
@@ -27,6 +27,8 @@ spec:
   retryInterval: 2m
   timeout: 10m
   dependsOn:
+    - name: kube-system-priority-class
+      namespace: kube-system
     - name: volsync
       namespace: volsync-system
     - name: sgc-secrets

--- a/kubernetes/apps/stargate-command/mosquitto/helmrelease.yaml
+++ b/kubernetes/apps/stargate-command/mosquitto/helmrelease.yaml
@@ -75,7 +75,11 @@ spec:
                   - ALL
               readOnlyRootFilesystem: true
         pod:
-          priorityClassName: system-cluster-critical
+          # critical-tier, not system-cluster-critical: this is an application pod,
+          # and the Kubernetes system-reserved class let it preempt genuine
+          # control-plane components on a 4-core node. See
+          # docs/cluster-consolidation/20-low-power-tier.md §4.
+          priorityClassName: critical-tier
           affinity:
             podAntiAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/apps/stargate-command/mosquitto/ks.yaml
+++ b/kubernetes/apps/stargate-command/mosquitto/ks.yaml
@@ -27,6 +27,8 @@ spec:
   retryInterval: 2m
   timeout: 10m
   dependsOn:
+    - name: kube-system-priority-class
+      namespace: kube-system
     - name: sgc-secrets
       namespace: *namespace
   sourceRef:

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -145,10 +145,7 @@ nodes:
           grow: false
           minSize: 1TB
           maxSize: 1TB
-    nodeLabels:
-      <<: *nodeLabels
-      # Pin Technitium DNS to this node — it has enp2s0, required for ipvlan L2 NAD
-      technitium-dns: "true"
+    nodeLabels: *nodeLabels
     nodeAnnotations: &amd_minifm_annotations
       node.longhorn.io/default-node-tags: '["bulk"]'
       node.longhorn.io/default-disks-config: |
@@ -280,7 +277,13 @@ nodes:
           grow: false
           minSize: 1TB
           maxSize: 1TB
-    nodeLabels: *nodeLabels
+    nodeLabels:
+      <<: *nodeLabels
+      # Technitium DNS runs on the control planes (they carry enp3s0, which the
+      # ipvlan L2 NAD now binds). Moved here from hard-hat 2026-08-19 so the LAN
+      # resolver survives a low-power window with every worker powered off —
+      # docs/cluster-consolidation/20-low-power-tier.md §0.3.
+      technitium-dns: "true"
     nodeAnnotations: &nodeAnnotations
       # `critical` = D6's low-power survivors: Tier-1 data must live on the
       # control planes. See docs/cluster-consolidation/12-longhorn-critical-tier.md.
@@ -340,7 +343,13 @@ nodes:
       secureboot: false
     controlPlane: true
     userVolumes: *userVolumes
-    nodeLabels: *nodeLabels
+    nodeLabels:
+      <<: *nodeLabels
+      # Technitium DNS runs on the control planes (they carry enp3s0, which the
+      # ipvlan L2 NAD now binds). Moved here from hard-hat 2026-08-19 so the LAN
+      # resolver survives a low-power window with every worker powered off —
+      # docs/cluster-consolidation/20-low-power-tier.md §0.3.
+      technitium-dns: "true"
     nodeAnnotations: *nodeAnnotations
     schematic: *schematic
     networkInterfaces:
@@ -369,7 +378,13 @@ nodes:
       secureboot: false
     controlPlane: true
     userVolumes: *userVolumes
-    nodeLabels: *nodeLabels
+    nodeLabels:
+      <<: *nodeLabels
+      # Technitium DNS runs on the control planes (they carry enp3s0, which the
+      # ipvlan L2 NAD now binds). Moved here from hard-hat 2026-08-19 so the LAN
+      # resolver survives a low-power window with every worker powered off —
+      # docs/cluster-consolidation/20-low-power-tier.md §0.3.
+      technitium-dns: "true"
     nodeAnnotations: *nodeAnnotations
     schematic: *schematic
     networkInterfaces:


### PR DESCRIPTION
Builds three of the things [20](docs/cluster-consolidation/20-low-power-tier.md) and [24](docs/cluster-consolidation/24-power-states.md) now say are *unbuilt* rather than *blocked*. The design write-up is #969; this is mergeable independently of it.

**Nothing here changes behaviour on its own.** The downscaler lands inert, the PriorityClass is a new object, and the Technitium move needs a deliberate cutover.

## Technitium onto the control planes — 20 §0.3

Your call from the design discussion: *"I would like technitium to move to the control plane if possible, if that means we change the adapters it's allowed to connect to, lets do that."*

The ipvlan NAD rebinds `enp2s0` → `enp3s0`, and `technitium-dns: "true"` moves from `hard-hat` to all three control planes in talconfig. `TECHNITIUM_VIP` does not change — talconfig already relies on the estate being one broadcast domain (`10.10.0.0/16` behind `10.10.0.1`) for the shared API VIP, so the same static address is valid on either parent NIC. The storage half is already done: #963 moved the PVC to `longhorn-critical` and all three replicas sit on the trio.

> [!IMPORTANT]
> **Sequencing.** A NAD is read at *pod creation* and a `nodeSelector` at *scheduling*, so neither change disturbs the running pod — but each **alone** arms a CNI failure on the next recreate (a reboot, an eviction, a Renovate image bump), hours or days removed from the merge. Land both, then cut over once:
> ```bash
> kubectl -n network rollout restart deployment technitium
> ```
> `Recreate` strategy at `replicas: 1`, so the static ipvlan address is never claimed twice. Full sequence with verification steps in 20 §0.3.

The control-plane toleration was already on the HelmRelease — left over from when `hard-hat` *was* a control plane. Its comment is corrected rather than the toleration added; it's exactly what §4's taint will require.

## `critical-tier` PriorityClass — 20 §4

`value: 100000` — below Kubernetes' `system-cluster-critical` and the Longhorn chart's `longhorn-critical`, above `observability-critical` and every unset pod.

`home-assistant`, `mosquitto` and `chrony` move off `system-cluster-critical` — a Kubernetes system-reserved class that was letting three application pods preempt genuine control-plane components on a 4-core node.

Each of the three gains a `dependsOn` on `kube-system-priority-class`: a missing PriorityClass fails pod creation, and these are Tier 1, so the ordering shouldn't be left to Flux racing itself.

## py-kube-downscaler, in dry-run — 24 "Mechanism"

Lands in `kube-system` with **no** default uptime/downtime schedule, so it scales nothing (upstream defaults are `always`/`never`). Scope is still opt-*out*, which is the half that matters: a new app in `equestria` sheds by default in Low Power without anyone remembering to opt it in.

The Full ↔ Low Power toggle is live, no Git commit:

```bash
kubectl annotate namespace equestria downscaler/force-downtime=true --overwrite
```

Nine keep-list workloads carry `downscaler/exclude: "true"` in Git. Per-workload exclude beats the namespace toggle via `define_scope` (`scaler.py:97`), which is what lets keep and shed share the `equestria` namespace — the whole design rests on that precedence.

> [!WARNING]
> `--dry-run` is deliberate and marked `SAFETY` in the values. It should come out only after a full scan is read in the logs and the would-be actions match the intended shed-list. Leaving it in permanently is the *other* failure mode — the toggle gets flipped and nothing happens.

**Not included, and required before this can act for real:** 48 HelmReleases run `driftDetection: mode: enabled` and will revert `replicas: 0` within the 15 m interval. 24 has the three ways out and recommends `driftDetection.ignore` on `/spec/replicas`.

`dynacat` is on the keep-list but rendered from a different source (`path: ./dashboard`), so it can't carry the annotation from this repo — flagged in 24.

## Verification

- `flate build ks` and `flate build hr` render clean; the PriorityClass, the rebound NAD and all nine exclude annotations appear as intended.
- `flate test all` — 355 passed, 2 skipped (missing secrets, pre-existing).
- `talhelper validate` reports only the pre-existing `talosVersion` warning; the rendered talconfig puts `technitium-dns=true` on exactly the three control planes and nowhere else.
- Pre-existing `hk`/biome failures in `scripts/op-to-bao/index.ts` are untouched by this branch — confirmed against a stashed tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)