### PR TITLE
feat(low-power): ignore replica and suspend drift in equestria so the downscaler can work

### DIFF
--- a/docs/cluster-consolidation/24-power-states.md
+++ b/docs/cluster-consolidation/24-power-states.md
@@ -325,6 +325,51 @@ Three ways out, and the choice should be deliberate:
 py-kube-downscaler is not the mechanism for this cluster, it is a second opinion Flux
 overrules.
 
+**Built 2026-08-19.** Option (1), applied **namespace-wide** rather than per-HelmRelease, in
+`kubernetes/apps/equestria/kustomization.yaml`:
+
+```yaml
+patches:
+  - target:
+      group: kustomize.toolkit.fluxcd.io
+      kind: Kustomization
+    patch: |-
+      # …injects spec.patches into every equestria child Kustomization, which then
+      # patches the HelmRelease it builds:
+      spec:
+        driftDetection:
+          ignore:
+            - paths: ["/spec/replicas"]
+            - paths: ["/spec/suspend"]
+              target:
+                kind: CronJob
+```
+
+Three things about that shape are deliberate:
+
+- **Two rules, not one.** The downscaler scales Deployments and StatefulSets but *suspends*
+  CronJobs, so `/spec/suspend` needs ignoring too or every suspended CronJob un-suspends on
+  the next reconcile. `/spec/replicas` is left untargeted (it only exists on workload kinds
+  in a rendered app chart); `/spec/suspend` is targeted at `CronJob` specifically, because
+  the same path exists on Flux's own `Kustomization` and `HelmRelease` kinds and must not be
+  ignored there.
+- **Namespace-wide, not per-app.** The design's premise is that a *new* app in `equestria`
+  sheds correctly without anyone opting it in. A per-HelmRelease ignore would have to be
+  remembered 60+ times, and forgetting it fails silently and only during a window — the same
+  inverted-default failure this mechanism exists to avoid.
+- **It reaches HelmReleases in two hops**, because `equestria/kustomization.yaml` renders
+  `ks.yaml` files (Flux `Kustomization` CRs), not HelmReleases. The patch injects
+  `spec.patches` into each child, and each child patches the HelmRelease it builds. Verified
+  with `kustomize build` at both hops: 47 of 47 equestria Kustomizations carry the injected
+  patch, and a rendered `plex` HelmRelease comes out with `mode: enabled` intact plus the two
+  ignore rules.
+
+**The cost, stated plainly:** replica drift is no longer corrected for the keep-list apps
+either, since they live in the same namespace and are never downscaled. Nothing but the
+downscaler writes replicas on these workloads, so this is accepted rather than solved. **No
+equestria child sets `spec.patches` of its own today** — if one ever needs to, this patch
+stops being additive and has to move to the app level.
+
 **Untested here:** whether `downscaler/exclude` on a workload also survives a `helm upgrade`
 that re-renders `spec.replicas` — drift detection and chart upgrade are different paths.
 A chart upgrade during a window is unlikely but not impossible (Renovate merges land

--- a/kubernetes/apps/equestria/kustomization.yaml
+++ b/kubernetes/apps/equestria/kustomization.yaml
@@ -7,6 +7,61 @@ components:
   - ../../components/alerts
   - ../../components/common
   - ../../components/repos/app-template
+# Low Power mode: py-kube-downscaler owns replica counts in this namespace.
+#
+# `equestria` is the shed-list namespace — entering Low Power is
+# `kubectl annotate namespace equestria downscaler/force-downtime=true`, which
+# scales every non-excluded Deployment/StatefulSet to 0 and suspends CronJobs.
+# 48 HelmReleases in this repo run `driftDetection: mode: enabled`, and Flux
+# would see `replicas: 0` as drift and correct it inside the 15m interval — so
+# the shed would partially undo itself several times an hour and the mode would
+# not work at all. See docs/cluster-consolidation/24-power-states.md.
+#
+# This is applied namespace-wide rather than per-HelmRelease deliberately. The
+# design's whole premise is that a NEW app in this namespace sheds correctly
+# without anyone remembering to opt it in; a per-app ignore rule would have to be
+# remembered 60+ times, and forgetting it fails silently and only during a
+# window. The cost is that replica drift is no longer corrected for the handful
+# of keep-list apps that are never downscaled either — accepted, because nothing
+# but the downscaler writes replicas on these workloads.
+#
+# It reaches the HelmReleases indirectly: this kustomization renders each app's
+# ks.yaml (a Flux Kustomization), so the patch below injects `spec.patches` into
+# every child, and each child then patches the HelmRelease it builds. No
+# equestria child sets `spec.patches` of its own today; if one ever needs to,
+# this stops being additive and has to move.
+patches:
+  - target:
+      group: kustomize.toolkit.fluxcd.io
+      kind: Kustomization
+    patch: |-
+      apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: not-used
+      spec:
+        patches:
+          - target:
+              group: helm.toolkit.fluxcd.io
+              kind: HelmRelease
+            patch: |-
+              apiVersion: helm.toolkit.fluxcd.io/v2
+              kind: HelmRelease
+              metadata:
+                name: not-used
+              spec:
+                driftDetection:
+                  ignore:
+                    # Untargeted on purpose: /spec/replicas only exists on
+                    # Deployment/StatefulSet/ReplicaSet in a rendered app chart, so
+                    # one rule covers every workload kind the downscaler touches.
+                    - paths: ["/spec/replicas"]
+                    # CronJobs are suspended, not scaled. Targeted, because
+                    # /spec/suspend also exists on Flux's own Kustomization and
+                    # HelmRelease kinds and must not be ignored there.
+                    - paths: ["/spec/suspend"]
+                      target:
+                        kind: CronJob
 resources:
   # - ./books   # deliberately disabled upstream; carried for parity only
   - ./dns


### PR DESCRIPTION
py-kube-downscaler landed inert in #970. It **cannot actually shed load** until Flux stops undoing it: 48 HelmReleases run `driftDetection: mode: enabled`, so `replicas: 0` reads as drift and is corrected inside the 15 m interval — the shed would partially undo itself several times an hour. [24](docs/cluster-consolidation/24-power-states.md) called this a prerequisite rather than a refinement. This is it.

## Two rules, because the downscaler does two different things

| Path | Why | Targeting |
|---|---|---|
| `/spec/replicas` | Deployments and StatefulSets are scaled to 0 | **Untargeted** — the path only exists on workload kinds in a rendered app chart, so one rule covers both |
| `/spec/suspend` | CronJobs are *suspended*, not scaled — without this, every suspended CronJob un-suspends on the next reconcile | **Targeted at `CronJob`**, because the same path exists on Flux's own `Kustomization` and `HelmRelease` kinds and must not be ignored there |

The `/spec/suspend` half isn't in the original design note — it follows from `--include-resources` including `cronjobs`, and would have been a silent hole: the mode would look like it worked while every CronJob in the namespace kept firing.

## Namespace-wide, not per-HelmRelease

One patch in [`kubernetes/apps/equestria/kustomization.yaml`](kubernetes/apps/equestria/kustomization.yaml) instead of 53 file edits.

The design's premise is that a **new** app in `equestria` sheds correctly without anyone opting it in. A per-app ignore rule would have to be remembered 60+ times, and forgetting it fails silently *and only during a window* — the same inverted-default failure the whole mechanism exists to avoid.

It reaches the HelmReleases in **two hops**, because `equestria/kustomization.yaml` renders `ks.yaml` files (Flux `Kustomization` CRs), not HelmReleases: the patch injects `spec.patches` into every child Kustomization, and each child then patches the HelmRelease it builds.

## The cost, stated rather than hidden

Replica drift is **no longer corrected for the keep-list apps either**, since they share the namespace and are never downscaled. Nothing but the downscaler writes replicas on these workloads, so this is accepted rather than solved — but it is a real guardrail traded away, and reversing it means moving to per-app rules.

**No equestria child sets `spec.patches` of its own today** (checked: 0 of 64). If one ever needs to, this patch stops being additive and has to move to the app level. That's called out in the file comment.

## Verification

- `kustomize build` at **both hops**: 47 of 47 equestria Kustomizations carry the injected patch, and a rendered `plex` HelmRelease comes out with `mode: enabled` intact plus both ignore rules.
- `flate test all` — **355 passed, 2 skipped**, 0 failed.
- `yamllint --strict` clean.

## Still gating the mode going live

- `--dry-run` is still on the downscaler. The way to exercise it safely is to annotate the namespace **while dry-run is on** — `kubectl annotate namespace equestria downscaler/force-downtime=true --overwrite` — read one 60 s interval of logs to confirm the keep-list is skipped and the shed-list is not, then remove the annotation. Confirmed live that the running process reports `dry_run=True`, `default_uptime=always`, `default_downtime=never`, so it cannot act.
- `dynacat` still can't carry `downscaler/exclude` from this repo (rendered from `path: ./dashboard`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)